### PR TITLE
Threads 18: Add the thread playground model

### DIFF
--- a/apps/site/components/thread-playground-model.ts
+++ b/apps/site/components/thread-playground-model.ts
@@ -1,0 +1,245 @@
+import { getMessageText, type MessageTreeSnapshot } from "@chatjs/thread";
+import type { UseThreadHelpers } from "@chatjs/thread/react";
+import type { ChatTransport, UIMessage, UIMessageChunk } from "ai";
+
+export interface PlaygroundMetadata {
+  activeStreamId: string | null;
+  createdAt: string;
+  title?: string;
+}
+
+export type PlaygroundMessage = UIMessage<PlaygroundMetadata>;
+export type PlaygroundChat = UseThreadHelpers<PlaygroundMessage>;
+
+interface StreamBody {
+  tree?: {
+    assistantMessageId?: string;
+    responseLabel?: string;
+  };
+}
+
+export interface LayoutNode {
+  depth: number;
+  id: string;
+  x: number;
+  y: number;
+}
+
+function createMessage({
+  id,
+  role,
+  text,
+  title,
+}: {
+  id: string;
+  role: "assistant" | "user";
+  text: string;
+  title: string;
+}): PlaygroundMessage {
+  return {
+    id,
+    metadata: {
+      activeStreamId: null,
+      createdAt: new Date().toISOString(),
+      title,
+    },
+    parts: [{ text, type: "text" }],
+    role,
+  };
+}
+
+const initialMessages = [
+  createMessage({
+    id: "msg_01",
+    role: "user",
+    text: "Plan a production launch.",
+    title: "Initial prompt",
+  }),
+  createMessage({
+    id: "msg_02",
+    role: "assistant",
+    text: "Start with architecture, rollout, and observability as separate workstreams.",
+    title: "Initial answer",
+  }),
+  createMessage({
+    id: "msg_03",
+    role: "user",
+    text: "Make the plan technical.",
+    title: "Follow-up",
+  }),
+  createMessage({
+    id: "msg_04a",
+    role: "assistant",
+    text: "Use staged environments, immutable builds, and progressive traffic shifting.",
+    title: "Deployment branch",
+  }),
+  createMessage({
+    id: "msg_05a",
+    role: "user",
+    text: "Add the deployment sequence.",
+    title: "Deployment follow-up",
+  }),
+  createMessage({
+    id: "msg_04b",
+    role: "assistant",
+    text: "Define service-level indicators before rollout and attach alerts to user impact.",
+    title: "Observability branch",
+  }),
+  createMessage({
+    id: "msg_05b",
+    role: "user",
+    text: "Focus on monitoring first.",
+    title: "Observability follow-up",
+  }),
+] satisfies PlaygroundMessage[];
+
+export const initialTree: MessageTreeSnapshot<PlaygroundMessage> = {
+  childrenByParentId: {
+    __root__: ["msg_01"],
+    msg_01: ["msg_02"],
+    msg_02: ["msg_03"],
+    msg_03: ["msg_04a", "msg_04b"],
+    msg_04a: ["msg_05a"],
+    msg_04b: ["msg_05b"],
+  },
+  cursorId: "msg_05a",
+  messagesById: Object.fromEntries(
+    initialMessages.map((message) => [message.id, message])
+  ),
+  parentById: {
+    msg_01: null,
+    msg_02: "msg_01",
+    msg_03: "msg_02",
+    msg_04a: "msg_03",
+    msg_04b: "msg_03",
+    msg_05a: "msg_04a",
+    msg_05b: "msg_04b",
+  },
+  rootIds: ["msg_01"],
+  version: 1,
+};
+
+function delay(ms: number, signal?: AbortSignal) {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+
+    const timeout = window.setTimeout(resolve, ms);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        window.clearTimeout(timeout);
+        reject(new DOMException("Aborted", "AbortError"));
+      },
+      { once: true }
+    );
+  });
+}
+
+export class PlaygroundTransport implements ChatTransport<PlaygroundMessage> {
+  sendMessages({
+    abortSignal,
+    body,
+    messages,
+  }: Parameters<ChatTransport<PlaygroundMessage>["sendMessages"]>[0]) {
+    const requestBody = body as StreamBody | undefined;
+    const assistantMessageId =
+      requestBody?.tree?.assistantMessageId ?? "assistant";
+    const responseLabel = requestBody?.tree?.responseLabel ?? "Assistant";
+    const userMessage = messages.at(-1);
+    const prompt = userMessage ? getMessageText(userMessage) : "this branch";
+    const response = `${responseLabel}: I am streaming independently from "${prompt}". Select another node while I run, or start more responses from the same prompt.`;
+    const words = response.split(" ");
+
+    return Promise.resolve(
+      new ReadableStream<UIMessageChunk<PlaygroundMetadata>>({
+        async start(controller) {
+          try {
+            controller.enqueue({
+              messageId: assistantMessageId,
+              messageMetadata: {
+                activeStreamId: assistantMessageId,
+                createdAt: new Date().toISOString(),
+                title: responseLabel,
+              },
+              type: "start",
+            });
+            controller.enqueue({ id: "text", type: "text-start" });
+
+            for (const [index, word] of words.entries()) {
+              await delay(55, abortSignal);
+              controller.enqueue({
+                delta: index === 0 ? word : ` ${word}`,
+                id: "text",
+                type: "text-delta",
+              });
+            }
+
+            controller.enqueue({ id: "text", type: "text-end" });
+            controller.enqueue({
+              finishReason: "stop",
+              messageMetadata: {
+                activeStreamId: null,
+                createdAt: new Date().toISOString(),
+                title: responseLabel,
+              },
+              type: "finish",
+            });
+            controller.close();
+          } catch (error) {
+            controller.error(error);
+          }
+        },
+      })
+    );
+  }
+
+  reconnectToStream() {
+    return Promise.resolve(null);
+  }
+}
+
+export function buildTreeLayout({
+  childrenByParentId,
+  rootIds,
+}: {
+  childrenByParentId: Record<string, string[]>;
+  rootIds: string[];
+}) {
+  const positions = new Map<string, LayoutNode>();
+  let nextLeaf = 0;
+  let maxDepth = 0;
+
+  function visit(id: string, depth: number): number {
+    maxDepth = Math.max(maxDepth, depth);
+    const children = childrenByParentId[id] ?? [];
+    let column: number;
+
+    if (children.length === 0) {
+      column = nextLeaf;
+      nextLeaf += 1;
+    } else {
+      const childColumns = children.map((childId) => visit(childId, depth + 1));
+      column =
+        childColumns.reduce((total, childColumn) => total + childColumn, 0) /
+        childColumns.length;
+    }
+
+    positions.set(id, { depth, id, x: column * 172 + 92, y: depth * 104 + 54 });
+    return column;
+  }
+
+  for (const rootId of rootIds) {
+    visit(rootId, 0);
+    nextLeaf += 1;
+  }
+
+  return {
+    height: Math.max(420, (maxDepth + 1) * 104 + 48),
+    nodes: [...positions.values()],
+    positions,
+    width: Math.max(430, Math.max(1, nextLeaf - 1) * 172 + 184),
+  };
+}

