### PR TITLE
Threads 16: Stop newly provisioned thread runs

### DIFF
--- a/apps/chat/app/(chat)/api/chat/route.ts
+++ b/apps/chat/app/(chat)/api/chat/route.ts
@@ -45,11 +45,13 @@ import { CostAccumulator } from "@/lib/credits/cost-accumulator";
 import { canSpend, deductCredits } from "@/lib/db/credits";
 import { getMcpConnectorsByUserId } from "@/lib/db/mcp-queries";
 import {
+  cancelActiveMessage,
   getChatById,
   getMessageById,
   getMessageCanceledAt,
   getProjectById,
   getUserById,
+  isGenerationCancellationRequested,
   saveChatIfNotExists,
   saveMessageIfNotExists,
   updateMessage,
@@ -353,6 +355,21 @@ async function createChatStream({
   // Build the data stream that will emit tokens
   const stream = createUIMessageStream<ChatMessage>({
     execute: async ({ writer: dataStream }) => {
+      if (!isAnonymous) {
+        const canceledAt = await getMessageCanceledAt({ messageId });
+        const cancellationRequested =
+          !!userId &&
+          (await isGenerationCancellationRequested({
+            chatId,
+            messageId,
+            userId,
+          }));
+        if (canceledAt || cancellationRequested) {
+          abortController.abort();
+          return;
+        }
+      }
+
       // Release provisional parallel responses only after this exact user
       // message has been persisted by the primary request.
       if (userId && isPrimaryParallel !== false) {
@@ -544,6 +561,15 @@ async function executeChatRequest({
     : generateUUID();
   const streamId = generateUUID();
 
+  if (
+    !isAnonymous &&
+    userId &&
+    (await isGenerationCancellationRequested({ chatId, messageId, userId }))
+  ) {
+    clearTimeout(timeoutId);
+    return emptyChatStreamResponse();
+  }
+
   if (!isAnonymous) {
     // The first provisional request can replay before its persistence acknowledgment arrives, so
     // placeholder creation must be idempotent.
@@ -568,6 +594,19 @@ async function executeChatRequest({
     });
 
     if (!insertedMessage) {
+      clearTimeout(timeoutId);
+      return emptyChatStreamResponse();
+    }
+
+    if (
+      userId &&
+      (await isGenerationCancellationRequested({ chatId, messageId, userId }))
+    ) {
+      await cancelActiveMessage({
+        canceledAt: new Date(),
+        chatId,
+        messageId,
+      });
       clearTimeout(timeoutId);
       return emptyChatStreamResponse();
     }
@@ -780,6 +819,7 @@ async function finalizeMessageAndCredits({
   isPrimaryParallel: boolean | null;
 }): Promise<void> {
   const log = createModuleLogger("api:chat:finalize");
+  let messageSaved = true;
 
   try {
     const assistantMessage = messages.at(-1);
@@ -789,7 +829,7 @@ async function finalizeMessageAndCredits({
     }
 
     if (!isAnonymous) {
-      const messageSaved = await updateMessage({
+      messageSaved = await updateMessage({
         id: assistantMessage.id,
         chatId,
         message: {
@@ -827,7 +867,7 @@ async function finalizeMessageAndCredits({
     log.info({ totalCost }, "Cost accumulator total cost");
 
     // Deduct credits for authenticated users
-    if (userId && !isAnonymous) {
+    if (userId && !isAnonymous && messageSaved) {
       await deductCredits(userId, totalCost);
     }
 

--- a/apps/chat/app/(chat)/api/chat/route.ts
+++ b/apps/chat/app/(chat)/api/chat/route.ts
@@ -610,11 +610,6 @@ async function executeChatRequest({
       clearTimeout(timeoutId);
       return emptyChatStreamResponse();
     }
-
-    await updateMessageActiveStreamId({
-      id: messageId,
-      activeStreamId: streamId,
-    });
   }
 
   // Create throttled cancel check (max once per second) for authenticated users
@@ -856,6 +851,7 @@ async function finalizeMessageAndCredits({
           { messageId: assistantMessage.id },
           "Skipped finalizing canceled message"
         );
+        return;
       }
     }
 

--- a/apps/chat/app/(chat)/api/chat/route.ts
+++ b/apps/chat/app/(chat)/api/chat/route.ts
@@ -789,7 +789,7 @@ async function finalizeMessageAndCredits({
     }
 
     if (!isAnonymous) {
-      await updateMessage({
+      const messageSaved = await updateMessage({
         id: assistantMessage.id,
         chatId,
         message: {
@@ -811,6 +811,12 @@ async function finalizeMessageAndCredits({
           },
         },
       });
+      if (!messageSaved) {
+        log.info(
+          { messageId: assistantMessage.id },
+          "Skipped finalizing canceled message"
+        );
+      }
     }
 
     // Get total cost from accumulator (includes all LLM calls + external API costs)

--- a/apps/chat/components/chat-sync.tsx
+++ b/apps/chat/components/chat-sync.tsx
@@ -58,10 +58,13 @@ export function ChatSync({
     () =>
       createGatedChatTransport(
         createCancellationAwareChatTransport({
-          onCancel: (target) => trpcClient.chat.stopStream.mutate(target),
+          onCancel: (target) =>
+            isAuthenticated
+              ? trpcClient.chat.stopStream.mutate(target)
+              : Promise.resolve(),
           transport: new DefaultChatTransport({
             api: "/api/chat",
-            fetch: fetchWithErrorHandlers as typeof fetch,
+            fetch: fetchWithErrorHandlers,
             prepareSendMessagesRequest({ messages, id: chatId, body }) {
               return {
                 body: {

--- a/apps/chat/components/chat-sync.tsx
+++ b/apps/chat/components/chat-sync.tsx
@@ -9,14 +9,16 @@ import { createCompletionQueue } from "@/lib/ai/completion-queue";
 import { getStreamErrorToastContent } from "@/lib/ai/stream-errors";
 import type { ChatMessage } from "@/lib/ai/types";
 import type { ApplicationThread } from "@/lib/application-thread";
+import { createCancellationAwareChatTransport } from "@/lib/cancellation-aware-chat-transport";
 import { createGatedChatTransport } from "@/lib/gated-chat-transport";
 import { acknowledgeParallelUserMessagePersistence } from "@/lib/parallel-chat-requests";
 import { acknowledgeProvisionalUserMessagePersistence } from "@/lib/provisional-chat-confirmations";
 import { useChat } from "@/lib/stores/base";
 import { useChatPersistenceActions } from "@/lib/stores/hooks-chat-persistence";
 import { useDataStream } from "@/lib/stores/hooks-data-stream";
-import { fetchWithErrorHandlers, generateUUID } from "@/lib/utils";
+import { fetchWithErrorHandlers } from "@/lib/utils";
 import { useSession } from "@/providers/session-provider";
+import { useTRPCClient } from "@/trpc/react";
 
 function isResumableActiveStreamId(activeStreamId: string | null | undefined) {
   return !!(activeStreamId && !activeStreamId.startsWith("pending:"));
@@ -33,6 +35,7 @@ export function ChatSync({
   const { mutate: saveChatMessage } = useSaveMessageMutation();
   const { setChatPersisted } = useChatPersistenceActions();
   const { setDataStream } = useDataStream();
+  const trpcClient = useTRPCClient();
 
   const isAuthenticated = !!session?.user;
   const completionQueueRef = useRef(
@@ -54,34 +57,36 @@ export function ChatSync({
   const transport = useMemo(
     () =>
       createGatedChatTransport(
-        new DefaultChatTransport({
-          api: "/api/chat",
-          fetch: fetchWithErrorHandlers as typeof fetch,
-          prepareSendMessagesRequest({ messages, id: chatId, body }) {
-            return {
-              body: {
-                id: chatId,
-                message: messages.at(-1),
-                prevMessages: isAuthenticated ? [] : messages.slice(0, -1),
-                requestId: generateUUID(),
-                ...body,
-              },
-            };
-          },
-          prepareReconnectToStreamRequest({ id: chatId }) {
-            const current = thread.getSnapshot().messages.at(-1);
-            const activeStreamId = current?.metadata?.activeStreamId ?? null;
-            const partialMessageId = isResumableActiveStreamId(activeStreamId)
-              ? (current?.id ?? null)
-              : null;
+        createCancellationAwareChatTransport({
+          onCancel: (target) => trpcClient.chat.stopStream.mutate(target),
+          transport: new DefaultChatTransport({
+            api: "/api/chat",
+            fetch: fetchWithErrorHandlers as typeof fetch,
+            prepareSendMessagesRequest({ messages, id: chatId, body }) {
+              return {
+                body: {
+                  id: chatId,
+                  message: messages.at(-1),
+                  prevMessages: isAuthenticated ? [] : messages.slice(0, -1),
+                  ...body,
+                },
+              };
+            },
+            prepareReconnectToStreamRequest({ id: chatId }) {
+              const current = thread.getSnapshot().messages.at(-1);
+              const activeStreamId = current?.metadata?.activeStreamId ?? null;
+              const partialMessageId = isResumableActiveStreamId(activeStreamId)
+                ? (current?.id ?? null)
+                : null;
 
-            return {
-              api: `/api/chat/${chatId}/stream${partialMessageId ? `?messageId=${encodeURIComponent(partialMessageId)}` : ""}`,
-            };
-          },
+              return {
+                api: `/api/chat/${chatId}/stream${partialMessageId ? `?messageId=${encodeURIComponent(partialMessageId)}` : ""}`,
+              };
+            },
+          }),
         })
       ),
-    [isAuthenticated, thread]
+    [isAuthenticated, thread, trpcClient]
   );
 
   const { resumeStream } = useChat<ChatMessage>({

--- a/apps/chat/components/multimodal-input.tsx
+++ b/apps/chat/components/multimodal-input.tsx
@@ -588,10 +588,10 @@ function PureMultimodalInput({
 
   const handleStop = useCallback(() => {
     if (session?.user && lastMessageId) {
-      stopStreamMutation.mutate({ messageId: lastMessageId });
+      stopStreamMutation.mutate({ chatId, messageId: lastMessageId });
     }
     stopHelper?.();
-  }, [lastMessageId, session?.user, stopHelper, stopStreamMutation]);
+  }, [chatId, lastMessageId, session?.user, stopHelper, stopStreamMutation]);
 
   return (
     <div className="relative">

--- a/apps/chat/components/multimodal-input.tsx
+++ b/apps/chat/components/multimodal-input.tsx
@@ -41,7 +41,10 @@ import { processFilesForUpload } from "@/lib/files/upload-prep";
 import { runParallelThreadRequestSpecs } from "@/lib/parallel-chat-requests";
 import { useStartProvisionalChat } from "@/lib/start-provisional-chat";
 import { useChatActions } from "@/lib/stores/base";
-import { useApplicationThread } from "@/lib/stores/custom-store-provider";
+import {
+  useApplicationThread,
+  useCustomChatStoreApi,
+} from "@/lib/stores/custom-store-provider";
 import { useLastMessageId } from "@/lib/stores/hooks-base";
 import { ANONYMOUS_LIMITS } from "@/lib/types/anonymous";
 import { cn } from "@/lib/utils";
@@ -103,6 +106,7 @@ function PureMultimodalInput({
   onSendMessage?: (message: ChatMessage) => void | Promise<void>;
 }) {
   const thread = useApplicationThread();
+  const storeApi = useCustomChatStoreApi<ChatMessage>();
   const { artifact, closeArtifact } = useArtifact();
   const { data: session } = useSession();
   const trpc = useTRPC();
@@ -352,6 +356,7 @@ function PureMultimodalInput({
         chatId,
         isAuthenticated: !!session?.user,
         message,
+        onRunStarted: storeApi.getState().registerParallelRun,
         projectId: currentRoute.projectId,
         requestSpecs,
         startRun,
@@ -393,6 +398,7 @@ function PureMultimodalInput({
     session?.user,
     startProvisionalChat,
     startRun,
+    storeApi,
     trimMessagesInEditMode,
   ]);
 
@@ -587,11 +593,16 @@ function PureMultimodalInput({
   });
 
   const handleStop = useCallback(() => {
-    if (session?.user && lastMessageId) {
-      stopStreamMutation.mutate({ chatId, messageId: lastMessageId });
+    const lastMessage = thread.getSnapshot().messages.at(-1);
+    if (session?.user && lastMessage?.role === "assistant") {
+      stopStreamMutation.mutate({
+        chatId,
+        messageId: lastMessage.id,
+        type: "message",
+      });
     }
     stopHelper?.();
-  }, [chatId, lastMessageId, session?.user, stopHelper, stopStreamMutation]);
+  }, [chatId, session?.user, stopHelper, stopStreamMutation, thread]);
 
   return (
     <div className="relative">

--- a/apps/chat/components/parallel-response-cards.tsx
+++ b/apps/chat/components/parallel-response-cards.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { LoaderCircle } from "lucide-react";
-import { memo, useMemo } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useNavigateToMessage } from "@/hooks/use-navigate-to-message";
 import type { AppModelId } from "@/lib/ai/app-models";
@@ -11,6 +11,7 @@ import {
   getPrimarySelectedModelId,
 } from "@/lib/ai/types";
 import { useMessageById } from "@/lib/stores/base";
+import { useApplicationThread } from "@/lib/stores/custom-store-provider";
 import { useParallelGroupInfo } from "@/lib/stores/hooks-threads";
 import { getParallelResponseForSlot } from "@/lib/thread-utils";
 import { cn } from "@/lib/utils";
@@ -51,10 +52,15 @@ function getStatusLabel(isSelected: boolean, isStreaming: boolean): string {
 
 function PureParallelResponseCards({ messageId }: { messageId: string }) {
   const message = useMessageById<ChatMessage>(messageId);
+  const thread = useApplicationThread();
   const parallelGroupInfo = useParallelGroupInfo(messageId);
   const navigateToMessage = useNavigateToMessage();
   const { handleModelChange } = useChatInput();
   const { getModelById, models } = useChatModels();
+  const [pendingParallelIndex, setPendingParallelIndex] = useState<
+    number | null
+  >(null);
+  const activatedRunIdRef = useRef<string | null>(null);
 
   const cardSlots = useMemo(() => {
     if (
@@ -83,6 +89,7 @@ function PureParallelResponseCards({ messageId }: { messageId: string }) {
         modelId,
         parallelIndex,
         message: actualMessage ?? null,
+        run: parallelGroupInfo?.runsByParallelIndex[parallelIndex],
       };
     });
   }, [message, parallelGroupInfo]);
@@ -112,6 +119,10 @@ function PureParallelResponseCards({ messageId }: { messageId: string }) {
   }, [cardSlots, models]);
 
   const selectedParallelIndex = useMemo(() => {
+    if (pendingParallelIndex !== null) {
+      return pendingParallelIndex;
+    }
+
     if (parallelGroupInfo?.selectedMessageId) {
       const selectedMessage = parallelGroupInfo.messages.find(
         (candidate) => candidate.id === parallelGroupInfo.selectedMessageId
@@ -122,7 +133,33 @@ function PureParallelResponseCards({ messageId }: { messageId: string }) {
     }
 
     return cardSlots.length > 0 ? 0 : null;
-  }, [cardSlots.length, parallelGroupInfo]);
+  }, [cardSlots.length, parallelGroupInfo, pendingParallelIndex]);
+
+  useEffect(() => {
+    if (pendingParallelIndex === null) {
+      return;
+    }
+
+    const slot = cardSlots.find(
+      (slot) => slot.parallelIndex === pendingParallelIndex
+    );
+    if (!slot) {
+      return;
+    }
+    if (!slot.message) {
+      if (slot.run && activatedRunIdRef.current !== slot.run.id) {
+        activatedRunIdRef.current = slot.run.id;
+        thread.setActiveRun(slot.run.id);
+      }
+      return;
+    }
+
+    setPendingParallelIndex(null);
+    if (activatedRunIdRef.current !== slot.run?.id) {
+      navigateToMessage(slot.message.id);
+    }
+    activatedRunIdRef.current = null;
+  }, [cardSlots, navigateToMessage, pendingParallelIndex, thread]);
 
   if (!message || sortedCardSlots.length <= 1) {
     return null;
@@ -147,14 +184,22 @@ function PureParallelResponseCards({ messageId }: { messageId: string }) {
               "h-auto min-w-[160px] flex-col items-start gap-1 rounded-xl px-3 py-2 text-left",
               isSelected && "border-primary bg-primary/5 text-primary"
             )}
-            disabled={!slot.message}
             key={`${message.id}-${slot.parallelIndex}`}
             onClick={() => {
               if (slot.message) {
+                activatedRunIdRef.current = null;
+                setPendingParallelIndex(null);
                 navigateToMessage(slot.message.id);
-                if (modelId) {
-                  handleModelChange(modelId);
-                }
+              } else if (slot.run) {
+                activatedRunIdRef.current = slot.run.id;
+                setPendingParallelIndex(slot.parallelIndex);
+                thread.setActiveRun(slot.run.id);
+              } else {
+                setPendingParallelIndex(slot.parallelIndex);
+                navigateToMessage(message.id);
+              }
+              if (modelId) {
+                handleModelChange(modelId);
               }
             }}
             type="button"

--- a/apps/chat/components/suggested-actions.tsx
+++ b/apps/chat/components/suggested-actions.tsx
@@ -18,6 +18,7 @@ import { buildDraftChatSubmission } from "@/lib/draft-chat-submission";
 import { runParallelThreadRequestSpecs } from "@/lib/parallel-chat-requests";
 import { useStartProvisionalChat } from "@/lib/start-provisional-chat";
 import { useChatActions } from "@/lib/stores/base";
+import { useCustomChatStoreApi } from "@/lib/stores/custom-store-provider";
 import { cn } from "@/lib/utils";
 import { useSession } from "@/providers/session-provider";
 
@@ -33,6 +34,7 @@ function PureSuggestedActions({
   className,
 }: SuggestedActionsProps) {
   const { startRun } = useChatActions<ChatMessage>();
+  const storeApi = useCustomChatStoreApi<ChatMessage>();
   const startProvisionalChat = useStartProvisionalChat(chatId);
   const { data: session } = useSession();
   const currentRoute = useCurrentChatRoute();
@@ -145,6 +147,7 @@ function PureSuggestedActions({
         chatId,
         isAuthenticated: !!session?.user,
         message: submission.message,
+        onRunStarted: storeApi.getState().registerParallelRun,
         projectId: currentRoute.projectId,
         requestSpecs: submission.requestSpecs,
         startRun,

--- a/apps/chat/lib/assistant-request-id.ts
+++ b/apps/chat/lib/assistant-request-id.ts
@@ -1,5 +1,4 @@
 import { v5 as uuidv5 } from "uuid";
-import type { AppModelId } from "@/lib/ai/app-model-id";
 
 const ASSISTANT_REQUEST_NAMESPACE = uuidv5(
   "chat-js:assistant-request",
@@ -18,7 +17,7 @@ export function createAssistantRequestMessageId({
   parallelGroupId: string | null;
   parallelIndex: number | null;
   requestId: string;
-  selectedModelId: AppModelId;
+  selectedModelId: string;
   userMessageId: string;
 }) {
   return uuidv5(

--- a/apps/chat/lib/cancellation-aware-chat-transport.test.ts
+++ b/apps/chat/lib/cancellation-aware-chat-transport.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import type { ChatTransport, UIMessageChunk } from "ai";
+import { describe, it, vi } from "vitest";
+import type { ChatMessage } from "@/lib/ai/types";
+import { createAssistantRequestMessageId } from "./assistant-request-id";
+import { createCancellationAwareChatTransport } from "./cancellation-aware-chat-transport";
+import {
+  createGatedChatTransport,
+  gateChatRequest,
+} from "./gated-chat-transport";
+import type { GenerationCancellationTarget } from "./generation-cancellation";
+
+const chatId = "019fc917-29fe-7441-952b-7617c2f25f10";
+const userMessageId = "019fc917-387d-7fc4-81c7-a2ad437f0ea1";
+const requestId = "019fc917-4bde-7f6e-8824-9f104db0fd12";
+const parallelGroupId = "019fc917-5ae8-7e86-8476-b2a4ad878623";
+
+const message: ChatMessage = {
+  id: userMessageId,
+  metadata: {
+    activeStreamId: null,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    isPrimaryParallel: null,
+    parallelGroupId,
+    parallelIndex: null,
+    parentMessageId: null,
+    selectedModel: "openai/gpt-5-mini",
+  },
+  parts: [{ text: "Compare these", type: "text" }],
+  role: "user",
+};
+
+function requestOptions({
+  abortSignal,
+  metadata,
+}: {
+  abortSignal?: AbortSignal;
+  metadata?: unknown;
+} = {}): Parameters<ChatTransport<ChatMessage>["sendMessages"]>[0] {
+  return {
+    abortSignal,
+    body: {
+      parallelGroupId,
+      parallelIndex: 1,
+      requestId,
+      selectedModelId: "openai/gpt-5-nano",
+    },
+    chatId,
+    messageId: undefined,
+    messages: [message],
+    metadata,
+    trigger: "submit-message",
+  };
+}
+
+describe("createCancellationAwareChatTransport", () => {
+  it("cancels the exact forwarded request identity", async () => {
+    const abortController = new AbortController();
+    const cancellations: GenerationCancellationTarget[] = [];
+    const onCancel = vi.fn((target: GenerationCancellationTarget) => {
+      cancellations.push(target);
+      return Promise.resolve();
+    });
+    let forwardedBody: object | undefined;
+    const transport = createCancellationAwareChatTransport({
+      onCancel,
+      transport: {
+        reconnectToStream: () => Promise.resolve(null),
+        sendMessages: (options) => {
+          forwardedBody = options.body;
+          return Promise.resolve(new ReadableStream<UIMessageChunk>());
+        },
+      },
+    });
+
+    await transport.sendMessages(
+      requestOptions({ abortSignal: abortController.signal })
+    );
+    abortController.abort();
+
+    await vi.waitFor(() => assert.equal(onCancel.mock.calls.length, 1));
+    assert.deepEqual(forwardedBody, {
+      parallelGroupId,
+      parallelIndex: 1,
+      requestId,
+      selectedModelId: "openai/gpt-5-nano",
+    });
+    assert.deepEqual(cancellations[0], {
+      chatId,
+      messageId: createAssistantRequestMessageId({
+        chatId,
+        parallelGroupId,
+        parallelIndex: 1,
+        requestId,
+        selectedModelId: "openai/gpt-5-nano",
+        userMessageId,
+      }),
+      type: "request",
+    });
+  });
+
+  it("does not create a server cancellation for a gated request stopped locally", async () => {
+    const abortController = new AbortController();
+    const onCancel = vi.fn(() => Promise.resolve());
+    const sendMessages = vi.fn(() =>
+      Promise.resolve(new ReadableStream<UIMessageChunk>())
+    );
+    const transport = createGatedChatTransport(
+      createCancellationAwareChatTransport({
+        onCancel,
+        transport: {
+          reconnectToStream: () => Promise.resolve(null),
+          sendMessages,
+        },
+      })
+    );
+
+    const request = transport.sendMessages(
+      requestOptions({
+        abortSignal: abortController.signal,
+        metadata: gateChatRequest(new Promise<void>(() => undefined)).metadata,
+      })
+    );
+    abortController.abort();
+
+    await assert.rejects(request, { name: "AbortError" });
+    assert.equal(sendMessages.mock.calls.length, 0);
+    assert.equal(onCancel.mock.calls.length, 0);
+  });
+});

--- a/apps/chat/lib/cancellation-aware-chat-transport.test.ts
+++ b/apps/chat/lib/cancellation-aware-chat-transport.test.ts
@@ -127,4 +127,31 @@ describe("createCancellationAwareChatTransport", () => {
     assert.equal(sendMessages.mock.calls.length, 0);
     assert.equal(onCancel.mock.calls.length, 0);
   });
+
+  it("does not cancel a request after its stream completes", async () => {
+    const abortController = new AbortController();
+    const onCancel = vi.fn(() => Promise.resolve());
+    const transport = createCancellationAwareChatTransport({
+      onCancel,
+      transport: {
+        reconnectToStream: () => Promise.resolve(null),
+        sendMessages: () =>
+          Promise.resolve(
+            new ReadableStream<UIMessageChunk>({
+              start(controller) {
+                controller.close();
+              },
+            })
+          ),
+      },
+    });
+
+    const stream = await transport.sendMessages(
+      requestOptions({ abortSignal: abortController.signal })
+    );
+    await stream.pipeTo(new WritableStream());
+    abortController.abort();
+
+    assert.equal(onCancel.mock.calls.length, 0);
+  });
 });

--- a/apps/chat/lib/cancellation-aware-chat-transport.ts
+++ b/apps/chat/lib/cancellation-aware-chat-transport.ts
@@ -15,9 +15,14 @@ const requestBodySchema = z
   })
   .loose();
 
+interface PreparedRequest {
+  options: Parameters<ChatTransport<ChatMessage>["sendMessages"]>[0];
+  target: GenerationCancellationTarget;
+}
+
 function prepareRequest(
   options: Parameters<ChatTransport<ChatMessage>["sendMessages"]>[0]
-) {
+): PreparedRequest | null {
   const message = options.messages.at(-1);
   if (message?.role !== "user") {
     return null;
@@ -49,8 +54,36 @@ function prepareRequest(
       ...options,
       body: { ...options.body, requestId },
     },
-    target: { chatId: options.chatId, messageId, type: "request" } as const,
+    target: { chatId: options.chatId, messageId, type: "request" },
   };
+}
+
+function cleanupStream<T>(
+  stream: ReadableStream<T>,
+  cleanup: () => void
+): ReadableStream<T> {
+  const reader = stream.getReader();
+
+  return new ReadableStream({
+    async cancel(reason) {
+      cleanup();
+      await reader.cancel(reason);
+    },
+    async pull(controller) {
+      try {
+        const result = await reader.read();
+        if (result.done) {
+          cleanup();
+          controller.close();
+          return;
+        }
+        controller.enqueue(result.value);
+      } catch (error) {
+        cleanup();
+        controller.error(error);
+      }
+    },
+  });
 }
 
 function observeCancellation({
@@ -96,7 +129,8 @@ export function createCancellationAwareChatTransport({
       });
 
       try {
-        return await transport.sendMessages(request.options);
+        const stream = await transport.sendMessages(request.options);
+        return cleanupStream(stream, cleanup);
       } catch (error) {
         cleanup();
         throw error;

--- a/apps/chat/lib/cancellation-aware-chat-transport.ts
+++ b/apps/chat/lib/cancellation-aware-chat-transport.ts
@@ -1,0 +1,106 @@
+import type { ChatTransport } from "ai";
+import { z } from "zod";
+import type { ChatMessage } from "@/lib/ai/types";
+import { getPrimarySelectedModelId } from "@/lib/ai/types";
+import { createAssistantRequestMessageId } from "@/lib/assistant-request-id";
+import type { GenerationCancellationTarget } from "@/lib/generation-cancellation";
+import { generateUUID } from "@/lib/utils";
+
+const requestBodySchema = z
+  .object({
+    parallelGroupId: z.string().uuid().nullable().optional(),
+    parallelIndex: z.number().int().nullable().optional(),
+    requestId: z.string().uuid().optional(),
+    selectedModelId: z.string().optional(),
+  })
+  .loose();
+
+function prepareRequest(
+  options: Parameters<ChatTransport<ChatMessage>["sendMessages"]>[0]
+) {
+  const message = options.messages.at(-1);
+  if (message?.role !== "user") {
+    return null;
+  }
+
+  const parsedBody = requestBodySchema.safeParse(options.body);
+  const body = parsedBody.success ? parsedBody.data : {};
+  const selectedModelId =
+    body.selectedModelId ??
+    getPrimarySelectedModelId(message.metadata.selectedModel);
+
+  if (!selectedModelId) {
+    return null;
+  }
+
+  const requestId = body.requestId ?? generateUUID();
+  const messageId = createAssistantRequestMessageId({
+    chatId: options.chatId,
+    parallelGroupId:
+      body.parallelGroupId ?? message.metadata.parallelGroupId ?? null,
+    parallelIndex: body.parallelIndex ?? null,
+    requestId,
+    selectedModelId,
+    userMessageId: message.id,
+  });
+
+  return {
+    options: {
+      ...options,
+      body: { ...options.body, requestId },
+    },
+    target: { chatId: options.chatId, messageId, type: "request" } as const,
+  };
+}
+
+function observeCancellation({
+  onCancel,
+  signal,
+  target,
+}: {
+  onCancel: (target: GenerationCancellationTarget) => Promise<unknown>;
+  signal: AbortSignal | undefined;
+  target: GenerationCancellationTarget;
+}) {
+  if (!signal || signal.aborted) {
+    return () => undefined;
+  }
+
+  const cancel = () => {
+    onCancel(target).catch(() => undefined);
+  };
+  signal.addEventListener("abort", cancel, { once: true });
+
+  return () => signal.removeEventListener("abort", cancel);
+}
+
+export function createCancellationAwareChatTransport({
+  onCancel,
+  transport,
+}: {
+  onCancel: (target: GenerationCancellationTarget) => Promise<unknown>;
+  transport: ChatTransport<ChatMessage>;
+}): ChatTransport<ChatMessage> {
+  return {
+    reconnectToStream: (options) => transport.reconnectToStream(options),
+    async sendMessages(options) {
+      const request = prepareRequest(options);
+      if (!request) {
+        return transport.sendMessages(options);
+      }
+
+      const cleanup = observeCancellation({
+        onCancel,
+        signal: request.options.abortSignal,
+        target: request.target,
+      });
+
+      try {
+        return await transport.sendMessages(request.options);
+      } catch (error) {
+        cleanup();
+        throw error;
+      }
+    },
+  };
+}

--- a/apps/chat/lib/db/migrations/0045_sleepy_luckman.sql
+++ b/apps/chat/lib/db/migrations/0045_sleepy_luckman.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "GenerationCancellation" (
+	"messageId" uuid NOT NULL,
+	"userId" text NOT NULL,
+	"chatId" uuid NOT NULL,
+	"canceledAt" timestamp NOT NULL,
+	CONSTRAINT "GenerationCancellation_messageId_userId_pk" PRIMARY KEY("messageId","userId")
+);
+--> statement-breakpoint
+ALTER TABLE "GenerationCancellation" ADD CONSTRAINT "GenerationCancellation_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/apps/chat/lib/db/migrations/meta/0045_snapshot.json
+++ b/apps/chat/lib/db/migrations/meta/0045_snapshot.json
@@ -1,0 +1,1532 @@
+{
+  "id": "cfea6c94-1ff8-4a7f-b02e-e712d3c6d588",
+  "prevId": "557ad212-e874-4463-a45b-17438f28fadb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_user_id_fk": {
+          "name": "Chat_userId_user_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Chat_projectId_Project_id_fk": {
+          "name": "Chat_projectId_Project_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "Project",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Document_message_id_idx": {
+          "name": "Document_message_id_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Document_userId_user_id_fk": {
+          "name": "Document_userId_user_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Document_messageId_Message_id_fk": {
+          "name": "Document_messageId_Message_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "Message",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Document_id_createdAt_pk": {
+          "name": "Document_id_createdAt_pk",
+          "columns": ["id", "createdAt"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.GenerationCancellation": {
+      "name": "GenerationCancellation",
+      "schema": "",
+      "columns": {
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canceledAt": {
+          "name": "canceledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "GenerationCancellation_userId_user_id_fk": {
+          "name": "GenerationCancellation_userId_user_id_fk",
+          "tableFrom": "GenerationCancellation",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "GenerationCancellation_messageId_userId_pk": {
+          "name": "GenerationCancellation_messageId_userId_pk",
+          "columns": ["messageId", "userId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.McpConnector": {
+      "name": "McpConnector",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nameId": {
+          "name": "nameId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'http'"
+        },
+        "oauthClientId": {
+          "name": "oauthClientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauthClientSecret": {
+          "name": "oauthClientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "McpConnector_user_id_idx": {
+          "name": "McpConnector_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "McpConnector_user_name_id_idx": {
+          "name": "McpConnector_user_name_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nameId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "McpConnector_user_name_id_unique": {
+          "name": "McpConnector_user_name_id_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nameId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "McpConnector_userId_user_id_fk": {
+          "name": "McpConnector_userId_user_id_fk",
+          "tableFrom": "McpConnector",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.McpOAuthSession": {
+      "name": "McpOAuthSession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "mcpConnectorId": {
+          "name": "mcpConnectorId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serverUrl": {
+          "name": "serverUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientInfo": {
+          "name": "clientInfo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codeVerifier": {
+          "name": "codeVerifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "McpOAuthSession_connector_idx": {
+          "name": "McpOAuthSession_connector_idx",
+          "columns": [
+            {
+              "expression": "mcpConnectorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "McpOAuthSession_state_idx": {
+          "name": "McpOAuthSession_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "McpOAuthSession_mcpConnectorId_McpConnector_id_fk": {
+          "name": "McpOAuthSession_mcpConnectorId_McpConnector_id_fk",
+          "tableFrom": "McpOAuthSession",
+          "tableTo": "McpConnector",
+          "columnsFrom": ["mcpConnectorId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "McpOAuthSession_state_unique": {
+          "name": "McpOAuthSession_state_unique",
+          "nullsNotDistinct": false,
+          "columns": ["state"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentMessageId": {
+          "name": "parentMessageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedModel": {
+          "name": "selectedModel",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedTool": {
+          "name": "selectedTool",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "parallelGroupId": {
+          "name": "parallelGroupId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parallelIndex": {
+          "name": "parallelIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPrimaryParallel": {
+          "name": "isPrimaryParallel",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastContext": {
+          "name": "lastContext",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activeStreamId": {
+          "name": "activeStreamId",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceledAt": {
+          "name": "canceledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Part": {
+      "name": "Part",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_text": {
+          "name": "text_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_text": {
+          "name": "reasoning_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_mediaType": {
+          "name": "file_mediaType",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_filename": {
+          "name": "file_filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url_sourceId": {
+          "name": "source_url_sourceId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url_url": {
+          "name": "source_url_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url_title": {
+          "name": "source_url_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_sourceId": {
+          "name": "source_document_sourceId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_mediaType": {
+          "name": "source_document_mediaType",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_title": {
+          "name": "source_document_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_filename": {
+          "name": "source_document_filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_toolCallId": {
+          "name": "tool_toolCallId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_state": {
+          "name": "tool_state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_input": {
+          "name": "tool_input",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_output": {
+          "name": "tool_output",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_errorText": {
+          "name": "tool_errorText",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_blob": {
+          "name": "data_blob",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerMetadata": {
+          "name": "providerMetadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Part_message_id_idx": {
+          "name": "Part_message_id_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Part_message_id_order_idx": {
+          "name": "Part_message_id_order_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Part_messageId_Message_id_fk": {
+          "name": "Part_messageId_Message_id_fk",
+          "tableFrom": "Part",
+          "tableTo": "Message",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "Part_text_required_if_type_text": {
+          "name": "Part_text_required_if_type_text",
+          "value": "CASE WHEN \"Part\".\"type\" = 'text' THEN \"Part\".\"text_text\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_reasoning_required_if_type_reasoning": {
+          "name": "Part_reasoning_required_if_type_reasoning",
+          "value": "CASE WHEN \"Part\".\"type\" = 'reasoning' THEN \"Part\".\"reasoning_text\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_file_required_if_type_file": {
+          "name": "Part_file_required_if_type_file",
+          "value": "CASE WHEN \"Part\".\"type\" = 'file' THEN \"Part\".\"file_mediaType\" IS NOT NULL AND \"Part\".\"file_url\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_source_url_required_if_type_source_url": {
+          "name": "Part_source_url_required_if_type_source_url",
+          "value": "CASE WHEN \"Part\".\"type\" = 'source-url' THEN \"Part\".\"source_url_sourceId\" IS NOT NULL AND \"Part\".\"source_url_url\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_source_document_required_if_type_source_document": {
+          "name": "Part_source_document_required_if_type_source_document",
+          "value": "CASE WHEN \"Part\".\"type\" = 'source-document' THEN \"Part\".\"source_document_sourceId\" IS NOT NULL AND \"Part\".\"source_document_mediaType\" IS NOT NULL AND \"Part\".\"source_document_title\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_tool_required_if_type_tool": {
+          "name": "Part_tool_required_if_type_tool",
+          "value": "CASE WHEN \"Part\".\"type\" LIKE 'tool-%' THEN \"Part\".\"tool_toolCallId\" IS NOT NULL AND \"Part\".\"tool_state\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_data_required_if_type_data": {
+          "name": "Part_data_required_if_type_data",
+          "value": "CASE WHEN \"Part\".\"type\" LIKE 'data-%' THEN \"Part\".\"data_type\" IS NOT NULL ELSE TRUE END"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.Project": {
+      "name": "Project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'folder'"
+        },
+        "iconColor": {
+          "name": "iconColor",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gray'"
+        }
+      },
+      "indexes": {
+        "Project_user_id_idx": {
+          "name": "Project_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Project_userId_user_id_fk": {
+          "name": "Project_userId_user_id_fk",
+          "tableFrom": "Project",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Suggestion": {
+      "name": "Suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentCreatedAt": {
+          "name": "documentCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalText": {
+          "name": "originalText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedText": {
+          "name": "suggestedText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Suggestion_userId_user_id_fk": {
+          "name": "Suggestion_userId_user_id_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk": {
+          "name": "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "Document",
+          "columnsFrom": ["documentId", "documentCreatedAt"],
+          "columnsTo": ["id", "createdAt"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Suggestion_id_pk": {
+          "name": "Suggestion_id_pk",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserCredit": {
+      "name": "UserCredit",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "UserCredit_userId_user_id_fk": {
+          "name": "UserCredit_userId_user_id_fk",
+          "tableFrom": "UserCredit",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserModelPreference": {
+      "name": "UserModelPreference",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelId": {
+          "name": "modelId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UserModelPreference_user_id_idx": {
+          "name": "UserModelPreference_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserModelPreference_userId_user_id_fk": {
+          "name": "UserModelPreference_userId_user_id_fk",
+          "tableFrom": "UserModelPreference",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "UserModelPreference_userId_modelId_pk": {
+          "name": "UserModelPreference_userId_modelId_pk",
+          "columns": ["userId", "modelId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Vote": {
+      "name": "Vote",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_chatId_Chat_id_fk": {
+          "name": "Vote_chatId_Chat_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "Vote_messageId_Message_id_fk": {
+          "name": "Vote_messageId_Message_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Message",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_chatId_messageId_pk": {
+          "name": "Vote_chatId_messageId_pk",
+          "columns": ["chatId", "messageId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/chat/lib/db/migrations/meta/_journal.json
+++ b/apps/chat/lib/db/migrations/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1773499312081,
       "tag": "0044_gray_red_shift",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1788085781083,
+      "tag": "0045_sleepy_luckman",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/chat/lib/db/queries.ts
+++ b/apps/chat/lib/db/queries.ts
@@ -1074,10 +1074,13 @@ export async function updateMessageCanceledAt({
   canceledAt: Date | null;
 }) {
   try {
-    return await db
+    const updatedMessages = await db
       .update(message)
       .set({ canceledAt })
-      .where(eq(message.id, messageId));
+      .where(eq(message.id, messageId))
+      .returning({ id: message.id });
+
+    return updatedMessages.length > 0;
   } catch (error) {
     logger.error({ error, messageId }, "updateMessageCanceledAt failed");
     throw error;

--- a/apps/chat/lib/db/queries.ts
+++ b/apps/chat/lib/db/queries.ts
@@ -34,6 +34,7 @@ import {
   chat,
   type DBMessage,
   document,
+  generationCancellation,
   message,
   type Part,
   part,
@@ -490,7 +491,13 @@ export async function updateMessage({
           lastContext: dbMessage.lastContext,
           activeStreamId: dbMessage.activeStreamId,
         })
-        .where(and(eq(message.id, id), isNull(message.canceledAt)))
+        .where(
+          and(
+            eq(message.id, id),
+            eq(message.chatId, chatId),
+            isNull(message.canceledAt)
+          )
+        )
         .returning({ id: message.id });
 
       if (updatedMessages.length === 0) {
@@ -847,58 +854,6 @@ export async function getMessageById({ id }: { id: string }) {
   }
 }
 
-export async function getCancelableResponseMessage({
-  chatId,
-  parentMessageId,
-  stoppedAt,
-}: {
-  chatId: string;
-  parentMessageId: string;
-  stoppedAt: Date;
-}) {
-  try {
-    const [activeResponse] = await db
-      .select({ id: message.id })
-      .from(message)
-      .where(
-        and(
-          eq(message.chatId, chatId),
-          eq(message.parentMessageId, parentMessageId),
-          eq(message.role, "assistant"),
-          isNotNull(message.activeStreamId)
-        )
-      )
-      .orderBy(asc(message.createdAt))
-      .limit(1);
-
-    if (activeResponse) {
-      return activeResponse;
-    }
-
-    const [responseCreatedAfterStop] = await db
-      .select({ id: message.id })
-      .from(message)
-      .where(
-        and(
-          eq(message.chatId, chatId),
-          eq(message.parentMessageId, parentMessageId),
-          eq(message.role, "assistant"),
-          gte(message.createdAt, stoppedAt)
-        )
-      )
-      .orderBy(asc(message.createdAt))
-      .limit(1);
-
-    return responseCreatedAfterStop;
-  } catch (error) {
-    logger.error(
-      { chatId, error, parentMessageId },
-      "getCancelableResponseMessage failed"
-    );
-    throw error;
-  }
-}
-
 export async function getChatMessageWithPartsById({
   id,
 }: {
@@ -1124,31 +1079,92 @@ export async function getMessageCanceledAt({
   }
 }
 
-export async function updateMessageCanceledAt({
-  messageId,
+export async function requestGenerationCancellation({
   canceledAt,
+  chatId,
+  messageId,
+  userId,
 }: {
+  canceledAt: Date;
+  chatId: string;
   messageId: string;
-  canceledAt: Date | null;
+  userId: string;
 }) {
   try {
-    const updatedMessages = await db.transaction(async (tx) => {
-      const updated = await tx
-        .update(message)
-        .set({ activeStreamId: null, canceledAt })
-        .where(eq(message.id, messageId))
-        .returning({ id: message.id });
-
-      if (updated.length > 0 && canceledAt !== null) {
-        await tx.delete(part).where(eq(part.messageId, messageId));
-      }
-
-      return updated;
-    });
-
-    return updatedMessages.length > 0;
+    await db
+      .insert(generationCancellation)
+      .values({ canceledAt, chatId, messageId, userId })
+      .onConflictDoUpdate({
+        target: [
+          generationCancellation.messageId,
+          generationCancellation.userId,
+        ],
+        set: { canceledAt, chatId },
+      });
   } catch (error) {
-    logger.error({ error, messageId }, "updateMessageCanceledAt failed");
+    logger.error({ error, messageId }, "requestGenerationCancellation failed");
+    throw error;
+  }
+}
+
+export async function isGenerationCancellationRequested({
+  chatId,
+  messageId,
+  userId,
+}: {
+  chatId: string;
+  messageId: string;
+  userId: string;
+}) {
+  try {
+    const [cancellation] = await db
+      .select({ messageId: generationCancellation.messageId })
+      .from(generationCancellation)
+      .where(
+        and(
+          eq(generationCancellation.chatId, chatId),
+          eq(generationCancellation.messageId, messageId),
+          eq(generationCancellation.userId, userId)
+        )
+      )
+      .limit(1);
+
+    return !!cancellation;
+  } catch (error) {
+    logger.error(
+      { error, messageId },
+      "isGenerationCancellationRequested failed"
+    );
+    throw error;
+  }
+}
+
+export async function cancelActiveMessage({
+  canceledAt,
+  chatId,
+  messageId,
+}: {
+  canceledAt: Date;
+  chatId: string;
+  messageId: string;
+}) {
+  try {
+    const canceledMessages = await db
+      .update(message)
+      .set({ activeStreamId: null, canceledAt })
+      .where(
+        and(
+          eq(message.chatId, chatId),
+          eq(message.id, messageId),
+          isNotNull(message.activeStreamId),
+          isNull(message.canceledAt)
+        )
+      )
+      .returning({ id: message.id });
+
+    return canceledMessages.length > 0;
+  } catch (error) {
+    logger.error({ error, messageId }, "cancelActiveMessage failed");
     throw error;
   }
 }

--- a/apps/chat/lib/db/queries.ts
+++ b/apps/chat/lib/db/queries.ts
@@ -7,6 +7,7 @@ import {
   gt,
   gte,
   inArray,
+  isNotNull,
   isNull,
   type SQL,
 } from "drizzle-orm";
@@ -474,7 +475,7 @@ export async function updateMessage({
       dbMessage.id = id;
 
       // Update message (without parts - parts are stored in Part table)
-      await tx
+      const updatedMessages = await tx
         .update(message)
         .set({
           annotations: dbMessage.annotations,
@@ -489,7 +490,12 @@ export async function updateMessage({
           lastContext: dbMessage.lastContext,
           activeStreamId: dbMessage.activeStreamId,
         })
-        .where(eq(message.id, id));
+        .where(and(eq(message.id, id), isNull(message.canceledAt)))
+        .returning({ id: message.id });
+
+      if (updatedMessages.length === 0) {
+        return false;
+      }
 
       // Update parts in Part table
       // Delete existing parts
@@ -501,7 +507,7 @@ export async function updateMessage({
         await tx.insert(part).values(mappedDBParts);
       }
 
-      return;
+      return true;
     });
   } catch (error) {
     logger.error({ error, messageId: id, chatId }, "updateMessage failed");
@@ -841,6 +847,58 @@ export async function getMessageById({ id }: { id: string }) {
   }
 }
 
+export async function getCancelableResponseMessage({
+  chatId,
+  parentMessageId,
+  stoppedAt,
+}: {
+  chatId: string;
+  parentMessageId: string;
+  stoppedAt: Date;
+}) {
+  try {
+    const [activeResponse] = await db
+      .select({ id: message.id })
+      .from(message)
+      .where(
+        and(
+          eq(message.chatId, chatId),
+          eq(message.parentMessageId, parentMessageId),
+          eq(message.role, "assistant"),
+          isNotNull(message.activeStreamId)
+        )
+      )
+      .orderBy(asc(message.createdAt))
+      .limit(1);
+
+    if (activeResponse) {
+      return activeResponse;
+    }
+
+    const [responseCreatedAfterStop] = await db
+      .select({ id: message.id })
+      .from(message)
+      .where(
+        and(
+          eq(message.chatId, chatId),
+          eq(message.parentMessageId, parentMessageId),
+          eq(message.role, "assistant"),
+          gte(message.createdAt, stoppedAt)
+        )
+      )
+      .orderBy(asc(message.createdAt))
+      .limit(1);
+
+    return responseCreatedAfterStop;
+  } catch (error) {
+    logger.error(
+      { chatId, error, parentMessageId },
+      "getCancelableResponseMessage failed"
+    );
+    throw error;
+  }
+}
+
 export async function getChatMessageWithPartsById({
   id,
 }: {
@@ -1074,11 +1132,19 @@ export async function updateMessageCanceledAt({
   canceledAt: Date | null;
 }) {
   try {
-    const updatedMessages = await db
-      .update(message)
-      .set({ canceledAt })
-      .where(eq(message.id, messageId))
-      .returning({ id: message.id });
+    const updatedMessages = await db.transaction(async (tx) => {
+      const updated = await tx
+        .update(message)
+        .set({ activeStreamId: null, canceledAt })
+        .where(eq(message.id, messageId))
+        .returning({ id: message.id });
+
+      if (updated.length > 0 && canceledAt !== null) {
+        await tx.delete(part).where(eq(part.messageId, messageId));
+      }
+
+      return updated;
+    });
 
     return updatedMessages.length > 0;
   } catch (error) {

--- a/apps/chat/lib/db/schema.ts
+++ b/apps/chat/lib/db/schema.ts
@@ -317,6 +317,21 @@ export const user = pgTable("user", {
     .notNull(),
 });
 
+export const generationCancellation = pgTable(
+  "GenerationCancellation",
+  {
+    messageId: uuid("messageId").notNull(),
+    userId: text("userId")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    chatId: uuid("chatId").notNull(),
+    canceledAt: timestamp("canceledAt").notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.messageId, table.userId] }),
+  })
+);
+
 export const session = pgTable("session", {
   id: text("id").primaryKey(),
   expiresAt: timestamp("expires_at").notNull(),

--- a/apps/chat/lib/generation-cancellation.ts
+++ b/apps/chat/lib/generation-cancellation.ts
@@ -1,0 +1,11 @@
+export type GenerationCancellationTarget =
+  | {
+      chatId: string;
+      messageId: string;
+      type: "request";
+    }
+  | {
+      chatId: string;
+      messageId: string;
+      type: "message";
+    };

--- a/apps/chat/lib/parallel-chat-requests.test.ts
+++ b/apps/chat/lib/parallel-chat-requests.test.ts
@@ -81,6 +81,11 @@ afterEach(() => {
 describe("runParallelThreadRequestSpecs", () => {
   it("creates every run immediately and gates only secondary transport", async () => {
     const underlyingTransport = new ControlledTransport();
+    const startedRuns: Array<{
+      parallelGroupId: string;
+      parallelIndex: number;
+      runId: string;
+    }> = [];
     const chat = new Thread<ChatMessage>({
       transport: createGatedChatTransport(underlyingTransport),
     });
@@ -89,6 +94,7 @@ describe("runParallelThreadRequestSpecs", () => {
       chatId: "chat-1",
       isAuthenticated: true,
       message,
+      onRunStarted: (run) => startedRuns.push(run),
       projectId: "project-1",
       requestSpecs,
       startRun: chat.startRun,
@@ -102,6 +108,20 @@ describe("runParallelThreadRequestSpecs", () => {
     assert.deepEqual(
       chat.getSnapshot().runs.map(({ status }) => status),
       ["submitted", "submitted"]
+    );
+    assert.deepEqual(
+      startedRuns.map(({ parallelGroupId, parallelIndex }) => ({
+        parallelGroupId,
+        parallelIndex,
+      })),
+      [
+        { parallelGroupId: "response-group-1", parallelIndex: 0 },
+        { parallelGroupId: "response-group-1", parallelIndex: 1 },
+      ]
+    );
+    assert.deepEqual(
+      startedRuns.map(({ runId }) => runId),
+      chat.getSnapshot().runs.map(({ id }) => id)
     );
     assert.deepEqual(underlyingTransport.requests[0]?.body, {
       isPrimaryParallel: true,

--- a/apps/chat/lib/parallel-chat-requests.ts
+++ b/apps/chat/lib/parallel-chat-requests.ts
@@ -146,6 +146,7 @@ export async function runParallelThreadRequestSpecs({
   message,
   projectId,
   requestSpecs,
+  onRunStarted,
   startRun,
 }: {
   chatId: string;
@@ -153,6 +154,11 @@ export async function runParallelThreadRequestSpecs({
   message: ChatMessage;
   projectId: string | null;
   requestSpecs: ParallelRequestSpec[];
+  onRunStarted: (input: {
+    parallelGroupId: string;
+    parallelIndex: number;
+    runId: string;
+  }) => void;
   startRun: TreeHelpers<ChatMessage>["startRun"];
 }) {
   const primaryRequest = requestSpecs[0];
@@ -175,11 +181,17 @@ export async function runParallelThreadRequestSpecs({
         },
       },
     });
+    if (primaryRequest.parallelGroupId) {
+      onRunStarted({
+        parallelGroupId: primaryRequest.parallelGroupId,
+        parallelIndex: primaryRequest.parallelIndex,
+        runId: primaryRun.id,
+      });
+    }
 
     const secondaryRuns = await Promise.all(
-      requestSpecs.slice(1).map(async (requestSpec) => ({
-        requestSpec,
-        run: await startRun({
+      requestSpecs.slice(1).map(async (requestSpec) => {
+        const run = await startRun({
           follow: false,
           from: message.id,
           request: {
@@ -191,8 +203,16 @@ export async function runParallelThreadRequestSpecs({
               projectId: projectId ?? undefined,
             },
           },
-        }),
-      }))
+        });
+        if (requestSpec.parallelGroupId) {
+          onRunStarted({
+            parallelGroupId: requestSpec.parallelGroupId,
+            parallelIndex: requestSpec.parallelIndex,
+            runId: run.id,
+          });
+        }
+        return { requestSpec, run };
+      })
     );
 
     const rejectUnconfirmedPersistence = persistenceGate

--- a/apps/chat/lib/start-provisional-chat.ts
+++ b/apps/chat/lib/start-provisional-chat.ts
@@ -91,6 +91,7 @@ export function useStartProvisionalChat(chatId: string) {
         chatId,
         isAuthenticated: true,
         message,
+        onRunStarted: storeState.registerParallelRun,
         projectId: currentRoute.projectId,
         requestSpecs,
         startRun,

--- a/apps/chat/lib/stores/custom-store-provider.tsx
+++ b/apps/chat/lib/stores/custom-store-provider.tsx
@@ -34,6 +34,10 @@ import {
   type PartsAugmentedState,
   withMessageParts,
 } from "./with-message-parts";
+import {
+  type ParallelRunsAugmentedState,
+  withParallelRuns,
+} from "./with-parallel-runs";
 import { type ThreadStateStore, withThreadState } from "./with-thread-state";
 import { withTracing } from "./with-tracing";
 import { ZustandThreadState } from "./zustand-thread-state";
@@ -41,6 +45,7 @@ import { ZustandThreadState } from "./zustand-thread-state";
 export type CustomChatStoreState<UI_MESSAGE extends UIMessage = UIMessage> =
   ChatPersistenceAugmentedState<UI_MESSAGE> &
     DataStreamAugmentedState<UI_MESSAGE> &
+    ParallelRunsAugmentedState<UI_MESSAGE> &
     PartsAugmentedState<UI_MESSAGE> &
     ThreadStateStore<UI_MESSAGE>;
 
@@ -62,11 +67,13 @@ export function createCustomChatStore<TMessage extends UIMessage = UIMessage>(
         withTracing(
           withChatPersistence(
             withDataStream(
-              withThreadState(
-                withMessageParts(
-                  createChatStoreCreator<TMessage>(initialSnapshot.messages)
-                ),
-                { initialSnapshot }
+              withParallelRuns(
+                withThreadState(
+                  withMessageParts(
+                    createChatStoreCreator<TMessage>(initialSnapshot.messages)
+                  ),
+                  { initialSnapshot }
+                )
               )
             ),
             {

--- a/apps/chat/lib/stores/hooks-threads.ts
+++ b/apps/chat/lib/stores/hooks-threads.ts
@@ -1,3 +1,4 @@
+import type { ThreadRun } from "@chatjs/thread";
 import { useCallback } from "react";
 import { useStoreWithEqualityFn } from "zustand/traditional";
 import type { ChatMessage } from "../ai/types";
@@ -15,6 +16,7 @@ export interface MessageSiblingInfo {
 export interface ParallelGroupInfo {
   messages: ChatMessage[];
   parallelGroupId: string;
+  runsByParallelIndex: Record<number, ThreadRun>;
   selectedMessageId: string | null;
 }
 
@@ -136,10 +138,23 @@ export function useParallelGroupInfo(
             (b.metadata.parallelIndex ?? Number.MAX_SAFE_INTEGER)
         );
       const visibleIds = new Set(snapshot.messages.map(({ id }) => id));
+      const runsById = new Map(snapshot.runs.map((run) => [run.id, run]));
+      const runsByParallelIndex: Record<number, ThreadRun> = {};
+      const runIdsByParallelIndex =
+        state.parallelRunIdsByGroup[parallelGroupId] ?? {};
+      for (const [parallelIndex, runId] of Object.entries(
+        runIdsByParallelIndex
+      )) {
+        const run = runsById.get(runId);
+        if (run) {
+          runsByParallelIndex[Number(parallelIndex)] = run;
+        }
+      }
 
       return {
         messages,
         parallelGroupId,
+        runsByParallelIndex,
         selectedMessageId:
           messages.find(({ id }) => visibleIds.has(id))?.id ?? null,
       };
@@ -150,6 +165,16 @@ export function useParallelGroupInfo(
         b !== null &&
         a.parallelGroupId === b.parallelGroupId &&
         a.selectedMessageId === b.selectedMessageId &&
+        Object.keys(a.runsByParallelIndex).length ===
+          Object.keys(b.runsByParallelIndex).length &&
+        Object.entries(a.runsByParallelIndex).every(([parallelIndex, run]) => {
+          const other = b.runsByParallelIndex[Number(parallelIndex)];
+          return (
+            run.id === other?.id &&
+            run.status === other.status &&
+            run.error === other.error
+          );
+        }) &&
         a.messages.length === b.messages.length &&
         a.messages.every(
           (message, index) =>

--- a/apps/chat/lib/stores/with-parallel-runs.ts
+++ b/apps/chat/lib/stores/with-parallel-runs.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import type { UIMessage } from "ai";
+import type { StateCreator } from "zustand";
+import type { StoreState as BaseChatStoreState } from "@/lib/stores/base";
+
+export type ParallelRunsAugmentedState<UM extends UIMessage> =
+  BaseChatStoreState<UM> & {
+    parallelRunIdsByGroup: Record<string, Record<number, string>>;
+    registerParallelRun: (input: {
+      parallelGroupId: string;
+      parallelIndex: number;
+      runId: string;
+    }) => void;
+  };
+
+export const withParallelRuns =
+  <TMessage extends UIMessage, TState extends BaseChatStoreState<TMessage>>(
+    creator: StateCreator<TState, [], []>
+  ): StateCreator<TState & ParallelRunsAugmentedState<TMessage>, [], []> =>
+  (set, get, api) => {
+    const base = creator(set, get, api);
+    const originalReset = base.reset;
+
+    return {
+      ...base,
+      parallelRunIdsByGroup: {},
+      registerParallelRun: ({ parallelGroupId, parallelIndex, runId }) => {
+        set((state) => ({
+          ...state,
+          parallelRunIdsByGroup: {
+            ...state.parallelRunIdsByGroup,
+            [parallelGroupId]: {
+              ...state.parallelRunIdsByGroup[parallelGroupId],
+              [parallelIndex]: runId,
+            },
+          },
+        }));
+      },
+      reset: () => {
+        originalReset();
+        set((state) => ({
+          ...state,
+          parallelRunIdsByGroup: {},
+        }));
+      },
+    };
+  };

--- a/apps/chat/lib/stores/zustand-thread-state.test.ts
+++ b/apps/chat/lib/stores/zustand-thread-state.test.ts
@@ -71,6 +71,23 @@ describe("ZustandThreadState", () => {
     unsubscribe();
   });
 
+  it("indexes parallel runs by response group and clears them on reset", () => {
+    const store = createCustomChatStore<UIMessage>([initialMessage]);
+
+    store.getState().registerParallelRun({
+      parallelGroupId: "group-1",
+      parallelIndex: 1,
+      runId: "run-2",
+    });
+
+    expect(store.getState().parallelRunIdsByGroup).toEqual({
+      "group-1": { 1: "run-2" },
+    });
+
+    store.getState().reset();
+    expect(store.getState().parallelRunIdsByGroup).toEqual({});
+  });
+
   it("propagates updater errors without committing", () => {
     const store = createCustomChatStore<UIMessage>([initialMessage]);
     const state = new ZustandThreadState(store);

--- a/apps/chat/lib/utils.ts
+++ b/apps/chat/lib/utils.ts
@@ -16,10 +16,7 @@ interface ApplicationError extends Error {
 	status: number;
 }
 
-export async function fetchWithErrorHandlers(
-	input: RequestInfo | URL,
-	init?: RequestInit,
-) {
+export const fetchWithErrorHandlers: typeof fetch = async (input, init) => {
 	try {
 		const response = await fetch(input, init);
 
@@ -36,7 +33,7 @@ export async function fetchWithErrorHandlers(
 
 		throw error;
 	}
-}
+};
 
 function findLastArtifact(
 	messages: Array<ChatMessage>,

--- a/apps/chat/trpc/routers/chat.router.ts
+++ b/apps/chat/trpc/routers/chat.router.ts
@@ -188,19 +188,23 @@ export const chatRouter = createTRPCRouter({
   stopStream: protectedProcedure
     .input(
       z.object({
+        chatId: z.string().uuid(),
         messageId: z.string().uuid(),
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const [msg] = await getMessageById({ id: input.messageId });
-      if (!msg) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Message not found",
-        });
+      // A new chat can still be generating its title when the client stops.
+      // Wait for its reserved assistant row so request ordering cannot lose cancellation.
+      const deadline = Date.now() + 30_000;
+      let retryDelay = 25;
+      let chat = await getChatById({ id: input.chatId });
+
+      while (!chat && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, retryDelay));
+        retryDelay = Math.min(retryDelay * 2, 250);
+        chat = await getChatById({ id: input.chatId });
       }
 
-      const chat = await getChatById({ id: msg.chatId });
       if (!chat || chat.userId !== ctx.user.id) {
         throw new TRPCError({
           code: "NOT_FOUND",
@@ -208,10 +212,24 @@ export const chatRouter = createTRPCRouter({
         });
       }
 
-      await updateMessageCanceledAt({
-        messageId: input.messageId,
-        canceledAt: new Date(),
-      });
+      const canceledAt = new Date();
+
+      while (
+        !(await updateMessageCanceledAt({
+          messageId: input.messageId,
+          canceledAt,
+        }))
+      ) {
+        if (Date.now() >= deadline) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Message not found",
+          });
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, retryDelay));
+        retryDelay = Math.min(retryDelay * 2, 250);
+      }
 
       return { success: true };
     }),

--- a/apps/chat/trpc/routers/chat.router.ts
+++ b/apps/chat/trpc/routers/chat.router.ts
@@ -9,21 +9,21 @@ import {
 } from "@/lib/clone-messages";
 import { config } from "@/lib/config";
 import {
+  cancelActiveMessage,
   deleteChatById,
   deleteMessagesByChatIdAfterMessageId,
   getAllMessagesByChatId,
-  getCancelableResponseMessage,
   getChatById,
   getChatsByUserId,
   getDocumentsByMessageIds,
   getMessageById,
+  requestGenerationCancellation,
   saveChat,
   saveChatMessages,
   saveDocuments,
   updateChatIsPinnedById,
   updateChatTitleById,
   updateChatVisiblityById,
-  updateMessageCanceledAt,
 } from "@/lib/db/queries";
 import { MAX_MESSAGE_CHARS } from "@/lib/limits/tokens";
 import { dbChatToUIChat } from "@/lib/message-conversion";
@@ -188,25 +188,22 @@ export const chatRouter = createTRPCRouter({
 
   stopStream: protectedProcedure
     .input(
-      z.object({
-        chatId: z.string().uuid(),
-        messageId: z.string().uuid(),
-      })
+      z.discriminatedUnion("type", [
+        z.object({
+          chatId: z.string().uuid(),
+          messageId: z.string().uuid(),
+          type: z.literal("message"),
+        }),
+        z.object({
+          chatId: z.string().uuid(),
+          messageId: z.string().uuid(),
+          type: z.literal("request"),
+        }),
+      ])
     )
     .mutation(async ({ ctx, input }) => {
-      // New-chat persistence and the assistant start chunk can both lag the stop click.
-      // Resolve the eventual response row before recording cancellation.
-      const deadline = Date.now() + 30_000;
-      let retryDelay = 25;
-      let chat = await getChatById({ id: input.chatId });
-
-      while (!chat && Date.now() < deadline) {
-        await new Promise((resolve) => setTimeout(resolve, retryDelay));
-        retryDelay = Math.min(retryDelay * 2, 250);
-        chat = await getChatById({ id: input.chatId });
-      }
-
-      if (!chat || chat.userId !== ctx.user.id) {
+      const chat = await getChatById({ id: input.chatId });
+      if (chat && chat.userId !== ctx.user.id) {
         throw new TRPCError({
           code: "NOT_FOUND",
           message: "Chat not found or access denied",
@@ -214,61 +211,34 @@ export const chatRouter = createTRPCRouter({
       }
 
       const canceledAt = new Date();
-      let [targetMessage] = await getMessageById({ id: input.messageId });
-
-      while (!targetMessage && Date.now() < deadline) {
-        await new Promise((resolve) => setTimeout(resolve, retryDelay));
-        retryDelay = Math.min(retryDelay * 2, 250);
-        [targetMessage] = await getMessageById({ id: input.messageId });
-      }
-
-      if (!targetMessage || targetMessage.chatId !== input.chatId) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Message not found",
-        });
-      }
-
-      let responseMessageId =
-        targetMessage.role === "assistant" ? input.messageId : null;
-
-      while (!responseMessageId && Date.now() < deadline) {
-        const response = await getCancelableResponseMessage({
-          chatId: input.chatId,
-          parentMessageId: input.messageId,
-          stoppedAt: canceledAt,
-        });
-        responseMessageId = response?.id ?? null;
-
-        if (!responseMessageId) {
-          await new Promise((resolve) => setTimeout(resolve, retryDelay));
-          retryDelay = Math.min(retryDelay * 2, 250);
-        }
-      }
-
-      if (!responseMessageId) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Response message not found",
-        });
-      }
-
-      while (
-        !(await updateMessageCanceledAt({
-          messageId: responseMessageId,
-          canceledAt,
-        }))
-      ) {
-        if (Date.now() >= deadline) {
+      if (input.type === "message") {
+        const [targetMessage] = await getMessageById({ id: input.messageId });
+        if (!(chat && targetMessage) || targetMessage.chatId !== input.chatId) {
           throw new TRPCError({
             code: "NOT_FOUND",
             message: "Message not found",
           });
         }
 
-        await new Promise((resolve) => setTimeout(resolve, retryDelay));
-        retryDelay = Math.min(retryDelay * 2, 250);
+        await cancelActiveMessage({
+          canceledAt,
+          chatId: input.chatId,
+          messageId: input.messageId,
+        });
+        return { success: true };
       }
+
+      await requestGenerationCancellation({
+        canceledAt,
+        chatId: input.chatId,
+        messageId: input.messageId,
+        userId: ctx.user.id,
+      });
+      await cancelActiveMessage({
+        canceledAt,
+        chatId: input.chatId,
+        messageId: input.messageId,
+      });
 
       return { success: true };
     }),

--- a/apps/chat/trpc/routers/chat.router.ts
+++ b/apps/chat/trpc/routers/chat.router.ts
@@ -12,6 +12,7 @@ import {
   deleteChatById,
   deleteMessagesByChatIdAfterMessageId,
   getAllMessagesByChatId,
+  getCancelableResponseMessage,
   getChatById,
   getChatsByUserId,
   getDocumentsByMessageIds,
@@ -193,8 +194,8 @@ export const chatRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      // A new chat can still be generating its title when the client stops.
-      // Wait for its reserved assistant row so request ordering cannot lose cancellation.
+      // New-chat persistence and the assistant start chunk can both lag the stop click.
+      // Resolve the eventual response row before recording cancellation.
       const deadline = Date.now() + 30_000;
       let retryDelay = 25;
       let chat = await getChatById({ id: input.chatId });
@@ -213,10 +214,48 @@ export const chatRouter = createTRPCRouter({
       }
 
       const canceledAt = new Date();
+      let [targetMessage] = await getMessageById({ id: input.messageId });
+
+      while (!targetMessage && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, retryDelay));
+        retryDelay = Math.min(retryDelay * 2, 250);
+        [targetMessage] = await getMessageById({ id: input.messageId });
+      }
+
+      if (!targetMessage || targetMessage.chatId !== input.chatId) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Message not found",
+        });
+      }
+
+      let responseMessageId =
+        targetMessage.role === "assistant" ? input.messageId : null;
+
+      while (!responseMessageId && Date.now() < deadline) {
+        const response = await getCancelableResponseMessage({
+          chatId: input.chatId,
+          parentMessageId: input.messageId,
+          stoppedAt: canceledAt,
+        });
+        responseMessageId = response?.id ?? null;
+
+        if (!responseMessageId) {
+          await new Promise((resolve) => setTimeout(resolve, retryDelay));
+          retryDelay = Math.min(retryDelay * 2, 250);
+        }
+      }
+
+      if (!responseMessageId) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Response message not found",
+        });
+      }
 
       while (
         !(await updateMessageCanceledAt({
-          messageId: input.messageId,
+          messageId: responseMessageId,
           canceledAt,
         }))
       ) {

--- a/packages/thread/src/abstract-thread.ts
+++ b/packages/thread/src/abstract-thread.ts
@@ -181,6 +181,14 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 		return this.readTree((tree) => tree.getSiblings(messageId));
 	}
 
+	setActiveRun(runId: string) {
+		const run = this.#runs.require(runId);
+		this.updateTree((tree) => {
+			this.#runs.select(runId);
+			tree.setCursor(run.spec.messageId ?? run.spec.initialPathMessageId);
+		});
+	}
+
 	setCursor(messageId: string | null) {
 		this.#runs.select(null);
 		this.updateTree((tree) => tree.setCursor(messageId));

--- a/packages/thread/src/abstract-thread.ts
+++ b/packages/thread/src/abstract-thread.ts
@@ -184,8 +184,8 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 	setActiveRun(runId: string) {
 		const run = this.#runs.require(runId);
 		this.updateTree((tree) => {
-			this.#runs.select(runId);
 			tree.setCursor(run.spec.messageId ?? run.spec.initialPathMessageId);
+			this.#runs.select(runId);
 		});
 	}
 

--- a/packages/thread/src/use-thread.ts
+++ b/packages/thread/src/use-thread.ts
@@ -58,6 +58,7 @@ export type TreeHelpers<TMessage extends UIMessage = UIMessage> = {
 	resumeRun: (runId: string, options?: ChatRequestOptions) => Promise<void>;
 	rootIds: string[];
 	runs: ThreadRun[];
+	setActiveRun: (runId: string) => void;
 	setCursor: (messageId: string | null) => void;
 	setCursorToParentOf: (messageId: string) => void;
 	startRun: (
@@ -243,6 +244,7 @@ export function useThread<TMessage extends UIMessage = UIMessage>(
 				thread.resumeRun(runId, requestOptions),
 			rootIds: snapshot.rootIds,
 			runs: snapshot.runs,
+			setActiveRun: (runId) => thread.setActiveRun(runId),
 			setCursor: (messageId) => thread.setCursor(messageId),
 			setCursorToParentOf: (messageId) => thread.setCursorToParentOf(messageId),
 			startRun: (runOptions) => thread.startRun(runOptions),

--- a/packages/thread/test/thread.test.ts
+++ b/packages/thread/test/thread.test.ts
@@ -550,6 +550,24 @@ describe("Thread", () => {
 		expect(() => chat.setActiveRun("missing")).toThrow("Unknown run missing");
 	});
 
+	test("preserves the selected run when its target path is missing", async () => {
+		const transport = new ControlledTransport();
+		const chat = new Thread({ messages: [user("user-1")], transport });
+		const first = await chat.startRun({ from: "user-1" });
+		const second = await chat.startRun({ follow: false, from: "user-1" });
+		await waitFor(() => transport.requests.length === 2);
+		chat.setActiveRun(first.id);
+		chat.removeMessage("user-1");
+
+		expect(() => chat.setActiveRun(second.id)).toThrow();
+		await chat.stop();
+
+		expect(transport.requests[0]?.abortSignal?.aborted).toBeTrue();
+		expect(transport.requests[1]?.abortSignal?.aborted).toBeFalse();
+		transport.finish(1);
+		await Promise.all([first.finished, second.finished]);
+	});
+
 	test("keeps creation order after an earlier run fails without a message", async () => {
 		const transport = new ControlledTransport();
 		const chat = new Thread({ transport });

--- a/packages/thread/test/thread.test.ts
+++ b/packages/thread/test/thread.test.ts
@@ -516,6 +516,40 @@ describe("Thread", () => {
 		await second.finished;
 	});
 
+	test("selects and follows a pending run before its response exists", async () => {
+		const transport = new ControlledTransport();
+		const chat = new Thread({ messages: [user("user-1")], transport });
+		const first = await chat.startRun({ from: "user-1" });
+		const second = await chat.startRun({ follow: false, from: "user-1" });
+		await waitFor(() => transport.requests.length === 2);
+
+		chat.setActiveRun(second.id);
+
+		expect(chat.getSnapshot().status).toBe("submitted");
+		expect(chat.getSnapshot().cursorId).toBe("user-1");
+		expect(chat.getSnapshot().messages.map(({ id }) => id)).toEqual(["user-1"]);
+
+		transport.emit(1, { messageId: "assistant-2", type: "start" });
+		await waitFor(() => chat.getSnapshot().cursorId === "assistant-2");
+
+		expect(chat.getSnapshot().messages.map(({ id }) => id)).toEqual([
+			"user-1",
+			"assistant-2",
+		]);
+		await chat.stop();
+		expect(transport.requests[1]?.abortSignal?.aborted).toBeTrue();
+		expect(transport.requests[0]?.abortSignal?.aborted).toBeFalse();
+
+		transport.finish(0);
+		await Promise.all([first.finished, second.finished]);
+	});
+
+	test("rejects selecting an unknown run", () => {
+		const chat = new Thread({ messages: [user("user-1")] });
+
+		expect(() => chat.setActiveRun("missing")).toThrow("Unknown run missing");
+	});
+
 	test("keeps creation order after an earlier run fails without a message", async () => {
 		const transport = new ControlledTransport();
 		const chat = new Thread({ transport });

--- a/packages/thread/test/use-thread-types.ts
+++ b/packages/thread/test/use-thread-types.ts
@@ -23,6 +23,7 @@ function useCompatibilityCheck() {
 	thread.tree.activeRuns;
 	thread.tree.runs;
 	thread.tree.status;
+	thread.tree.setActiveRun(messageId);
 	thread.tree.getRunForMessage(messageId);
 	thread.tree.getSnapshot();
 	thread.tree.startRun({ from: messageId, message: { text: "branch" } });


### PR DESCRIPTION
## Summary
- Makes server cancellation wait for a newly provisioned chat and reserved assistant row.
- Scopes cancellation by both chat and message identity.
- Preserves cancellation when stop races request preparation.

## Behavior
Stop works during the provisioning window instead of being lost as a not-found race.

## Verification
- Browser verified an aborted GPT-5 mini run finalized with zero accumulated model cost while its GPT-5 nano sibling continued.

## Review focus
Cancellation ownership, retry bounds, and database pressure of the short polling barrier.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists stop requests during new-thread provisioning so a stop isn't lost when the chat or assistant response doesn't exist yet; previously a stop fired before the run started silently vanished, burning tokens.

- Adds a per-user `GenerationCancellation` table; the chat route checks it before starting the stream and again at finalization, aborting or skipping canceled work.
- `stopStream` now takes `{chatId, messageId, type}`: `"message"` targets a persisted assistant message, `"request"` targets a pending run by deterministic request message ID.
- Cancellation is terminal: `cancelActiveMessage` only cancels uncanceled rows with an active stream, finalization skips canceled messages, `updateMessage` refuses canceled rows, and credits aren't deducted.
- The chat transport maps stream aborts to server-side cancellation requests, using the deterministic request identity for pending runs.
- The thread store tracks pending runs per parallel group so response cards can select and follow a run before its response is persisted.

<sup>Written for commit ceac4239a8cc4d72c47aa169f0584b64382ae890. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Make stopping newly provisioned and parallel thread runs reliable without allowing canceled work to finalize or incur model costs.

New Features:
- Persist cancellation requests for newly provisioned and parallel assistant runs so stopping a generation during setup is reliable.
- Allow users to select and stop parallel runs before their assistant responses have been persisted.

Bug Fixes:
- Prevent canceled generations from being finalized or charged after a stop request races stream preparation.
- Scope stop requests to the owning chat and exact message or deterministic request identity.

Enhancements:
- Make generation cancellation terminal across request startup, active streaming, message updates, and finalization.
- Add cancellation-aware transport handling and coverage for abort races, gated requests, completed streams, and pending run selection.

Tests:
- Add tests covering cancellation-aware transport behavior, parallel run registration, and selecting pending thread runs.

Chores:
- Add database support for persisted generation cancellation requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added more reliable cancellation for in-progress responses, including requests that have not produced a visible message yet.
  * Added support for selecting and switching to parallel responses while they are still starting.
* **Bug Fixes**
  * Prevented canceled responses from being finalized or charged when they were not saved.
  * Improved stopping behavior and response state synchronization across chat views.
* **Tests**
  * Added coverage for response cancellation and pending parallel-run selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->