### PR TITLE
Threads 21: Add the value-first package guide

### DIFF
--- a/packages/thread/ARCHITECTURE.md
+++ b/packages/thread/ARCHITECTURE.md
@@ -78,6 +78,7 @@ chat.tree.cursorId;
 chat.tree.getChildren(messageId);
 chat.tree.getSiblings(messageId);
 chat.tree.setCursor(messageId);
+chat.tree.setActiveRun(runId);
 chat.tree.startRun({ from: messageId });
 chat.tree.stopRun(runId);
 ```
@@ -98,6 +99,12 @@ whether the cursor selects the new user immediately and its assistant once
 streaming begins; it defaults to `true` when the resolved origin equals the
 active cursor and `false` otherwise. This includes an explicit `from` whose
 value equals the current `cursorId`.
+
+`setActiveRun(runId)` selects a request lifecycle directly. Before that run
+has emitted a message, the active path remains at its origin. Once its first
+message is written, the cursor follows it. This lets `chat.status`,
+`chat.error`, and `chat.stop()` retain their `useChat` semantics for pending
+concurrent runs without requiring optimistic message nodes.
 
 Top-level fields always describe the selected path:
 

--- a/packages/thread/ARCHITECTURE.md
+++ b/packages/thread/ARCHITECTURE.md
@@ -183,6 +183,26 @@ The default `Thread` creates its own `MemoryThreadState`. A custom controller
 can instead extend `AbstractThread` and supply another implementation:
 
 ```ts