--- a/apps/site/components/thread-playground-model.ts
+++ b/apps/site/components/thread-playground-model.ts
@@ -13,9 +13,6 @@ export type PlaygroundChat = UseThreadHelpers<PlaygroundMessage>;
 
 interface StreamBody {
   responseLabel?: string;
-  tree?: {
-    assistantMessageId?: string;
-  };
 }
 
 export interface LayoutNode {
@@ -127,15 +124,15 @@ function delay(ms: number, signal?: AbortSignal) {
       return;
     }
 
-    const timeout = window.setTimeout(resolve, ms);
-    signal?.addEventListener(
-      "abort",
-      () => {
-        window.clearTimeout(timeout);
-        reject(new DOMException("Aborted", "AbortError"));
-      },
-      { once: true }
-    );
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
   });
 }
 
@@ -146,9 +143,8 @@ export class PlaygroundTransport implements ChatTransport<PlaygroundMessage> {
     messages,
   }: Parameters<ChatTransport<PlaygroundMessage>["sendMessages"]>[0]) {
     const requestBody = body as StreamBody | undefined;
-    const assistantMessageId =
-      requestBody?.tree?.assistantMessageId ?? "assistant";
     const responseLabel = requestBody?.responseLabel ?? "Assistant";
+    const streamId = crypto.randomUUID();
     const userMessage = messages.at(-1);
     const prompt = userMessage ? getMessageText(userMessage) : "this branch";
     const response = `${responseLabel}: I am streaming independently from "${prompt}". Select another node while I run, or start more responses from the same prompt.`;
@@ -159,9 +155,8 @@ export class PlaygroundTransport implements ChatTransport<PlaygroundMessage> {
         async start(controller) {
           try {
             controller.enqueue({
-              messageId: assistantMessageId,
               messageMetadata: {
-                activeStreamId: assistantMessageId,
+                activeStreamId: streamId,
                 createdAt: new Date().toISOString(),
                 title: responseLabel,
               },
@@ -190,6 +185,19 @@ export class PlaygroundTransport implements ChatTransport<PlaygroundMessage> {
             });
             controller.close();
           } catch (error) {
+            if (abortSignal?.aborted) {
+              controller.enqueue({
+                finishReason: "stop",
+                messageMetadata: {
+                  activeStreamId: null,
+                  createdAt: new Date().toISOString(),
+                  title: responseLabel,
+                },
+                type: "finish",
+              });
+              controller.close();
+              return;
+            }
             controller.error(error);
           }
         },

--- a/apps/site/components/thread-playground-model.ts
+++ b/apps/site/components/thread-playground-model.ts
@@ -12,9 +12,9 @@ export type PlaygroundMessage = UIMessage<PlaygroundMetadata>;
 export type PlaygroundChat = UseThreadHelpers<PlaygroundMessage>;
 
 interface StreamBody {
+  responseLabel?: string;
   tree?: {
     assistantMessageId?: string;
-    responseLabel?: string;
   };
 }
 
@@ -48,74 +48,75 @@ function createMessage({
   };
 }
 
-const initialMessages = [
-  createMessage({
-    id: "msg_01",
-    role: "user",
-    text: "Plan a production launch.",
-    title: "Initial prompt",
-  }),
-  createMessage({
-    id: "msg_02",
-    role: "assistant",
-    text: "Start with architecture, rollout, and observability as separate workstreams.",
-    title: "Initial answer",
-  }),
-  createMessage({
-    id: "msg_03",
-    role: "user",
-    text: "Make the plan technical.",
-    title: "Follow-up",
-  }),
-  createMessage({
-    id: "msg_04a",
-    role: "assistant",
-    text: "Use staged environments, immutable builds, and progressive traffic shifting.",
-    title: "Deployment branch",
-  }),
-  createMessage({
-    id: "msg_05a",
-    role: "user",
-    text: "Add the deployment sequence.",
-    title: "Deployment follow-up",
-  }),
-  createMessage({
-    id: "msg_04b",
-    role: "assistant",
-    text: "Define service-level indicators before rollout and attach alerts to user impact.",
-    title: "Observability branch",
-  }),
-  createMessage({
-    id: "msg_05b",
-    role: "user",
-    text: "Focus on monitoring first.",
-    title: "Observability follow-up",
-  }),
-] satisfies PlaygroundMessage[];
+const initialNodes = [
+  {
+    message: createMessage({
+      id: "msg_01",
+      role: "user",
+      text: "Plan a production launch.",
+      title: "Initial prompt",
+    }),
+    parentId: null,
+  },
+  {
+    message: createMessage({
+      id: "msg_02",
+      role: "assistant",
+      text: "Start with architecture, rollout, and observability as separate workstreams.",
+      title: "Initial answer",
+    }),
+    parentId: "msg_01",
+  },
+  {
+    message: createMessage({
+      id: "msg_03",
+      role: "user",
+      text: "Make the plan technical.",
+      title: "Follow-up",
+    }),
+    parentId: "msg_02",
+  },
+  {
+    message: createMessage({
+      id: "msg_04a",
+      role: "assistant",
+      text: "Use staged environments, immutable builds, and progressive traffic shifting.",
+      title: "Deployment branch",
+    }),
+    parentId: "msg_03",
+  },
+  {
+    message: createMessage({
+      id: "msg_05a",
+      role: "user",
+      text: "Add the deployment sequence.",
+      title: "Deployment follow-up",
+    }),
+    parentId: "msg_04a",
+  },
+  {
+    message: createMessage({
+      id: "msg_04b",
+      role: "assistant",
+      text: "Define service-level indicators before rollout and attach alerts to user impact.",
+      title: "Observability branch",
+    }),
+    parentId: "msg_03",
+  },
+  {
+    message: createMessage({
+      id: "msg_05b",
+      role: "user",
+      text: "Focus on monitoring first.",
+      title: "Observability follow-up",
+    }),
+    parentId: "msg_04b",
+  },
+] satisfies MessageTreeSnapshot<PlaygroundMessage>["nodes"];
 
 export const initialTree: MessageTreeSnapshot<PlaygroundMessage> = {
-  childrenByParentId: {
-    __root__: ["msg_01"],
-    msg_01: ["msg_02"],
-    msg_02: ["msg_03"],
-    msg_03: ["msg_04a", "msg_04b"],
-    msg_04a: ["msg_05a"],
-    msg_04b: ["msg_05b"],
-  },
   cursorId: "msg_05a",
-  messagesById: Object.fromEntries(
-    initialMessages.map((message) => [message.id, message])
-  ),
-  parentById: {
-    msg_01: null,
-    msg_02: "msg_01",
-    msg_03: "msg_02",
-    msg_04a: "msg_03",
-    msg_04b: "msg_03",
-    msg_05a: "msg_04a",
-    msg_05b: "msg_04b",
-  },
-  rootIds: ["msg_01"],
+  nodes: initialNodes,
   version: 1,
 };
 
@@ -147,7 +148,7 @@ export class PlaygroundTransport implements ChatTransport<PlaygroundMessage> {
     const requestBody = body as StreamBody | undefined;
     const assistantMessageId =
       requestBody?.tree?.assistantMessageId ?? "assistant";
-    const responseLabel = requestBody?.tree?.responseLabel ?? "Assistant";
+    const responseLabel = requestBody?.responseLabel ?? "Assistant";
     const userMessage = messages.at(-1);
     const prompt = userMessage ? getMessageText(userMessage) : "this branch";
     const response = `${responseLabel}: I am streaming independently from "${prompt}". Select another node while I run, or start more responses from the same prompt.`;

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "prebuild": "bun --filter @chatjs/thread build",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
@@ -11,7 +12,10 @@
     "format": "ultracite fix"
   },
   "dependencies": {
+    "@ai-sdk/react": "^3.0.152",
+    "@chatjs/thread": "workspace:*",
     "@vercel/analytics": "^1.5.0",
+    "ai": "^6.0.150",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "0.553.0",

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -23,7 +23,8 @@
     "next-themes": "^0.4.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.10",

--- a/bun.lock
+++ b/bun.lock
@@ -188,7 +188,10 @@
       "name": "@chatjs/site",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/react": "^3.0.152",
+        "@chatjs/thread": "workspace:*",
         "@vercel/analytics": "^1.5.0",
+        "ai": "^6.0.150",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "0.553.0",

--- a/bun.lock
+++ b/bun.lock
@@ -200,6 +200,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "tailwind-merge": "^3.3.1",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.10",


### PR DESCRIPTION
## Summary
- Adds the site playground state model over the real thread package.
- Simulates branch creation, navigation, multiple response runs, and stop behavior.
- Keeps demo-only tree rendering outside the package.

## Behavior
Adds headless playground behavior only; the product page UI follows later.

## Verification
- Site type checks pass at the stack tip.

## Review focus
Whether the demo exercises the public package rather than reimplementing it.

## Summary by Sourcery

Add a site-side thread playground model for exercising threaded conversation behavior before the product UI is introduced.

New Features:
- Add a headless thread playground model that demonstrates branching, navigation, concurrent response runs, and stopping streams through the public thread package.

Enhancements:
- Provide sample thread-tree data and layout calculations for playground rendering.

Build:
- Add the thread package build as a site prebuild step and include the thread and AI SDK dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a thread playground with branching conversation examples.
  * Added support for streaming responses that can be stopped during generation.
  * Added a visual tree layout for exploring message relationships.

* **Build Improvements**
  * Improved site build setup to ensure chat functionality is available when building the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->