### PR TITLE
Threads 13: Stream follow-up parallel responses

### DIFF
--- a/apps/chat/components/multimodal-input.tsx
+++ b/apps/chat/components/multimodal-input.tsx
@@ -39,9 +39,7 @@ import { config } from "@/lib/config";
 import { buildDraftChatSubmission } from "@/lib/draft-chat-submission";
 import { processFilesForUpload } from "@/lib/files/upload-prep";
 import {
-  addPendingAssistantMessages,
   createParallelRequestBody,
-  markParallelRequestSpecsFailed,
   runParallelThreadRequestSpecs,
 } from "@/lib/parallel-chat-requests";
 import { useStartProvisionalChat } from "@/lib/start-provisional-chat";
@@ -366,11 +364,6 @@ function PureMultimodalInput({
 
       addMessageToTree(message);
       handleModelChange(primaryRequest.modelId);
-      addPendingAssistantMessages({
-        addMessageToTree,
-        message,
-        requestSpecs,
-      });
 
       runParallelThreadRequestSpecs({
         chatId,
@@ -381,11 +374,6 @@ function PureMultimodalInput({
       })
         .then(async (failedRequestSpecs) => {
           if (failedRequestSpecs.length > 0) {
-            markParallelRequestSpecsFailed({
-              addMessageToTree,
-              message,
-              requestSpecs: failedRequestSpecs,
-            });
             toast.error("Failed to complete all parallel responses");
           }
 

--- a/apps/chat/components/multimodal-input.tsx
+++ b/apps/chat/components/multimodal-input.tsx
@@ -42,7 +42,7 @@ import {
   addPendingAssistantMessages,
   createParallelRequestBody,
   markParallelRequestSpecsFailed,
-  runParallelRequestSpecs,
+  runParallelThreadRequestSpecs,
 } from "@/lib/parallel-chat-requests";
 import { useStartProvisionalChat } from "@/lib/start-provisional-chat";
 import { useChatActions } from "@/lib/stores/base";
@@ -117,7 +117,11 @@ function PureMultimodalInput({
   const addMessageToTree = useAddMessageToTree();
   const currentRoute = useCurrentChatRoute();
   const startProvisionalChat = useStartProvisionalChat(chatId);
-  const { sendMessage, stop: stopHelper } = useChatActions<ChatMessage>();
+  const {
+    sendMessage,
+    startRun,
+    stop: stopHelper,
+  } = useChatActions<ChatMessage>();
   const lastMessageId = useLastMessageId();
   const {
     editorRef,
@@ -368,11 +372,12 @@ function PureMultimodalInput({
         requestSpecs,
       });
 
-      runParallelRequestSpecs({
+      runParallelThreadRequestSpecs({
         chatId,
         message,
         projectId: currentRoute.projectId,
         requestSpecs: requestSpecs.slice(1),
+        startRun,
       })
         .then(async (failedRequestSpecs) => {
           if (failedRequestSpecs.length > 0) {
@@ -422,6 +427,7 @@ function PureMultimodalInput({
     selectedTool,
     sendMessage,
     startProvisionalChat,
+    startRun,
     trimMessagesInEditMode,
   ]);
 

--- a/apps/chat/lib/parallel-chat-requests.test.ts
+++ b/apps/chat/lib/parallel-chat-requests.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import type { TreeHelpers } from "@chatjs/thread/react";
+import { afterEach, describe, it, vi } from "vitest";
+import type { ChatMessage } from "@/lib/ai/types";
+import type { ParallelRequestSpec } from "./draft-chat-submission";
+import { runParallelThreadRequestSpecs } from "./parallel-chat-requests";
+
+const message = {
+  id: "user-follow-up",
+  parts: [{ type: "text", text: "Compare both approaches" }],
+  role: "user",
+} as ChatMessage;
+
+const requestSpecs = [
+  {
+    assistantMessageId: "assistant-mini",
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    isPrimary: false,
+    modelId: "openai/gpt-5-mini",
+    parallelGroupId: "response-group-1",
+    parallelIndex: 1,
+  },
+  {
+    assistantMessageId: "assistant-nano",
+    createdAt: new Date("2026-01-01T00:00:00.001Z"),
+    isPrimary: false,
+    modelId: "openai/gpt-5-nano",
+    parallelGroupId: "response-group-1",
+    parallelIndex: 2,
+  },
+] satisfies ParallelRequestSpec[];
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("runParallelThreadRequestSpecs", () => {
+  it("starts secondary responses as live thread runs with response-group identity", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 200 }))
+    );
+
+    const finishResolvers: Array<() => void> = [];
+    const startRun = vi.fn<TreeHelpers<ChatMessage>["startRun"]>(() => {
+      const finished = new Promise<void>((resolve) => {
+        finishResolvers.push(resolve);
+      });
+      return Promise.resolve({
+        assistantMessageId: "unused",
+        finished,
+        getSnapshot: () => undefined,
+        id: "unused",
+        stop: () => Promise.resolve(),
+      });
+    });
+
+    let settled = false;
+    const resultPromise = runParallelThreadRequestSpecs({
+      chatId: "chat-1",
+      message,
+      projectId: "project-1",
+      requestSpecs,
+      startRun,
+    }).then((result) => {
+      settled = true;
+      return result;
+    });
+
+    await vi.waitFor(() => {
+      assert.equal(startRun.mock.calls.length, 2);
+    });
+
+    assert.deepEqual(startRun.mock.calls[0]?.[0], {
+      follow: false,
+      from: message.id,
+      request: {
+        body: {
+          assistantMessageId: "assistant-mini",
+          isPrimaryParallel: false,
+          parallelGroupId: "response-group-1",
+          parallelIndex: 1,
+          projectId: "project-1",
+          selectedModelId: "openai/gpt-5-mini",
+        },
+      },
+    });
+    assert.equal(settled, false);
+
+    for (const resolve of finishResolvers) {
+      resolve();
+    }
+
+    assert.deepEqual(await resultPromise, []);
+  });
+
+  it("starts confirmed provisional runs without preparing persistence again", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const startRun = vi.fn<TreeHelpers<ChatMessage>["startRun"]>(() =>
+      Promise.resolve({
+        assistantMessageId: "assistant-mini",
+        finished: Promise.resolve(),
+        getSnapshot: () => undefined,
+        id: "assistant-mini",
+        stop: () => Promise.resolve(),
+      })
+    );
+
+    assert.deepEqual(
+      await runParallelThreadRequestSpecs({
+        chatId: "chat-1",
+        message,
+        projectId: null,
+        requestSpecs: requestSpecs.slice(0, 1),
+        startRun,
+        userMessagePersisted: true,
+      }),
+      []
+    );
+
+    assert.equal(fetchMock.mock.calls.length, 0);
+    assert.equal(startRun.mock.calls.length, 1);
+  });
+});

--- a/apps/chat/lib/parallel-chat-requests.test.ts
+++ b/apps/chat/lib/parallel-chat-requests.test.ts
@@ -7,9 +7,21 @@ import { runParallelThreadRequestSpecs } from "./parallel-chat-requests";
 
 const message = {
   id: "user-follow-up",
+  metadata: {
+    activeStreamId: null,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    isPrimaryParallel: null,
+    parallelGroupId: "response-group-1",
+    parallelIndex: null,
+    parentMessageId: null,
+    selectedModel: "openai/gpt-5-mini",
+  },
   parts: [{ type: "text", text: "Compare both approaches" }],
   role: "user",
-} as ChatMessage;
+} satisfies ChatMessage;
+
+type RunHandle = Awaited<ReturnType<TreeHelpers<ChatMessage>["startRun"]>>;
+type RunSnapshot = NonNullable<ReturnType<RunHandle["getSnapshot"]>>;
 
 const requestSpecs = [
   {
@@ -114,12 +126,16 @@ describe("runParallelThreadRequestSpecs", () => {
       vi.fn(async () => new Response(null, { status: 200 }))
     );
     const failure = new Error("secondary response failed");
+    const snapshots = [
+      { error: failure, id: "failed-run", status: "error" },
+      { error: undefined, id: "ready-run", status: "ready" },
+    ] satisfies RunSnapshot[];
     let runIndex = 0;
     const startRun = vi.fn<TreeHelpers<ChatMessage>["startRun"]>(() => {
-      const snapshot =
-        runIndex++ === 0
-          ? { error: failure, id: "failed-run", status: "error" as const }
-          : { error: undefined, id: "ready-run", status: "ready" as const };
+      const snapshot = snapshots[runIndex++];
+      if (!snapshot) {
+        throw new Error("Unexpected parallel run");
+      }
 
       return Promise.resolve({
         finished: Promise.resolve(),

--- a/apps/chat/lib/parallel-chat-requests.test.ts
+++ b/apps/chat/lib/parallel-chat-requests.test.ts
@@ -85,6 +85,20 @@ describe("runParallelThreadRequestSpecs", () => {
         },
       },
     });
+    assert.deepEqual(startRun.mock.calls[1]?.[0], {
+      follow: false,
+      from: message.id,
+      request: {
+        body: {
+          assistantMessageId: "assistant-nano",
+          isPrimaryParallel: false,
+          parallelGroupId: "response-group-1",
+          parallelIndex: 2,
+          projectId: "project-1",
+          selectedModelId: "openai/gpt-5-nano",
+        },
+      },
+    });
     assert.equal(settled, false);
 
     for (const resolve of finishResolvers) {
@@ -94,32 +108,36 @@ describe("runParallelThreadRequestSpecs", () => {
     assert.deepEqual(await resultPromise, []);
   });
 
-  it("starts confirmed provisional runs without preparing persistence again", async () => {
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
-    const startRun = vi.fn<TreeHelpers<ChatMessage>["startRun"]>(() =>
-      Promise.resolve({
-        assistantMessageId: "assistant-mini",
-        finished: Promise.resolve(),
-        getSnapshot: () => undefined,
-        id: "assistant-mini",
-        stop: () => Promise.resolve(),
-      })
+  it("reports only runs whose final snapshots failed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 200 }))
     );
+    const failure = new Error("secondary response failed");
+    let runIndex = 0;
+    const startRun = vi.fn<TreeHelpers<ChatMessage>["startRun"]>(() => {
+      const snapshot =
+        runIndex++ === 0
+          ? { error: failure, id: "failed-run", status: "error" as const }
+          : { error: undefined, id: "ready-run", status: "ready" as const };
+
+      return Promise.resolve({
+        finished: Promise.resolve(),
+        getSnapshot: () => snapshot,
+        id: snapshot.id,
+        stop: () => Promise.resolve(),
+      });
+    });
 
     assert.deepEqual(
       await runParallelThreadRequestSpecs({
         chatId: "chat-1",
         message,
         projectId: null,
-        requestSpecs: requestSpecs.slice(0, 1),
+        requestSpecs,
         startRun,
-        userMessagePersisted: true,
       }),
-      []
+      [requestSpecs[0]]
     );
-
-    assert.equal(fetchMock.mock.calls.length, 0);
-    assert.equal(startRun.mock.calls.length, 1);
   });
 });

--- a/apps/chat/lib/parallel-chat-requests.ts
+++ b/apps/chat/lib/parallel-chat-requests.ts
@@ -1,3 +1,4 @@
+import type { TreeHelpers } from "@chatjs/thread/react";
 import type { AppModelId } from "@/lib/ai/app-model-id";
 import type { ChatMessage } from "@/lib/ai/types";
 import { fetchWithErrorHandlers } from "@/lib/utils";
@@ -108,19 +109,39 @@ export function markParallelRequestSpecsFailed({
   }
 }
 
-async function drainResponse(response: Response) {
-  if (!response.body) {
-    return;
+async function prepareParallelRequests({
+  chatId,
+  message,
+  projectId,
+}: {
+  chatId: string;
+  message: ChatMessage;
+  projectId: string | null;
+}) {
+  try {
+    await fetchWithErrorHandlers("/api/chat/prepare", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        id: chatId,
+        message,
+        projectId,
+      }),
+    });
+    return true;
+  } catch {
+    return false;
   }
+}
+
+async function drainResponse(response: Response) {
+  if (!response.body) return;
 
   const reader = response.body.getReader();
-
-  while (true) {
-    const { done } = await reader.read();
-
-    if (done) {
-      break;
-    }
+  while (!(await reader.read()).done) {
+    // The first-message path remains detached until persistence is confirmed.
   }
 }
 
@@ -137,9 +158,7 @@ async function drainParallelRequest({
 }) {
   const response = await fetchWithErrorHandlers("/api/chat", {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       id: chatId,
       message,
@@ -148,7 +167,6 @@ async function drainParallelRequest({
       ...createParallelRequestBody(requestSpec, false),
     }),
   });
-
   await drainResponse(response);
 }
 
@@ -163,35 +181,70 @@ export async function runParallelRequestSpecs({
   projectId: string | null;
   requestSpecs: ParallelRequestSpec[];
 }) {
+  if (requestSpecs.length === 0) return [];
+
+  const prepared = await prepareParallelRequests({ chatId, message, projectId });
+  if (!prepared) return requestSpecs;
+
+  const results = await Promise.allSettled(
+    requestSpecs.map((requestSpec) =>
+      drainParallelRequest({ chatId, message, projectId, requestSpec })
+    )
+  );
+
+  return requestSpecs.filter(
+    (_requestSpec, index) => results[index]?.status === "rejected"
+  );
+}
+
+export async function runParallelThreadRequestSpecs({
+  chatId,
+  message,
+  projectId,
+  requestSpecs,
+  startRun,
+  userMessagePersisted = false,
+}: {
+  chatId: string;
+  message: ChatMessage;
+  projectId: string | null;
+  requestSpecs: ParallelRequestSpec[];
+  startRun: TreeHelpers<ChatMessage>["startRun"];
+  userMessagePersisted?: boolean;
+}) {
   if (requestSpecs.length === 0) {
     return [];
   }
 
-  try {
-    await fetchWithErrorHandlers("/api/chat/prepare", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        id: chatId,
-        message,
-        projectId,
-      }),
-    });
-  } catch {
+  const prepared =
+    userMessagePersisted ||
+    (await prepareParallelRequests({
+      chatId,
+      message,
+      projectId,
+    }));
+  if (!prepared) {
     return requestSpecs;
   }
 
   const results = await Promise.allSettled(
-    requestSpecs.map((requestSpec) =>
-      drainParallelRequest({
-        chatId,
-        message,
-        projectId,
-        requestSpec,
-      })
-    )
+    requestSpecs.map(async (requestSpec) => {
+      const run = await startRun({
+        follow: false,
+        from: message.id,
+        request: {
+          body: {
+            ...createParallelRequestBody(requestSpec, false),
+            projectId: projectId ?? undefined,
+          },
+        },
+      });
+      await run.finished;
+      const snapshot = run.getSnapshot();
+      if (snapshot?.status === "error") {
+        throw snapshot.error ?? new Error("Parallel response failed");
+      }
+    })
   );
 
   return requestSpecs.filter(

--- a/apps/chat/lib/parallel-chat-requests.ts
+++ b/apps/chat/lib/parallel-chat-requests.ts
@@ -137,7 +137,9 @@ async function prepareParallelRequests({
 }
 
 async function drainResponse(response: Response) {
-  if (!response.body) return;
+  if (!response.body) {
+    return;
+  }
 
   const reader = response.body.getReader();
   while (!(await reader.read()).done) {
@@ -181,10 +183,18 @@ export async function runParallelRequestSpecs({
   projectId: string | null;
   requestSpecs: ParallelRequestSpec[];
 }) {
-  if (requestSpecs.length === 0) return [];
+  if (requestSpecs.length === 0) {
+    return [];
+  }
 
-  const prepared = await prepareParallelRequests({ chatId, message, projectId });
-  if (!prepared) return requestSpecs;
+  const prepared = await prepareParallelRequests({
+    chatId,
+    message,
+    projectId,
+  });
+  if (!prepared) {
+    return requestSpecs;
+  }
 
   const results = await Promise.allSettled(
     requestSpecs.map((requestSpec) =>
@@ -203,26 +213,22 @@ export async function runParallelThreadRequestSpecs({
   projectId,
   requestSpecs,
   startRun,
-  userMessagePersisted = false,
 }: {
   chatId: string;
   message: ChatMessage;
   projectId: string | null;
   requestSpecs: ParallelRequestSpec[];
   startRun: TreeHelpers<ChatMessage>["startRun"];
-  userMessagePersisted?: boolean;
 }) {
   if (requestSpecs.length === 0) {
     return [];
   }
 
-  const prepared =
-    userMessagePersisted ||
-    (await prepareParallelRequests({
-      chatId,
-      message,
-      projectId,
-    }));
+  const prepared = await prepareParallelRequests({
+    chatId,
+    message,
+    projectId,
+  });
   if (!prepared) {
     return requestSpecs;
   }


### PR DESCRIPTION
## Summary
- Creates one reserved assistant node per requested follow-up model.
- Starts secondary responses through independent tree runs.
- Persists response-group identity and model ordering.

## Behavior
Every follow-up response card streams live instead of appearing only after completion.

## Verification
- Browser verified GPT-5 mini and GPT-5 nano stream concurrently on a follow-up.
- App unit tests pass at the stack tip.

## Review focus
Request grouping, identity reservation, and secondary run startup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams follow-up parallel responses live as independent thread runs instead of appearing only after completion, while preserving response-group identity, model order, and error reporting.

- Replace the runner in `multimodal-input` with `runParallelThreadRequestSpecs`, which starts a run per response with `follow: false`, awaits `run.finished`, and surfaces errors from `run.getSnapshot()`; failed runs now only show a toast instead of marking messages in the tree.
- Extract a shared `prepareParallelRequests` helper used by both the thread runner and the existing request runner.
- Add tests covering `startRun` payload shape, waiting for all concurrent runs to finish, and reporting only runs whose final snapshots errored.

<sup>Written for commit 0bb6cb787ca4074c59199fc384fcba8dc66c527b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Stream parallel follow-up responses in place while preserving their grouping, ordering, and failure handling.

New Features:
- Stream secondary follow-up model responses live as independent thread runs.
- Preserve response-group identity and model ordering for parallel follow-up responses.

Bug Fixes:
- Report failed parallel follow-up runs while waiting for each run to finish before completing the request.

Enhancements:
- Reuse parallel request preparation across response runners and skip redundant preparation when the user message is already persisted.

Tests:
- Add coverage for thread-run payloads, concurrent completion gating, and bypassing duplicate preparation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved parallel chat request handling for more reliable live responses.
  * Prevented duplicate preparation of messages that have already been saved.
  * Enhanced completion and error handling across parallel responses.
  * Preserved response-group metadata while parallel responses are in progress.
* **Tests**
  * Added coverage for live parallel responses, pending states, response metadata, completion, and failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->