+const applicationStore = createStore(
+  subscribeWithSelector(() => ({
+    threadSnapshot: createThreadStateSnapshot<MyMessage>({ messages }),
+  })),
+);
+
+const state: ThreadState<MyMessage> = {
+  getSnapshot: () => applicationStore.getState().threadSnapshot,
+  subscribe: (listener) =>
+    applicationStore.subscribe(
+      (storeState) => storeState.threadSnapshot,
+      () => listener(),
+    ),
+  update: (updater) => {
+    applicationStore.setState((storeState) => ({
+      threadSnapshot: updater(storeState.threadSnapshot),
+    }));
+  },
+};
+
 class ApplicationThread extends AbstractThread<MyMessage> {
   constructor(
     state: ThreadState<MyMessage>,
@@ -192,13 +212,17 @@ class ApplicationThread extends AbstractThread<MyMessage> {
   }
 }
 
-const thread = new ApplicationThread(applicationThreadState, transport);
+const thread = new ApplicationThread(state, transport);
 const chat = useThread({ thread });
 ```
 
 This allows an application store to own observable state without moving
 transport objects, promises, abort controllers, or internal run adapters into
-that store.
+that store. `createThreadStateSnapshot` is the supported initializer for a
+custom adapter. The returned `ThreadStateSnapshot` should be the application's
+canonical conversation value; linear `messages`, `status`, and `error` fields,
+when retained for compatibility, are projections updated in the same atomic
+store transaction rather than separate sources of truth.
 
 `ThreadState` stores:
 

--- a/packages/thread/ARCHITECTURE.md
+++ b/packages/thread/ARCHITECTURE.md
@@ -192,7 +192,7 @@ can instead extend `AbstractThread` and supply another implementation:
 ```ts
 const applicationStore = createStore(
   subscribeWithSelector(() => ({
-    threadSnapshot: createThreadStateSnapshot<MyMessage>({ messages }),
+    threadSnapshot: createThreadStateSnapshot<MyMessage>({ messages: [] }),
   })),
 );
 

--- a/packages/thread/README.md
+++ b/packages/thread/README.md
@@ -1,0 +1,481 @@
+# @chatjs/thread
+
+Build branching AI chats without giving up the `useChat` API.
+
+`@chatjs/thread` turns a linear AI SDK conversation into a message tree. Users
+can edit an earlier message, compare multiple responses, move between branches,
+and keep streams running on branches that are not currently visible.
+
+```tsx
+const chat = useThread({ transport });
+
+chat.messages; // The selected conversation path, just like useChat
+chat.tree.setCursor(messageId); // Select any point in the tree
+await chat.sendMessage({ text: "Try another direction" }); // Branch from it
+```
+
+The package is headless. It owns message topology and request lifecycles, while
+your application owns the conversation UI, branch controls, and persistence.
+
+## Why useThread?
+
+- **A familiar migration path.** `useThread` is assignable to AI SDK's
+  `UseChatHelpers`. Existing chat rendering and composer code can keep using
+  `messages`, `sendMessage`, `regenerate`, `stop`, `status`, and `error`.
+- **Branch from any message.** Move a cursor to an earlier node and send as
+  usual. Existing descendants are preserved as another branch.
+- **Run branches concurrently.** Every response has an isolated AI SDK request
+  lifecycle. Switching branches does not abort streams on hidden branches.
+- **Keep AI SDK behavior.** `ThreadChat` uses the caller's `ChatTransport` and
+  AI SDK's request orchestration, including tools, approvals, data parts,
+  automatic follow-ups, cancellation, and reconnection.
+- **Bring your own UI and storage.** The public tree is plain messages, IDs, and
+  edges. No component library or database model is imposed.
+
+## Installation
+
+Install the package and its AI SDK peer dependencies:
+
+```bash
+bun add @chatjs/thread ai @ai-sdk/react
+```
+
+Or copy the source into an application with the ChatJS shadcn registry:
+
+```bash
+bunx shadcn@latest add FranciscoMoretti/chat-js/thread#main
+```
+
+The optional registry demo includes an application-owned conversation and tree
+UI:
+
+```bash
+bunx shadcn@latest add FranciscoMoretti/chat-js/thread-demo#main
+```
+
+## Quick start
+
+Use the same transport you would pass to `useChat`:
+
+```tsx
+"use client";
+
+import { DefaultChatTransport } from "ai";
+import { useThread } from "@chatjs/thread/react";
+import { useState } from "react";
+
+const transport = new DefaultChatTransport({ api: "/api/chat" });
+
+export function Chat() {
+  const [input, setInput] = useState("");
+  const chat = useThread({ transport });
+
+  return (
+    <main>
+      {chat.messages.map((message) => (
+        <article key={message.id}>
+          <strong>{message.role}</strong>
+          {message.parts.map((part, index) =>
+            part.type === "text" ? <p key={index}>{part.text}</p> : null
+          )}
+        </article>
+      ))}
+
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (!input.trim()) return;
+          chat.sendMessage({ text: input });
+          setInput("");
+        }}
+      >
+        <input
+          onChange={(event) => setInput(event.target.value)}
+          value={input}
+        />
+        <button disabled={chat.status !== "ready"} type="submit">
+          Send
+        </button>
+      </form>
+    </main>
+  );
+}
+```
+
+At the top level, the hook behaves like a normal linear chat. The difference is
+that `messages` is a projection of the tree from its root to `tree.cursorId`.
+
+## The mental model
+
+`ThreadChat` stores every message once and records its parent:
+
+```text
+user: Plan a launch
+└── assistant: Start with architecture
+    └── user: Make it technical
+        ├── assistant: Define service-level indicators  <- selected cursor
+        └── assistant: Use staged environments
+```
+
+There are three distinct concepts:
+
+1. **Tree:** all messages and parent-child relationships.
+2. **Cursor:** the last message in the path currently shown by `chat.messages`.
+3. **Run:** one assistant request, with its own status, error, and abort
+   controller.
+
+Moving the cursor only changes the visible path. It does not delete descendants
+or stop active runs.
+
+## Create a branch
+
+Select the message to continue from, then call `sendMessage` normally:
+
+```ts
+chat.tree.setCursor(messageId);
+await chat.sendMessage({ text: "Explore a different approach" });
+```
+
+The new user message becomes a child of `messageId`, followed by its assistant
+response. Because `sendMessage` follows the selected cursor by default, the new
+branch becomes the active conversation.
+
+This is also the edit-message pattern. Editing is an application-level action:
+select the edited message's parent and send the replacement as a new message.
+The original message and its descendants remain available.
+
+```ts
+chat.tree.setCursorToParentOf(originalUserMessageId);
+await chat.sendMessage({
+  id: crypto.randomUUID(),
+  role: "user",
+  parts: [{ type: "text", text: editedText }],
+});
+```
+
+To display sibling controls:
+
+```ts
+const siblings = chat.tree.getSiblings(messageId);
+const index = siblings.findIndex((message) => message.id === messageId);
+
+function showSibling(offset: number) {
+  const sibling = siblings[index + offset];
+  if (sibling) chat.tree.setCursor(sibling.id);
+}
+```
+
+## Request parallel responses
+
+`sendMessage` intentionally keeps the AI SDK completion contract: its promise
+resolves when the request and automatic tool follow-ups finish. Use
+`tree.startRun` when you need an immediate run handle or multiple responses.
+
+First add a user message and start its primary response:
+
+```ts
+const primary = await chat.tree.startRun({
+  message: { text: "Give me three implementation plans" },
+  follow: true,
+});
+```
+
+Then start more assistant responses from the same user node:
+
+```ts
+const alternativeA = await chat.tree.startRun({
+  from: primary.getSnapshot()?.userMessageId,
+  follow: false,
+});
+
+const alternativeB = await chat.tree.startRun({
+  from: primary.getSnapshot()?.userMessageId,
+  follow: false,
+});
+
+await Promise.all([
+  primary.finished,
+  alternativeA.finished,
+  alternativeB.finished,
+]);
+```
+
+`follow: false` leaves the cursor where it is while the response streams into
+the tree. Each returned handle can be inspected or stopped independently:
+
+```ts
+primary.id;
+primary.assistantMessageId;
+primary.getSnapshot();
+await primary.stop();
+```
+
+Set concurrency limits when creating the hook:
+
+```ts
+const chat = useThread({
+  transport,
+  concurrency: {
+    maxActiveRuns: 4,
+    maxActiveRunsPerMessage: 3,
+  },
+});
+```
+
+## Active path versus whole tree
+
+The top-level API always describes the selected path and selected run:
+
+```ts
+chat.messages;
+chat.status;
+chat.error;
+await chat.stop();
+chat.clearError();
+await chat.resumeStream();
+```
+
+Whole-tree state and controls live under `tree`:
+
+```ts
+chat.tree.cursorId;
+chat.tree.status;
+chat.tree.activeRuns;
+chat.tree.runs;
+
+chat.tree.messagesById;
+chat.tree.parentById;
+chat.tree.childrenByParentId;
+chat.tree.rootIds;
+
+chat.tree.getMessage(messageId);
+chat.tree.getParent(messageId);
+chat.tree.getChildren(messageId);
+chat.tree.getSiblings(messageId);
+chat.tree.getLeaves(messageId);
+chat.tree.getPath(messageId);
+```
+
+`chat.status` uses AI SDK's `submitted`, `streaming`, `ready`, and `error`
+states for the selected path. `chat.tree.status` aggregates every run. A run is
+included in `activeRuns` while it is `submitted` or `streaming`.
+
+Target a specific run without moving the cursor:
+
+```ts
+const run = chat.tree.getRun(runId);
+const messageRun = chat.tree.getRunForMessage(assistantMessageId);
+
+await chat.tree.stopRun(runId);
+await chat.tree.stopRunForMessage(assistantMessageId);
+await chat.tree.resumeRun(runId);
+await chat.tree.stopAll();
+```
+
+## Migrating from useChat
+
+For a conventional chat component, the initial migration is usually an import
+change:
+
+```diff
+- import { useChat } from "@ai-sdk/react";
++ import { useThread } from "@chatjs/thread/react";
+
+- const chat = useChat({ transport });
++ const chat = useThread({ transport });
+```
+
+`UseThreadHelpers<TMessage>` extends `UseChatHelpers<TMessage>`. These standard
+helpers retain their normal signatures:
+
+- `messages`, `sendMessage`, and `setMessages`
+- `status`, `error`, `stop`, and `clearError`
+- `regenerate` and `resumeStream`
+- `addToolOutput`, `addToolResult`, and `addToolApprovalResponse`
+
+There are two tree-specific behavioral details:
+
+- Top-level state refers to the selected path, not every active branch.
+- `setMessages` reconciles the selected path. Truncating it moves the cursor
+  backward without deleting hidden descendants; changing its suffix creates a
+  branch. A message ID cannot be reused under a different parent.
+
+## Tools and approvals
+
+Tool outputs and approval responses use the standard `useChat` signatures.
+`ThreadChat` records which run emitted each tool call or approval ID and routes
+the response back to that run, even when another branch is selected.
+
+Tool call and approval IDs must be unique across active runs.
+
+## Persistence
+
+Save the complete tree rather than only `chat.messages`:
+
+```ts
+const snapshot = chat.tree.getSnapshot();
+await saveThread(snapshot);
+```
+
+Restore it when creating the hook:
+
+```ts
+const chat = useThread({
+  initialTree: savedSnapshot,
+  transport,
+});
+```
+
+Snapshots contain serializable message and topology state:
+
+```ts
+type MessageTreeSnapshot<TMessage> = {
+  version: 1;
+  cursorId: string | null;
+  messagesById: Record<string, TMessage>;
+  parentById: Record<string, string | null>;
+  childrenByParentId: Record<string, string[]>;
+  rootIds: string[];
+};
+```
+
+Runs are request-lifecycle state and are not persisted in the tree snapshot.
+Resumable assistant messages can be restored and resumed through
+`resumeStream` or `tree.resumeRun`.
+
+## Transport and server integration
+
+`useThread` accepts AI SDK `ChatTransport` implementations directly. It does
+not define another transport protocol or parse stream chunks itself.
+
+Every request includes branch context in its body while preserving your custom
+request body fields:
+
+```ts
+{
+  assistantMessageId,
+  tree: {
+    assistantMessageId,
+    cursorId,
+    originCursorId,
+    parentMessageId,
+    pathIds,
+    userMessageId
+  }
+}
+```
+
+Servers that only need a linear model history can ignore this metadata; the
+transport still receives the selected path. Persist the IDs when the server
+also needs to reconstruct branches or associate streams with message nodes.
+
+For resumable HTTP streams, reconnect by assistant message ID using AI SDK's
+native transport hook. Your server can resolve that stable message identity to
+an infrastructure-specific stream ID:
+
+```ts
+const transport = new DefaultChatTransport({
+  api: "/api/chat",
+  prepareReconnectToStreamRequest({ body, id }) {
+    const messageId = body?.assistantMessageId;
+    return {
+      api: `/api/chat/${id}/stream?messageId=${messageId}`,
+    };
+  },
+});
+```
+
+## Externally owned ThreadChat
+
+Create `ThreadChat` outside React when it must outlive a component or be shared
+with application infrastructure:
+
+```tsx
+import { createThreadChat } from "@chatjs/thread";
+import { useThread } from "@chatjs/thread/react";
+
+const threadChat = createThreadChat({ transport });
+
+function Chat() {
+  const chat = useThread({ chat: threadChat });
+  // ...
+}
+```
+
+This is the instance-level equivalent of supplying an externally owned chat to
+`useChat`.
+
+## How it works
+
+`ThreadChat` uses a canonical tree plus one isolated AI SDK chat engine per
+active request:
+
+```text
+useThread
+  └── ThreadChat
+      ├── message tree (nodes, edges, cursor)
+      ├── run registry
+      │   ├── run A -> AI SDK AbstractChat -> ChatTransport
+      │   ├── run B -> AI SDK AbstractChat -> ChatTransport
+      │   └── run C -> AI SDK AbstractChat -> ChatTransport
+      └── React subscription snapshot
+```
+
+`ThreadChat` owns tree topology, cursor selection, run identity, and
+concurrency policy. Each run owns one AI SDK request lifecycle and abort
+controller. All runs use the caller-provided transport.
+
+This design matters because one linear `useChat` instance has one active
+message array and request lifecycle. Replacing that array during branch
+navigation can abort, reconnect, or misroute an in-flight response. Isolated
+runs continue writing to their reserved assistant nodes regardless of which
+path is visible.
+
+The implementation deliberately reuses AI SDK's `AbstractChat` orchestration
+instead of maintaining a custom stream reducer. That preserves standard stream
+parts, tools, approvals, callbacks, automatic sends, cancellation, and resume
+behavior while the package adds tree ownership around it.
+
+See [ARCHITECTURE.md](./ARCHITECTURE.md) for the ownership model, evaluated
+alternatives, and the differential coverage behind this decision.
+
+## Exports
+
+React APIs are exported from `@chatjs/thread/react`:
+
+```ts
+useThread;
+type UseThreadOptions;
+type UseThreadHelpers;
+type TreeHelpers;
+```
+
+Chat engine APIs and types are exported from `@chatjs/thread`:
+
+```ts
+createThreadChat;
+ThreadChat;
+getMessageText;
+ROOT_PARENT_ID;
+
+type MessageTreeSnapshot;
+type ThreadConcurrency;
+type ThreadEvent;
+type ThreadRun;
+type ThreadRunHandle;
+type ThreadChatOptions;
+type ThreadStartRunOptions;
+type TreeSendOptions;
+type ThreadStateSnapshot;
+```
+
+## Scope
+
+The package does not include chat components, branch controls, tree diagrams,
+storage adapters, or server routes. Those remain application concerns because
+their design and persistence requirements vary substantially. The package
+provides the headless state and controls needed to build them.
+
+## License
+
+Apache-2.0

--- a/packages/thread/README.md
+++ b/packages/thread/README.md
@@ -174,8 +174,13 @@ resolves when the request and automatic tool follow-ups finish. Use
 First add a user message and start its primary response:
 
 ```ts
+const prompt = {
+  id: crypto.randomUUID(),
+  role: "user" as const,
+  parts: [{ type: "text" as const, text: "Give me three implementation plans" }],
+};
 const primary = await chat.tree.startRun({
-  message: { text: "Give me three implementation plans" },
+  message: prompt,
   follow: true,
 });
 ```
@@ -184,12 +189,12 @@ Then start more assistant responses from the same user node:
 
 ```ts
 const alternativeA = await chat.tree.startRun({
-  from: primary.getSnapshot()?.userMessageId,
+  from: prompt.id,
   follow: false,
 });
 
 const alternativeB = await chat.tree.startRun({
-  from: primary.getSnapshot()?.userMessageId,
+  from: prompt.id,
   follow: false,
 });
 
@@ -204,8 +209,7 @@ await Promise.all([
 the tree. Each returned handle can be inspected or stopped independently:
 
 ```ts
-primary.id;
-primary.assistantMessageId;
+primary.id; // stable run ID
 primary.getSnapshot();
 await primary.stop();
 ```
@@ -348,42 +352,15 @@ Resumable assistant messages can be restored and resumed through
 `useThread` accepts AI SDK `ChatTransport` implementations directly. It does
 not define another transport protocol or parse stream chunks itself.
 
-Every request includes branch context in its body while preserving your custom
-request body fields:
+The active branch is sent as the transport's linear message history.
+`ChatRequestOptions` are forwarded unchanged, so application body and metadata
+fields remain entirely application-owned.
 
-```ts
-{
-  assistantMessageId,
-  tree: {
-    assistantMessageId,
-    cursorId,
-    originCursorId,
-    parentMessageId,
-    pathIds,
-    userMessageId
-  }
-}
-```
-
-Servers that only need a linear model history can ignore this metadata; the
-transport still receives the selected path. Persist the IDs when the server
-also needs to reconstruct branches or associate streams with message nodes.
-
-For resumable HTTP streams, reconnect by assistant message ID using AI SDK's
-native transport hook. Your server can resolve that stable message identity to
-an infrastructure-specific stream ID:
-
-```ts
-const transport = new DefaultChatTransport({
-  api: "/api/chat",
-  prepareReconnectToStreamRequest({ body, id }) {
-    const messageId = body?.assistantMessageId;
-    return {
-      api: `/api/chat/${id}/stream?messageId=${messageId}`,
-    };
-  },
-});
-```
+Like AI SDK's `useChat`, `useThread` keeps a submitted response outside the
+public message collection. The assistant node is inserted on the first stream
+write, using the server's `start.messageId` when provided and the AI SDK
+client-generated ID otherwise. Applications can render queued work from
+`tree.activeRuns` without creating placeholder `UIMessage` values.
 
 ## Externally owned ThreadChat
 
@@ -428,8 +405,8 @@ controller. All runs use the caller-provided transport.
 This design matters because one linear `useChat` instance has one active
 message array and request lifecycle. Replacing that array during branch
 navigation can abort, reconnect, or misroute an in-flight response. Isolated
-runs continue writing to their reserved assistant nodes regardless of which
-path is visible.
+runs continue writing to their own assistant nodes regardless of which path is
+visible.
 
 The implementation deliberately reuses AI SDK's `AbstractChat` orchestration
 instead of maintaining a custom stream reducer. That preserves standard stream
@@ -456,11 +433,9 @@ Chat engine APIs and types are exported from `@chatjs/thread`:
 createThreadChat;
 ThreadChat;
 getMessageText;
-ROOT_PARENT_ID;
 
 type MessageTreeSnapshot;
 type ThreadConcurrency;
-type ThreadEvent;
 type ThreadRun;
 type ThreadRunHandle;
 type ThreadChatOptions;

--- a/packages/thread/README.md
+++ b/packages/thread/README.md
@@ -78,12 +78,8 @@ As in `useChat`, `sendMessage()` with no input continues a selected assistant
 message in place. Passing an explicit assistant message also streams into that
 same message ID. `regenerate({ messageId })` uses AI SDK's native regeneration
 request and stores the replacement as a sibling, preserving the original
-branch.
-
-Regeneration is currently rejected when both the target and its parent are
-assistant messages. AI SDK currently continues the assistant parent in that
-case instead of creating a replacement for the requested target; see
-`ARCHITECTURE.md` for the upstream blocker.
+branch. Assistant-to-assistant targets regenerate the same way: the original
+node stays, and the replacement is inserted beside it.
 
 The selected path is a projection of the complete tree:
 
@@ -92,6 +88,15 @@ chat.tree.cursorId;
 chat.tree.getChildren(messageId);
 chat.tree.getSiblings(messageId);
 chat.tree.setCursor(messageId);
+```
+
+Branch from an earlier node with the same `sendMessage` helper:
+
+```ts
+await chat.sendMessage(
+  { text: "Create a branch" },
+  { tree: { follow: false, from: messageId } },
+);
 ```
 
 Start independent responses without mounting another hook:
@@ -128,7 +133,9 @@ Create the controller yourself when it must outlive a particular component:
 
 ```ts
 import { createThread } from "@chatjs/thread";
+import { DefaultChatTransport } from "ai";
 
+const transport = new DefaultChatTransport({ api: "/api/chat" });
 const thread = createThread({ transport });
 
 function Conversation() {
@@ -147,13 +154,19 @@ import {
   createThreadStateSnapshot,
   type ThreadState,
 } from "@chatjs/thread";
-import type { UIMessage } from "ai";
+import {
+  type ChatTransport,
+  DefaultChatTransport,
+  type UIMessage,
+} from "ai";
 import { subscribeWithSelector } from "zustand/middleware";
 import { createStore } from "zustand/vanilla";
 
+const transport = new DefaultChatTransport({ api: "/api/chat" });
+
 const applicationStore = createStore(
   subscribeWithSelector(() => ({
-    threadSnapshot: createThreadStateSnapshot<UIMessage>({ messages }),
+    threadSnapshot: createThreadStateSnapshot<UIMessage>({ messages: [] }),
   })),
 );
 
@@ -172,12 +185,15 @@ const applicationThreadState: ThreadState<UIMessage> = {
 };
 
 class ApplicationThread extends AbstractThread<UIMessage> {
-  constructor(state: ThreadState<UIMessage>) {
+  constructor(
+    state: ThreadState<UIMessage>,
+    transport: ChatTransport<UIMessage>,
+  ) {
     super({ state, transport });
   }
 }
 
-const thread = new ApplicationThread(applicationThreadState);
+const thread = new ApplicationThread(applicationThreadState, transport);
 const chat = useThread({ thread });
 ```
 
@@ -211,13 +227,17 @@ const snapshot = chat.tree.getSnapshot();
 const restored = useThread({
   id: conversationId,
   initialTree: snapshot,
-  transport,
+  resume: true,
+  transport: new DefaultChatTransport({ api: "/api/chat" }),
 });
 ```
 
-The snapshot contains ordered nodes, parent IDs, and the selected cursor.
-Active requests, abort controllers, errors, and run adapters are runtime state
-and are not serialized.
+The snapshot is `{ version: 1, cursorId, nodes }`. `nodes` is the ordered
+message list with parent IDs; runtime indexes such as `messagesById` are not
+serialized. Active requests, abort controllers, errors, and run adapters are
+runtime state. `resume: true` (or `resumeStream()`) reconstructs a run for the
+selected assistant. `tree.resumeRun(runId)` only works for runs still in the
+live registry.
 
 See [ARCHITECTURE.md](./ARCHITECTURE.md) for lifecycle, identity, status, and
 AI SDK compatibility decisions.

--- a/packages/thread/README.md
+++ b/packages/thread/README.md
@@ -7,10 +7,32 @@ branch.
 `tree` namespace for navigation, sibling responses, concurrent runs, and
 run-specific cancellation.
 
+## Package Layers
+
+`@chatjs/thread` is the headless core. It exports the framework-independent
+`AbstractThread`, default memory-backed `Thread`, `ThreadState` contract, tree
+management, and stream orchestration.
+
+`@chatjs/thread/react` is the React adapter. It exports `useThread` and owns
+React subscriptions, render throttling, and hook lifecycle behavior. The core
+entry point does not import React.
+
+`AbstractThread` exposes `getSnapshot()` and `subscribe()`, so future Vue,
+Svelte, or vanilla adapters can observe the same controller without changing
+the core.
+
 ## Install
 
+For the headless core:
+
 ```bash
-bun add @chatjs/thread ai @ai-sdk/react
+bun add @chatjs/thread ai
+```
+
+For React:
+
+```bash
+bun add @chatjs/thread ai @ai-sdk/react react
 ```
 
 ## Use
@@ -51,6 +73,17 @@ chat.sendMessage();
 chat.regenerate();
 chat.stop();
 ```
+
+As in `useChat`, `sendMessage()` with no input continues a selected assistant
+message in place. Passing an explicit assistant message also streams into that
+same message ID. `regenerate({ messageId })` uses AI SDK's native regeneration
+request and stores the replacement as a sibling, preserving the original
+branch.
+
+Regeneration is currently rejected when both the target and its parent are
+assistant messages. AI SDK currently continues the assistant parent in that
+case instead of creating a replacement for the requested target; see
+`ARCHITECTURE.md` for the upstream blocker.
 
 The selected path is a projection of the complete tree:
 
@@ -96,20 +129,43 @@ function Conversation() {
 }
 ```
 
-`Thread` extends the framework-independent `AbstractThread`. It accepts an
-optional `ThreadState` implementation for integration with an application
-state container:
+`Thread` extends the framework-independent `AbstractThread` and owns its
+in-memory state. To integrate another state container, create an
+`AbstractThread` subclass that supplies a `ThreadState`:
 
 ```ts
-import { MemoryThreadState, Thread } from "@chatjs/thread";
+import {
+  AbstractThread,
+  type ThreadState,
+} from "@chatjs/thread";
+import type { UIMessage } from "ai";
 
-const state = new MemoryThreadState({ messages: initialMessages });
-const thread = new Thread({ state, transport });
+class ApplicationThread extends AbstractThread<UIMessage> {
+  constructor(state: ThreadState<UIMessage>) {
+    super({ state, transport });
+  }
+}
+
+const thread = new ApplicationThread(applicationThreadState);
+const chat = useThread({ thread });
 ```
 
 `ThreadState.update` invokes its updater exactly once, synchronously and
 atomically. The controller must remain the only writer so concurrent streams
 cannot overwrite each other.
+
+Framework adapters observe the controller through:
+
+```ts
+const snapshot = thread.getSnapshot();
+const unsubscribe = thread.subscribe(() => {
+  render(thread.getSnapshot());
+});
+```
+
+These methods are framework-neutral. React's `useThread` consumes them through
+`useSyncExternalStore`; other adapters can provide their own subscription
+integration.
 
 ## Persistence
 

--- a/packages/thread/README.md
+++ b/packages/thread/README.md
@@ -136,9 +136,32 @@ in-memory state. To integrate another state container, create an
 ```ts
 import {
   AbstractThread,
+  createThreadStateSnapshot,
   type ThreadState,
 } from "@chatjs/thread";
 import type { UIMessage } from "ai";
+import { subscribeWithSelector } from "zustand/middleware";
+import { createStore } from "zustand/vanilla";
+
+const applicationStore = createStore(
+  subscribeWithSelector(() => ({
+    threadSnapshot: createThreadStateSnapshot<UIMessage>({ messages }),
+  })),
+);
+
+const applicationThreadState: ThreadState<UIMessage> = {
+  getSnapshot: () => applicationStore.getState().threadSnapshot,
+  subscribe: (listener) =>
+    applicationStore.subscribe(
+      (state) => state.threadSnapshot,
+      () => listener(),
+    ),
+  update: (updater) => {
+    applicationStore.setState((state) => ({
+      threadSnapshot: updater(state.threadSnapshot),
+    }));
+  },
+};
 
 class ApplicationThread extends AbstractThread<UIMessage> {
   constructor(state: ThreadState<UIMessage>) {
@@ -152,7 +175,10 @@ const chat = useThread({ thread });
 
 `ThreadState.update` invokes its updater exactly once, synchronously and
 atomically. The controller must remain the only writer so concurrent streams
-cannot overwrite each other.
+cannot overwrite each other. `createThreadStateSnapshot` initializes the full
+tree, index, selected-path, status, and run projection required by a custom
+adapter; the application store then keeps that snapshot as its canonical
+conversation state.
 
 Framework adapters observe the controller through:
 

--- a/packages/thread/README.md
+++ b/packages/thread/README.md
@@ -1,456 +1,133 @@
 # @chatjs/thread
 
-Build branching AI chats without giving up the `useChat` API.
+Build branching AI SDK conversations without mounting one `useChat` hook per
+branch.
 
-`@chatjs/thread` turns a linear AI SDK conversation into a message tree. Users
-can edit an earlier message, compare multiple responses, move between branches,
-and keep streams running on branches that are not currently visible.
+`useThread` preserves the `useChat` interface for the selected path and adds a
+`tree` namespace for navigation, sibling responses, concurrent runs, and
+run-specific cancellation.
 
-```tsx
-const chat = useThread({ transport });
-
-chat.messages; // The selected conversation path, just like useChat
-chat.tree.setCursor(messageId); // Select any point in the tree
-await chat.sendMessage({ text: "Try another direction" }); // Branch from it
-```
-
-The package is headless. It owns message topology and request lifecycles, while
-your application owns the conversation UI, branch controls, and persistence.
-
-## Why useThread?
-
-- **A familiar migration path.** `useThread` is assignable to AI SDK's
-  `UseChatHelpers`. Existing chat rendering and composer code can keep using
-  `messages`, `sendMessage`, `regenerate`, `stop`, `status`, and `error`.
-- **Branch from any message.** Move a cursor to an earlier node and send as
-  usual. Existing descendants are preserved as another branch.
-- **Run branches concurrently.** Every response has an isolated AI SDK request
-  lifecycle. Switching branches does not abort streams on hidden branches.
-- **Keep AI SDK behavior.** `ThreadChat` uses the caller's `ChatTransport` and
-  AI SDK's request orchestration, including tools, approvals, data parts,
-  automatic follow-ups, cancellation, and reconnection.
-- **Bring your own UI and storage.** The public tree is plain messages, IDs, and
-  edges. No component library or database model is imposed.
-
-## Installation
-
-Install the package and its AI SDK peer dependencies:
+## Install
 
 ```bash
 bun add @chatjs/thread ai @ai-sdk/react
 ```
 
-Or copy the source into an application with the ChatJS shadcn registry:
-
-```bash
-bunx shadcn@latest add FranciscoMoretti/chat-js/thread#main
-```
-
-The optional registry demo includes an application-owned conversation and tree
-UI:
-
-```bash
-bunx shadcn@latest add FranciscoMoretti/chat-js/thread-demo#main
-```
-
-## Quick start
-
-Use the same transport you would pass to `useChat`:
+## Use
 
 ```tsx
-"use client";
-
-import { DefaultChatTransport } from "ai";
 import { useThread } from "@chatjs/thread/react";
-import { useState } from "react";
+import { DefaultChatTransport } from "ai";
 
-const transport = new DefaultChatTransport({ api: "/api/chat" });
-
-export function Chat() {
-  const [input, setInput] = useState("");
-  const chat = useThread({ transport });
+function Conversation() {
+  const chat = useThread({
+    transport: new DefaultChatTransport({ api: "/api/chat" }),
+  });
 
   return (
-    <main>
+    <>
       {chat.messages.map((message) => (
-        <article key={message.id}>
-          <strong>{message.role}</strong>
-          {message.parts.map((part, index) =>
-            part.type === "text" ? <p key={index}>{part.text}</p> : null
-          )}
-        </article>
+        <div key={message.id}>{message.role}</div>
       ))}
 
-      <form
-        onSubmit={(event) => {
-          event.preventDefault();
-          if (!input.trim()) return;
-          chat.sendMessage({ text: input });
-          setInput("");
-        }}
+      <button
+        type="button"
+        onClick={() => chat.sendMessage({ text: "Continue" })}
       >
-        <input
-          onChange={(event) => setInput(event.target.value)}
-          value={input}
-        />
-        <button disabled={chat.status !== "ready"} type="submit">
-          Send
-        </button>
-      </form>
-    </main>
+        Send
+      </button>
+    </>
   );
 }
 ```
 
-At the top level, the hook behaves like a normal linear chat. The difference is
-that `messages` is a projection of the tree from its root to `tree.cursorId`.
-
-## The mental model
-
-`ThreadChat` stores every message once and records its parent:
-
-```text
-user: Plan a launch
-└── assistant: Start with architecture
-    └── user: Make it technical
-        ├── assistant: Define service-level indicators  <- selected cursor
-        └── assistant: Use staged environments
-```
-
-There are three distinct concepts:
-
-1. **Tree:** all messages and parent-child relationships.
-2. **Cursor:** the last message in the path currently shown by `chat.messages`.
-3. **Run:** one assistant request, with its own status, error, and abort
-   controller.
-
-Moving the cursor only changes the visible path. It does not delete descendants
-or stop active runs.
-
-## Create a branch
-
-Select the message to continue from, then call `sendMessage` normally:
-
-```ts
-chat.tree.setCursor(messageId);
-await chat.sendMessage({ text: "Explore a different approach" });
-```
-
-The new user message becomes a child of `messageId`, followed by its assistant
-response. Because `sendMessage` follows the selected cursor by default, the new
-branch becomes the active conversation.
-
-This is also the edit-message pattern. Editing is an application-level action:
-select the edited message's parent and send the replacement as a new message.
-The original message and its descendants remain available.
-
-```ts
-chat.tree.setCursorToParentOf(originalUserMessageId);
-await chat.sendMessage({
-  id: crypto.randomUUID(),
-  role: "user",
-  parts: [{ type: "text", text: editedText }],
-});
-```
-
-To display sibling controls:
-
-```ts
-const siblings = chat.tree.getSiblings(messageId);
-const index = siblings.findIndex((message) => message.id === messageId);
-
-function showSibling(offset: number) {
-  const sibling = siblings[index + offset];
-  if (sibling) chat.tree.setCursor(sibling.id);
-}
-```
-
-## Request parallel responses
-
-`sendMessage` intentionally keeps the AI SDK completion contract: its promise
-resolves when the request and automatic tool follow-ups finish. Use
-`tree.startRun` when you need an immediate run handle or multiple responses.
-
-First add a user message and start its primary response:
-
-```ts
-const prompt = {
-  id: crypto.randomUUID(),
-  role: "user" as const,
-  parts: [{ type: "text" as const, text: "Give me three implementation plans" }],
-};
-const primary = await chat.tree.startRun({
-  message: prompt,
-  follow: true,
-});
-```
-
-Then start more assistant responses from the same user node:
-
-```ts
-const alternativeA = await chat.tree.startRun({
-  from: prompt.id,
-  follow: false,
-});
-
-const alternativeB = await chat.tree.startRun({
-  from: prompt.id,
-  follow: false,
-});
-
-await Promise.all([
-  primary.finished,
-  alternativeA.finished,
-  alternativeB.finished,
-]);
-```
-
-`follow: false` leaves the cursor where it is while the response streams into
-the tree. Each returned handle can be inspected or stopped independently:
-
-```ts
-primary.id; // stable run ID
-primary.getSnapshot();
-await primary.stop();
-```
-
-Set concurrency limits when creating the hook:
-
-```ts
-const chat = useThread({
-  transport,
-  concurrency: {
-    maxActiveRuns: 4,
-    maxActiveRunsPerMessage: 3,
-  },
-});
-```
-
-## Active path versus whole tree
-
-The top-level API always describes the selected path and selected run:
+Existing rendering and composer code can continue using:
 
 ```ts
 chat.messages;
 chat.status;
 chat.error;
-await chat.stop();
-chat.clearError();
-await chat.resumeStream();
+chat.sendMessage();
+chat.regenerate();
+chat.stop();
 ```
 
-Whole-tree state and controls live under `tree`:
+The selected path is a projection of the complete tree:
 
 ```ts
 chat.tree.cursorId;
-chat.tree.status;
-chat.tree.activeRuns;
-chat.tree.runs;
-
-chat.tree.messagesById;
-chat.tree.parentById;
-chat.tree.childrenByParentId;
-chat.tree.rootIds;
-
-chat.tree.getMessage(messageId);
-chat.tree.getParent(messageId);
 chat.tree.getChildren(messageId);
 chat.tree.getSiblings(messageId);
-chat.tree.getLeaves(messageId);
-chat.tree.getPath(messageId);
+chat.tree.setCursor(messageId);
 ```
 
-`chat.status` uses AI SDK's `submitted`, `streaming`, `ready`, and `error`
-states for the selected path. `chat.tree.status` aggregates every run. A run is
-included in `activeRuns` while it is `submitted` or `streaming`.
-
-Target a specific run without moving the cursor:
+Start independent responses without mounting another hook:
 
 ```ts
-const run = chat.tree.getRun(runId);
-const messageRun = chat.tree.getRunForMessage(assistantMessageId);
+const first = await chat.tree.startRun({ from: messageId });
+const second = await chat.tree.startRun({
+  follow: false,
+  from: messageId,
+});
 
-await chat.tree.stopRun(runId);
-await chat.tree.stopRunForMessage(assistantMessageId);
-await chat.tree.resumeRun(runId);
+await Promise.all([first.finished, second.finished]);
+```
+
+Each run has independent status, error, stream state, and cancellation:
+
+```ts
+await chat.tree.stopRun(second.id);
 await chat.tree.stopAll();
 ```
 
-## Migrating from useChat
+## External Ownership
 
-For a conventional chat component, the initial migration is usually an import
-change:
-
-```diff
-- import { useChat } from "@ai-sdk/react";
-+ import { useThread } from "@chatjs/thread/react";
-
-- const chat = useChat({ transport });
-+ const chat = useThread({ transport });
-```
-
-`UseThreadHelpers<TMessage>` extends `UseChatHelpers<TMessage>`. These standard
-helpers retain their normal signatures:
-
-- `messages`, `sendMessage`, and `setMessages`
-- `status`, `error`, `stop`, and `clearError`
-- `regenerate` and `resumeStream`
-- `addToolOutput`, `addToolResult`, and `addToolApprovalResponse`
-
-There are two tree-specific behavioral details:
-
-- Top-level state refers to the selected path, not every active branch.
-- `setMessages` reconciles the selected path. Truncating it moves the cursor
-  backward without deleting hidden descendants; changing its suffix creates a
-  branch. A message ID cannot be reused under a different parent.
-
-## Tools and approvals
-
-Tool outputs and approval responses use the standard `useChat` signatures.
-`ThreadChat` records which run emitted each tool call or approval ID and routes
-the response back to that run, even when another branch is selected.
-
-Tool call and approval IDs must be unique across active runs.
-
-## Persistence
-
-Save the complete tree rather than only `chat.messages`:
+By default, `useThread` creates and retains a `Thread` for the hook lifetime.
+Create the controller yourself when it must outlive a particular component:
 
 ```ts
-const snapshot = chat.tree.getSnapshot();
-await saveThread(snapshot);
-```
+import { createThread } from "@chatjs/thread";
 
-Restore it when creating the hook:
+const thread = createThread({ transport });
 
-```ts
-const chat = useThread({
-  initialTree: savedSnapshot,
-  transport,
-});
-```
-
-Snapshots contain serializable message and topology state:
-
-```ts
-type MessageTreeSnapshot<TMessage> = {
-  version: 1;
-  cursorId: string | null;
-  messagesById: Record<string, TMessage>;
-  parentById: Record<string, string | null>;
-  childrenByParentId: Record<string, string[]>;
-  rootIds: string[];
-};
-```
-
-Runs are request-lifecycle state and are not persisted in the tree snapshot.
-Resumable assistant messages can be restored and resumed through
-`resumeStream` or `tree.resumeRun`.
-
-## Transport and server integration
-
-`useThread` accepts AI SDK `ChatTransport` implementations directly. It does
-not define another transport protocol or parse stream chunks itself.
-
-The active branch is sent as the transport's linear message history.
-`ChatRequestOptions` are forwarded unchanged, so application body and metadata
-fields remain entirely application-owned.
-
-Like AI SDK's `useChat`, `useThread` keeps a submitted response outside the
-public message collection. The assistant node is inserted on the first stream
-write, using the server's `start.messageId` when provided and the AI SDK
-client-generated ID otherwise. Applications can render queued work from
-`tree.activeRuns` without creating placeholder `UIMessage` values.
-
-## Externally owned ThreadChat
-
-Create `ThreadChat` outside React when it must outlive a component or be shared
-with application infrastructure:
-
-```tsx
-import { createThreadChat } from "@chatjs/thread";
-import { useThread } from "@chatjs/thread/react";
-
-const threadChat = createThreadChat({ transport });
-
-function Chat() {
-  const chat = useThread({ chat: threadChat });
+function Conversation() {
+  const chat = useThread({ thread });
   // ...
 }
 ```
 
-This is the instance-level equivalent of supplying an externally owned chat to
-`useChat`.
-
-## How it works
-
-`ThreadChat` uses a canonical tree plus one isolated AI SDK chat engine per
-active request:
-
-```text
-useThread
-  └── ThreadChat
-      ├── message tree (nodes, edges, cursor)
-      ├── run registry
-      │   ├── run A -> AI SDK AbstractChat -> ChatTransport
-      │   ├── run B -> AI SDK AbstractChat -> ChatTransport
-      │   └── run C -> AI SDK AbstractChat -> ChatTransport
-      └── React subscription snapshot
-```
-
-`ThreadChat` owns tree topology, cursor selection, run identity, and
-concurrency policy. Each run owns one AI SDK request lifecycle and abort
-controller. All runs use the caller-provided transport.
-
-This design matters because one linear `useChat` instance has one active
-message array and request lifecycle. Replacing that array during branch
-navigation can abort, reconnect, or misroute an in-flight response. Isolated
-runs continue writing to their own assistant nodes regardless of which path is
-visible.
-
-The implementation deliberately reuses AI SDK's `AbstractChat` orchestration
-instead of maintaining a custom stream reducer. That preserves standard stream
-parts, tools, approvals, callbacks, automatic sends, cancellation, and resume
-behavior while the package adds tree ownership around it.
-
-See [ARCHITECTURE.md](./ARCHITECTURE.md) for the ownership model, evaluated
-alternatives, and the differential coverage behind this decision.
-
-## Exports
-
-React APIs are exported from `@chatjs/thread/react`:
+`Thread` extends the framework-independent `AbstractThread`. It accepts an
+optional `ThreadState` implementation for integration with an application
+state container:
 
 ```ts
-useThread;
-type UseThreadOptions;
-type UseThreadHelpers;
-type TreeHelpers;
+import { MemoryThreadState, Thread } from "@chatjs/thread";
+
+const state = new MemoryThreadState({ messages: initialMessages });
+const thread = new Thread({ state, transport });
 ```
 
-Chat engine APIs and types are exported from `@chatjs/thread`:
+`ThreadState.update` invokes its updater exactly once, synchronously and
+atomically. The controller must remain the only writer so concurrent streams
+cannot overwrite each other.
+
+## Persistence
+
+Persist the serializable message tree, not the live controller:
 
 ```ts
-createThreadChat;
-ThreadChat;
-getMessageText;
+const snapshot = chat.tree.getSnapshot();
 
-type MessageTreeSnapshot;
-type ThreadConcurrency;
-type ThreadRun;
-type ThreadRunHandle;
-type ThreadChatOptions;
-type ThreadStartRunOptions;
-type TreeSendOptions;
-type ThreadStateSnapshot;
+const restored = useThread({
+  id: conversationId,
+  initialTree: snapshot,
+  transport,
+});
 ```
 
-## Scope
+The snapshot contains ordered nodes, parent IDs, and the selected cursor.
+Active requests, abort controllers, errors, and run adapters are runtime state
+and are not serialized.
 
-The package does not include chat components, branch controls, tree diagrams,
-storage adapters, or server routes. Those remain application concerns because
-their design and persistence requirements vary substantially. The package
-provides the headless state and controls needed to build them.
-
-## License
-
-Apache-2.0
+See [ARCHITECTURE.md](./ARCHITECTURE.md) for lifecycle, identity, status, and
+AI SDK compatibility decisions.

--- a/packages/thread/README.md
+++ b/packages/thread/README.md
@@ -103,8 +103,16 @@ const second = await chat.tree.startRun({
   from: messageId,
 });
 
+// Focus a run even before it has produced a response message.
+chat.tree.setActiveRun(second.id);
+await chat.stop();
+
 await Promise.all([first.finished, second.finished]);
 ```
+
+Selecting a pending run keeps `chat.messages` on its origin path until the
+first response message arrives. The cursor then follows that response, while
+the top-level `status`, `error`, and `stop()` helpers target the selected run.
 
 Each run has independent status, error, stream state, and cancellation:
 

--- a/packages/thread/package.json
+++ b/packages/thread/package.json
@@ -47,7 +47,7 @@
 	"scripts": {
 		"build": "bun -e \"import { rmSync } from 'node:fs'; rmSync('dist', { recursive: true, force: true })\" && tsc -p tsconfig.build.json && bun ./build.ts",
 		"format": "bunx @biomejs/biome@2.4.10 check --write src test build.ts *.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
-		"lint": "bunx @biomejs/biome@2.4.10 check src test build.ts ARCHITECTURE.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
+		"lint": "bunx @biomejs/biome@2.4.10 check src test build.ts README.md ARCHITECTURE.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
 		"prepublishOnly": "bun run build",
 		"test": "bun test --pass-with-no-tests",
 		"test:unit": "bun test --pass-with-no-tests",


### PR DESCRIPTION
## Summary
- Adds a package README that starts with the migration value.
- Documents linear compatibility, branching, parallel runs, status, stopping, transport identity, and persistence.
- Separates package responsibilities from app persistence concerns.

## Behavior
Documentation only.

## Verification
- README examples checked against package types and implementation.

## Review focus
Can an existing AI SDK React user migrate without reading the internals first?

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a value-first `README.md` for `@chatjs/thread` and expands `ARCHITECTURE.md` so `useChat` users can adopt `useThread` without reading package internals. Documentation only; lint now covers the README.

**Documented behavior**
- `useThread` preserves the `useChat` interface and adds tree navigation, `startRun({ from, follow })`, `setActiveRun`, and independent `stopRun`/`stopAll` controls; `@chatjs/thread/react` owns React behavior while the headless core stays framework-neutral.
- `startRun` returns a run handle with `finished`; `setActiveRun(runId)` keeps `messages` on the origin path until the first response arrives, while `status`, `error`, and `stop()` target the selected run.
- `regenerate({ messageId })` stores a sibling; continuing an assistant message streams into the same ID, and assistant-to-assistant targets regenerate the same way.
- Persist `tree.getSnapshot()` and restore via `initialTree`; do not serialize transports, in-flight runs, or errors.
- Custom adapters subclass `AbstractThread` with `createThreadStateSnapshot`; the snapshot is the canonical store value, with compatibility fields as projections updated in the same atomic `ThreadState.update`.

<sup>Written for commit fb420436aefe7128aa406b6ad990a3a849bca001. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Document how to adopt `@chatjs/thread` for branching and concurrent AI conversations without requiring users to understand the package internals.

New Features:
- Add a value-first package guide for migrating from `useChat` to `useThread`, including branching conversations, concurrent runs, cancellation, external state ownership, and persistence.

Enhancements:
- Expand the architecture documentation with pending-run selection semantics and guidance for custom state adapters and canonical snapshots.

CI:
- Include the package README in lint checks.

Documentation:
- Document the framework-neutral core and React adapter responsibilities, compatibility behavior, tree navigation, run lifecycle, external ownership, and persistence boundaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for thread usage, including tree navigation, branching, concurrent runs, cancellation, external state ownership, and persistence.
  * Documented selecting active runs while retaining compatible status, error, and stop behavior.
  * Added guidance for custom application-backed thread state and atomic state updates.
  * Clarified snapshot persistence, resuming conversations and streams, and run-resumption limitations.
* **Chores**
  * Included the package README in automated lint checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->