### PR TITLE
Threads 22: Document ChatJS threaded behavior

### DIFF
--- a/.github/workflows/cli-scaffold.yml
+++ b/.github/workflows/cli-scaffold.yml
@@ -23,6 +23,11 @@ jobs:
           bun-version: 1.3.1
       - name: Enable Corepack
         run: corepack enable
+      - name: Pin npm
+        run: |
+          # npm 10 crashes resolving vitest@^4 after Vitest 5 (npm/cli#9787)
+          npm install --global npm@11
+          npm --version
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache

--- a/apps/docs/blume.config.ts
+++ b/apps/docs/blume.config.ts
@@ -69,6 +69,7 @@ export default defineConfig({
           items: [
             "/core/architecture",
             "/core/configuration",
+            "/core/use-thread",
             "/core/file-storage",
             "/core/authentication",
             "/core/tool-registry",

--- a/apps/docs/blume.config.ts
+++ b/apps/docs/blume.config.ts
@@ -68,8 +68,8 @@ export default defineConfig({
           label: "Core Concepts",
           items: [
             "/core/architecture",
-            "/core/configuration",
             "/core/use-thread",
+            "/core/configuration",
             "/core/file-storage",
             "/core/authentication",
             "/core/tool-registry",

--- a/apps/docs/cookbook/stop-resumable-streams.mdx
+++ b/apps/docs/cookbook/stop-resumable-streams.mdx
@@ -22,10 +22,11 @@ Using message-level cancellation (instead of chat-level) is more precise since e
 ## How it works
 
 1. Client calls `chat.stopStream` with the current `messageId`
-2. Server persists `canceledAt` on the message row
-3. The `onChunk` callback (throttled to 1/sec) polls `canceledAt` on each token
-4. When `canceledAt` is set, calls `abortController.abort()`
-5. The provider stops and no more tokens are generated
+2. If streaming has not published an assistant yet, the server resolves the new response from the user message ID
+3. Server atomically persists `canceledAt`, clears `activeStreamId`, and removes finalized parts
+4. The `onChunk` callback (throttled to 1/sec) polls `canceledAt` on each token
+5. When `canceledAt` is set, calls `abortController.abort()`
+6. Finalization skips canceled messages, closing the race where a fast response finishes between polling checks
 
 ## Basic use case
 
@@ -98,6 +99,8 @@ const stream = await createChatStream({
 ```
 
 The `onChunk` callback is passed through `createChatStream` into `createCoreChatAgent`, which forwards it to the AI SDK's `streamText` call. Each chunk emitted by the model triggers the throttled check.
+
+The final database write must also require `canceledAt IS NULL`. Chunk polling is intentionally throttled, so a fast response can finish between checks. Cancellation and finalization therefore form a database race: cancellation clears any already-finalized parts, while finalization refuses to overwrite a cancellation that committed first.
 
 ## Flow
 

--- a/apps/docs/cookbook/stop-resumable-streams.mdx
+++ b/apps/docs/cookbook/stop-resumable-streams.mdx
@@ -9,7 +9,10 @@ You want a user to stop an in-flight response without killing resumable streams.
 
 ## Solution
 
-Store a `canceledAt` timestamp on the message (not the chat). When the user clicks stop, set it with a tRPC mutation using the current message ID. The stream loop polls `canceledAt` and aborts the provider with a server-owned `AbortController`.
+Store a `canceledAt` timestamp on the message, not the chat. For unpublished
+responses, also record cancellation against the assistant ID derived from the
+user message. The stream loop polls `canceledAt` and aborts the provider with a
+server-owned `AbortController`.
 
 Using message-level cancellation (instead of chat-level) is more precise since each message has its own stream state, aligning with the existing `activeStreamId` pattern on messages.
 
@@ -21,12 +24,12 @@ Using message-level cancellation (instead of chat-level) is more precise since e
 
 ## How it works
 
-1. Client calls `chat.stopStream` with the current `messageId`
-2. If streaming has not published an assistant yet, the server resolves the new response from the user message ID
-3. Server atomically persists `canceledAt`, clears `activeStreamId`, and removes finalized parts
+1. Client calls `trpc.chat.stopStream` with `{ chatId, messageId, type }`
+2. `type: "request"` records cancellation against the unpublished assistant ID derived from the user message. `type: "message"` cancels an already persisted assistant
+3. `cancelActiveMessage` sets `canceledAt` and clears `activeStreamId` when that row exists
 4. The `onChunk` callback (throttled to 1/sec) polls `canceledAt` on each token
 5. When `canceledAt` is set, calls `abortController.abort()`
-6. Finalization skips canceled messages, closing the race where a fast response finishes between polling checks
+6. Finalization's `updateMessage` requires `canceledAt IS NULL`, so a cancel that commits first is not overwritten
 
 ## Basic use case
 
@@ -34,27 +37,43 @@ Add a stop mutation and call it from the stop button.
 
 ```ts title="trpc/routers/chat.router.ts"
 stopStream: protectedProcedure
-  .input(z.object({ messageId: z.string().uuid() }))
+  .input(
+    z.discriminatedUnion("type", [
+      z.object({
+        chatId: z.string().uuid(),
+        messageId: z.string().uuid(),
+        type: z.literal("message"),
+      }),
+      z.object({
+        chatId: z.string().uuid(),
+        messageId: z.string().uuid(),
+        type: z.literal("request"),
+      }),
+    ])
+  )
   .mutation(async ({ ctx, input }) => {
-    const [msg] = await getMessageById({ id: input.messageId });
-    if (!msg) {
-      throw new TRPCError({
-        code: "NOT_FOUND",
-        message: "Message not found",
-      });
-    }
-
-    const chat = await getChatById({ id: msg.chatId });
-    if (!chat || chat.userId !== ctx.user.id) {
+    const chat = await getChatById({ id: input.chatId });
+    if (chat && chat.userId !== ctx.user.id) {
       throw new TRPCError({
         code: "NOT_FOUND",
         message: "Chat not found or access denied",
       });
     }
 
-    await updateMessageCanceledAt({
+    const canceledAt = new Date();
+    if (input.type === "request") {
+      await requestGenerationCancellation({
+        canceledAt,
+        chatId: input.chatId,
+        messageId: input.messageId,
+        userId: ctx.user.id,
+      });
+    }
+
+    await cancelActiveMessage({
+      canceledAt,
+      chatId: input.chatId,
       messageId: input.messageId,
-      canceledAt: new Date(),
     });
 
     return { success: true };
@@ -69,10 +88,14 @@ const lastMessageId = useLastMessageId();
 
 const handleStop = useCallback(() => {
   if (session?.user && lastMessageId) {
-    stopStreamMutation.mutate({ messageId: lastMessageId });
+    stopStreamMutation.mutate({
+      chatId,
+      messageId: lastMessageId,
+      type: "message",
+    });
   }
   stopHelper?.();
-}, [lastMessageId, session?.user, stopHelper, stopStreamMutation]);
+}, [chatId, lastMessageId, session?.user, stopHelper, stopStreamMutation]);
 ```
 
 ## Server-side polling via onChunk
@@ -100,7 +123,7 @@ const stream = await createChatStream({
 
 The `onChunk` callback is passed through `createChatStream` into `createCoreChatAgent`, which forwards it to the AI SDK's `streamText` call. Each chunk emitted by the model triggers the throttled check.
 
-The final database write must also require `canceledAt IS NULL`. Chunk polling is intentionally throttled, so a fast response can finish between checks. Cancellation and finalization therefore form a database race: cancellation clears any already-finalized parts, while finalization refuses to overwrite a cancellation that committed first.
+The final database write must also require `canceledAt IS NULL`. Chunk polling is intentionally throttled, so a fast response can finish between checks. Cancellation and finalization therefore form a database race: `cancelActiveMessage` stamps `canceledAt` and clears `activeStreamId`, while `updateMessage` refuses to overwrite a cancellation that committed first.
 
 ## Flow
 
@@ -116,7 +139,7 @@ sequenceDiagram
     Provider-->>API: chunk (triggers onChunk)
     API->>DB: getMessageCanceledAt()
     DB-->>API: null (continue)
-    Client->>API: chat.stopStream({ messageId })
+    Client->>API: chat.stopStream({ chatId, messageId, type })
     API->>DB: update Message.canceledAt = now
     Provider-->>API: chunk (triggers onChunk)
     API->>DB: getMessageCanceledAt()

--- a/apps/docs/cookbook/stop-resumable-streams.mdx
+++ b/apps/docs/cookbook/stop-resumable-streams.mdx
@@ -61,15 +61,29 @@ stopStream: protectedProcedure
     }
 
     const canceledAt = new Date();
-    if (input.type === "request") {
-      await requestGenerationCancellation({
+    if (input.type === "message") {
+      const [targetMessage] = await getMessageById({ id: input.messageId });
+      if (!(chat && targetMessage) || targetMessage.chatId !== input.chatId) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Message not found",
+        });
+      }
+
+      await cancelActiveMessage({
         canceledAt,
         chatId: input.chatId,
         messageId: input.messageId,
-        userId: ctx.user.id,
       });
+      return { success: true };
     }
 
+    await requestGenerationCancellation({
+      canceledAt,
+      chatId: input.chatId,
+      messageId: input.messageId,
+      userId: ctx.user.id,
+    });
     await cancelActiveMessage({
       canceledAt,
       chatId: input.chatId,
@@ -130,6 +144,7 @@ The final database write must also require `canceledAt IS NULL`. Chunk polling i
 ```mermaid
 sequenceDiagram
     participant Client
+    participant TRPC as tRPC chat.stopStream
     participant API as POST /api/chat
     participant DB
     participant Provider
@@ -139,8 +154,8 @@ sequenceDiagram
     Provider-->>API: chunk (triggers onChunk)
     API->>DB: getMessageCanceledAt()
     DB-->>API: null (continue)
-    Client->>API: chat.stopStream({ chatId, messageId, type })
-    API->>DB: update Message.canceledAt = now
+    Client->>TRPC: stopStream({ chatId, messageId, type })
+    TRPC->>DB: update Message.canceledAt = now
     Provider-->>API: chunk (triggers onChunk)
     API->>DB: getMessageCanceledAt()
     DB-->>API: timestamp (abort)

--- a/apps/docs/core/architecture.mdx
+++ b/apps/docs/core/architecture.mdx
@@ -20,6 +20,7 @@ The application uses:
 - **PostgreSQL** (via [Drizzle ORM](https://orm.drizzle.team)) for persistent data (users, chats, messages, documents)
 - **Redis** for ephemeral data (resumable streams, caching). See [Resumable Streams](/cookbook/resumable-streams)
 - **AI SDK** to connect to multiple AI providers through a [gateway abstraction](/gateways/overview)
+- **`useThread`** to manage the selected conversation path, message tree, and independent response runs. See [useThread](./use-thread)
 - **Files SDK** through a configured [file storage provider](./file-storage) for attachments and generated media
 - **tRPC** for end-to-end type-safe API routes between client and server
 - **Langfuse** (optional) for LLM observability, tracing, and analytics
@@ -30,15 +31,27 @@ When a user sends a message:
 
 ```mermaid
 sequenceDiagram
-    Client->>API: Send message
+    participant Client
+    participant Thread as useThread
+    participant API
+    participant DB
+    participant AI
+    participant Cache
+    Client->>Thread: Send message or start run
+    Thread->>API: Send selected path
     API->>DB: Save messages
     API->>AI: Stream response
-    AI-->>Client: Token stream (SSE)
+    AI-->>API: Model stream
+    API-->>Thread: UI message stream (SSE)
+    Thread-->>Client: Update reserved response node
     Note over API,Cache: Chunks stored in Redis for resumability
     API->>DB: Save final response
 ```
 
-Messages are stored with normalized **parts** (text, tool calls, files, reasoning) allowing efficient querying and streaming updates.
+Messages are stored with normalized **parts** (text, tool calls, files,
+reasoning) allowing efficient querying and streaming updates. Each active
+assistant response has its own run, so navigating to another branch does not
+redirect or stop that response.
 
 If [resumable streams](/cookbook/resumable-streams) are enabled, response chunks are published to Redis so clients can reconnect mid-generation without losing progress.
 

--- a/apps/docs/core/architecture.mdx
+++ b/apps/docs/core/architecture.mdx
@@ -43,7 +43,7 @@ sequenceDiagram
     API->>AI: Stream response
     AI-->>API: Model stream
     API-->>Thread: UI message stream (SSE)
-    Thread-->>Client: Update reserved response node
+    Thread-->>Client: Publish the assistant message
     Note over API,Cache: Chunks stored in Redis for resumability
     API->>DB: Save final response
 ```

--- a/apps/docs/core/architecture.mdx
+++ b/apps/docs/core/architecture.mdx
@@ -48,10 +48,10 @@ sequenceDiagram
     API->>DB: Save final response
 ```
 
-Messages are stored with normalized **parts** (text, tool calls, files,
-reasoning) allowing efficient querying and streaming updates. Each active
-assistant response has its own run, so navigating to another branch does not
-redirect or stop that response.
+ChatJS stores messages with normalized **parts** (text, tool calls, files,
+reasoning) so you can query and stream updates efficiently. Each active
+assistant response has its own run. When you navigate to another branch, that
+response keeps streaming.
 
 If [resumable streams](/cookbook/resumable-streams) are enabled, response chunks are published to Redis so clients can reconnect mid-generation without losing progress.
 

--- a/apps/docs/core/configuration.mdx
+++ b/apps/docs/core/configuration.mdx
@@ -83,7 +83,9 @@ See [Gateways](/gateways/overview) for detailed setup and comparison.
 
 ## Features
 
-Toggle feature flags on/off. Tool flags live under `ai.tools.*.enabled`. `features` currently contains only attachments. Missing env vars are caught at build time via `bun run prebuild`.
+Toggle feature flags on/off. Tool flags live under `ai.tools.*.enabled`.
+Application-level flags live under `features`. Missing env vars are caught at
+build time via `bun run prebuild`.
 
 | Feature               | Config Key                            | Env Dependency                                                                           |
 | --------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------- |
@@ -96,6 +98,7 @@ Toggle feature flags on/off. Tool flags live under `ai.tools.*.enabled`. `featur
 | Deep Research         | `ai.tools.deepResearch.enabled`       | `TAVILY_API_KEY` or `FIRECRAWL_API_KEY`                                                  |
 | Follow-up Suggestions | `ai.tools.followupSuggestions.enabled` | Uses your configured language model provider                                              |
 | Attachments           | `features.attachments`                | Configured file storage provider                                                         |
+| Parallel Responses    | `features.parallelResponses`          | None                                                                                     |
 
 ```typescript
 ai: {
@@ -112,6 +115,7 @@ ai: {
 },
 features: {
   attachments: true, // Requires durable file storage
+  parallelResponses: true,
 },
 ```
 

--- a/apps/docs/core/use-thread.mdx
+++ b/apps/docs/core/use-thread.mdx
@@ -1,0 +1,155 @@
+---
+title: "useThread"
+description: "Build branching AI conversations with a useChat-compatible interface"
+---
+
+`useThread` is the React interface to the `ThreadChat` engine behind branching
+conversations in ChatJS. It keeps the familiar AI SDK `useChat` interface for
+the selected conversation while storing every message and response branch in a
+complete tree.
+
+Use it when people need to edit earlier messages, compare alternative replies,
+or move between branches while responses continue streaming.
+
+## Install
+
+```bash
+bun add @chatjs/thread ai @ai-sdk/react
+```
+
+Replace the `useChat` import without changing your existing message list or
+composer:
+
+```diff
+- import { useChat } from "@ai-sdk/react";
++ import { useThread } from "@chatjs/thread/react";
+
+- const chat = useChat({ transport });
++ const chat = useThread({ transport });
+```
+
+The top-level helpers remain compatible with `UseChatHelpers`, including
+`messages`, `sendMessage`, `regenerate`, `stop`, `status`, tools, and approvals.
+
+## Mental model
+
+`useThread` separates four concepts:
+
+- **Tree:** every message and its parent-child relationship
+- **Cursor:** the message currently selected by the application
+- **Active path:** the root-to-cursor messages exposed as `chat.messages`
+- **Run:** one assistant response with its own status, error, and stop control
+
+```mermaid
+flowchart TD
+    U1[User message] --> A1[Assistant response]
+    A1 --> U2[Follow-up]
+    U2 --> A2[Selected response]
+    U2 --> A3[Alternative response]
+```
+
+Moving the cursor changes the active path. It does not delete descendants or
+stop runs on other branches.
+
+## Create a branch
+
+Select any message and send normally. The new user message becomes a child of
+the selected node.
+
+```ts
+chat.tree.setCursor(messageId);
+await chat.sendMessage({ text: "Explore another approach" });
+```
+
+Editing is an application-level operation. Select the original user message's
+parent, then send the replacement as a new message:
+
+```ts
+chat.tree.setCursorToParentOf(originalMessageId);
+await chat.sendMessage({
+  id: crypto.randomUUID(),
+  role: "user",
+  parts: [{ type: "text", text: editedText }],
+});
+```
+
+See [Branching](../features/branching) for the ChatJS user experience.
+
+## Run parallel responses
+
+Each assistant response is an independent run. Start the first response with a
+new user message, then start alternatives from that same user node:
+
+```ts
+const primary = await chat.tree.startRun({
+  message: { text: "Give me three options" },
+  follow: true,
+});
+
+const userMessageId = primary.getSnapshot()?.userMessageId;
+
+if (userMessageId) {
+  const alternatives = await Promise.all([
+    chat.tree.startRun({ from: userMessageId, follow: false }),
+    chat.tree.startRun({ from: userMessageId, follow: false }),
+  ]);
+
+  await Promise.all([
+    primary.finished,
+    ...alternatives.map((run) => run.finished),
+  ]);
+}
+```
+
+`follow: false` leaves the cursor unchanged while the response streams into its
+reserved assistant node. ChatJS uses this model for multiple replies from the
+same model and for comparisons across different models.
+
+See [Parallel Responses](../features/parallel-responses) for the product flow.
+
+## Status and controls
+
+Top-level state describes the selected path:
+
+```ts
+chat.status;
+chat.error;
+await chat.stop();
+```
+
+Tree state describes all runs:
+
+```ts
+chat.tree.status;
+chat.tree.activeRuns;
+chat.tree.runs;
+
+await chat.tree.stopRun(runId);
+await chat.tree.stopAll();
+```
+
+Statuses use the AI SDK values `submitted`, `streaming`, `ready`, and `error`.
+
+## Persist the tree
+
+Save the complete tree instead of only the selected `chat.messages` path:
+
+```ts
+const snapshot = chat.tree.getSnapshot();
+await saveThread(snapshot);
+```
+
+Restore it with `initialTree`:
+
+```ts
+const chat = useThread({
+  initialTree: savedSnapshot,
+  transport,
+});
+```
+
+Snapshots contain messages, parent links, child ordering, roots, and the
+cursor. Active request objects are not persisted.
+
+The package README documents the complete interface, transport metadata, and
+`ThreadChat` exports.

--- a/apps/docs/core/use-thread.mdx
+++ b/apps/docs/core/use-thread.mdx
@@ -3,7 +3,7 @@ title: "useThread"
 description: "Build branching AI conversations with a useChat-compatible interface"
 ---
 
-`useThread` is the React interface to the `ThreadChat` engine behind branching
+`useThread` is the React interface to the `Thread` controller behind branching
 conversations in ChatJS. It keeps the familiar AI SDK `useChat` interface for
 the selected conversation while storing every message and response branch in a
 complete tree.
@@ -81,24 +81,25 @@ Each assistant response is an independent run. Start the first response with a
 new user message, then start alternatives from that same user node:
 
 ```ts
+const userMessageId = crypto.randomUUID();
 const primary = await chat.tree.startRun({
-  message: { text: "Give me three options" },
+  message: {
+    id: userMessageId,
+    role: "user",
+    parts: [{ type: "text", text: "Give me three options" }],
+  },
   follow: true,
 });
 
-const userMessageId = primary.getSnapshot()?.userMessageId;
+const alternatives = await Promise.all([
+  chat.tree.startRun({ from: userMessageId, follow: false }),
+  chat.tree.startRun({ from: userMessageId, follow: false }),
+]);
 
-if (userMessageId) {
-  const alternatives = await Promise.all([
-    chat.tree.startRun({ from: userMessageId, follow: false }),
-    chat.tree.startRun({ from: userMessageId, follow: false }),
-  ]);
-
-  await Promise.all([
-    primary.finished,
-    ...alternatives.map((run) => run.finished),
-  ]);
-}
+await Promise.all([
+  primary.finished,
+  ...alternatives.map((run) => run.finished),
+]);
 ```
 
 `follow: false` leaves the cursor unchanged while the response streams into its
@@ -152,4 +153,4 @@ Snapshots contain messages, parent links, child ordering, roots, and the
 cursor. Active request objects are not persisted.
 
 The package README documents the complete interface, transport metadata, and
-`ThreadChat` exports.
+`Thread` exports.

--- a/apps/docs/core/use-thread.mdx
+++ b/apps/docs/core/use-thread.mdx
@@ -4,12 +4,12 @@ description: "Build branching AI conversations with a useChat-compatible interfa
 ---
 
 `useThread` is the React interface to the `Thread` controller behind branching
-conversations in ChatJS. It keeps the familiar AI SDK `useChat` interface for
-the selected conversation while storing every message and response branch in a
+conversations in ChatJS. You keep the familiar AI SDK `useChat` interface for
+the selected conversation, while every message and response branch lives in a
 complete tree.
 
-Use it when people need to edit earlier messages, compare alternative replies,
-or move between branches while responses continue streaming.
+Use it when you need to edit earlier messages, compare alternative replies, or
+move between branches while responses continue streaming.
 
 ## Install
 

--- a/apps/docs/core/use-thread.mdx
+++ b/apps/docs/core/use-thread.mdx
@@ -14,7 +14,7 @@ or move between branches while responses continue streaming.
 ## Install
 
 ```bash
-bun add @chatjs/thread ai @ai-sdk/react
+bun add @chatjs/thread ai @ai-sdk/react react
 ```
 
 Replace the `useChat` import without changing your existing message list or
@@ -102,9 +102,9 @@ await Promise.all([
 ]);
 ```
 
-`follow: false` leaves the cursor unchanged while the response streams into its
-reserved assistant node. ChatJS uses this model for multiple replies from the
-same model and for comparisons across different models.
+`follow: false` leaves the cursor unchanged. The sibling appears when the first
+stream write arrives. ChatJS uses this model for multiple replies from the same
+model and for comparisons across different models.
 
 See [Parallel Responses](../features/parallel-responses) for the product flow.
 
@@ -143,14 +143,16 @@ await saveThread(snapshot);
 Restore it with `initialTree`:
 
 ```ts
+import { DefaultChatTransport } from "ai";
+
 const chat = useThread({
   initialTree: savedSnapshot,
-  transport,
+  transport: new DefaultChatTransport({ api: "/api/chat" }),
 });
 ```
 
-Snapshots contain messages, parent links, child ordering, roots, and the
-cursor. Active request objects are not persisted.
+The snapshot is `{ version: 1, cursorId, nodes }`. Runtime indexes, active
+requests, and run adapters are not persisted.
 
 The package README documents the complete interface, transport metadata, and
 `Thread` exports.

--- a/apps/docs/features/branching.mdx
+++ b/apps/docs/features/branching.mdx
@@ -3,64 +3,59 @@ title: Branching
 description: Explore alternative conversation paths without losing context
 ---
 
-Branching lets you fork a conversation at any point and explore different directions. When you re-submit a message or the AI generates a new response, a branch is created automatically. You can navigate between branches using the sibling controls that appear on messages.
+Branching lets you fork a conversation at any message and explore another
+direction without replacing the original path. Editing a message or generating
+another response creates a sibling that you can return to later.
 
 <Frame>
   <img src="/docs/images/branching.gif" alt="Navigating between conversation branches" />
 </Frame>
 
-## How It Works
+## How it works
 
-Every message stores a `parentMessageId` that forms a tree structure. When you edit a message or regenerate a response, a new child is added under the same parent, creating siblings. The UI displays the active thread (a single root-to-leaf path through the tree) while keeping all branches available.
+Every message has a parent, which forms a conversation tree. ChatJS displays
+one root-to-message path at a time while keeping the other branches available.
 
-## Navigating Branches
+```mermaid
+flowchart TD
+    U1[User: Plan a launch] --> A1[Assistant: Start with architecture]
+    A1 --> U2[User: Make it technical]
+    U2 --> A2[Assistant: Define service indicators]
+    U2 --> A3[Assistant: Use staged environments]
+```
 
-When a message has siblings (alternative versions), arrow controls appear next to it showing the current position (e.g., "2/3"). Click the left or right arrows to switch between branches.
+The selected message is the cursor. Sending a message continues from that
+cursor, so selecting an earlier node before sending creates a new branch.
+
+## Navigate branches
+
+When a message has siblings, arrow controls show the current position, such as
+`2/3`. Use the arrows to move to the previous or next branch.
 
 Switching branches:
 
-- Stops any active stream
-- Clears buffered data
-- Closes artifacts that belong to the previous branch
-- Loads the full thread from the selected sibling down to its most recent leaf
+- changes the active conversation path
+- preserves responses that are still streaming on other branches
+- clears transient data that belongs to the previous path
+- closes an open artifact when its message is not in the selected path
+- follows the selected branch to its latest descendant
 
-## Data Model
+## Edit a message
 
-Messages are stored with a `parentMessageId` column in the database. Root messages have a `null` parent. This creates a tree where each node can have multiple children (siblings).
+Editing creates a replacement branch. The original message and all of its
+descendants remain in the tree, so you can switch back with the same sibling
+controls.
 
-```mermaid
-graph TD
-    A[User: Hello] --> B[AI: Hi there!]
-    A --> C[AI: Hey! How can I help?]
-    B --> D[User: Tell me about X]
-    C --> E[User: Tell me about Y]
-    D --> F[AI: X is...]
-    E --> G[AI: Y is...]
-```
+## Data model
 
-## Architecture
+Messages are persisted with a parent message ID. Root messages have no parent.
+The client uses `useThread` to project the selected path and to keep each active
+assistant response attached to its own reserved node.
 
-The branching system has three layers:
+See [useThread](../core/use-thread) for the tree, cursor, active-path, and run
+model.
 
-### Tree Utilities (`lib/thread-utils.ts`)
+## Related
 
-Pure functions that operate on the message tree:
-
-- `buildThreadFromLeaf` - walks `parentMessageId` links from a leaf to the root to construct the active thread
-- `buildChildrenMap` - creates a parent-to-children index sorted by creation time
-- `getDefaultThread` - finds the most recent leaf and builds the thread to it
-- `findLeafDfsToRightFromMessageId` - DFS to find the rightmost leaf from a given node (used when switching branches)
-
-### Zustand Middleware (`lib/stores/with-threads.ts`)
-
-A `withThreads` middleware wraps the base chat store and adds:
-
-- `allMessages` - the complete message tree (all branches)
-- `childrenMap` - reactive parent-to-children index, rebuilt when `allMessages` changes
-- `getMessageSiblingInfo` - looks up siblings and current index for any message
-- `switchToSibling` - finds the target sibling, walks to its rightmost leaf, builds the new thread, and swaps it in
-- `threadEpoch` - a counter that bumps on thread switches, used as a React key to remount `useChat`
-
-### Server Sync (`components/message-tree-sync.tsx`)
-
-`MessageTreeSync` is a renderless component that fetches the full message tree from the server via React Query and feeds it into the Zustand store with `setAllMessages`. It also handles resetting state when navigating to the home page.
+- [Parallel Responses](./parallel-responses)
+- [Architecture](../core/architecture)

--- a/apps/docs/features/parallel-responses.mdx
+++ b/apps/docs/features/parallel-responses.mdx
@@ -1,52 +1,70 @@
 ---
 title: Parallel Responses
-description: Send one message to multiple models simultaneously and compare their answers side by side
+description: Generate independent replies from one or more models and compare them as conversation branches
 ---
 
-Parallel responses let you select more than one model before submitting a message. ChatJS fans the request out to every selected model at the same time and displays each answer as a clickable card. You can then pick the response you want to continue the conversation with.
+Parallel responses let you request several replies to one user message. You can
+compare different models, ask one model for multiple alternatives, or combine
+both approaches in the same response group.
 
-## How to Use
+## Request responses
 
 1. Open the model selector in the chat input.
-2. Toggle **Use Multiple Models**.
-3. Select two or more models. Each model shows a count badge when it is part of the parallel set.
-4. Type your message and submit.
+2. Enable **Use Multiple Models**.
+3. Select the models you want to use.
+4. Set the response count for each selected model.
+5. Send your message.
 
-Each model starts streaming immediately. A row of cards appears above the message showing the model name and current status. Click any card to switch the active thread to that response.
+The total response count must be greater than one. Selecting one model with a
+count of three creates three independent replies from that model. Selecting
+three models with a count of one creates one reply from each model.
 
 <Callout type="note">
   Parallel responses require authentication. Anonymous sessions are limited to a
   single model per request.
 </Callout>
 
-## Response Cards
+## Independent runs
 
-Each card in the batch displays:
-
-- The model label
-- A streaming indicator while the response is being generated
-- One of three states: **Generating**, **Task completed**, or **Selected**
-
-Clicking a card runs `switchToMessage`, which rebuilds the visible thread from that assistant branch down to its most recent leaf. The previously selected branch is preserved and you can return to it at any time by clicking its card again.
+ChatJS reserves a message ID for each response and attaches it to an
+independent branch. In an active conversation, secondary responses use
+`useThread` runs with their own streaming state and stop control.
 
 ```mermaid
-graph TD
-    U[User message] --> A[Claude response]
-    U --> B[GPT-4o response]
-    U --> C[Gemini response]
-    A -->|Selected| D[Next user message]
+flowchart TD
+    U[User message] --> A[Model A, response 1]
+    U --> B[Model A, response 2]
+    U --> C[Model B, response 1]
 ```
 
-## Continuing the Conversation
+The first response becomes the selected path. Other responses use background
+runs, so they continue streaming when you select another response or navigate
+to a different branch.
 
-After you select a card, the conversation continues from that branch as a normal single-model thread. Subsequent messages go only to the model of the selected branch. You can always navigate back up and pick a different card before sending a follow-up.
+For a new chat, all cards appear optimistically. The primary request persists
+the chat and user message, then emits an acknowledgment containing the user
+message and response-group identities. ChatJS starts the secondary runs only
+after that acknowledgment, avoiding duplicate chat creation without delaying
+ordinary single-response chats.
 
-## Current Constraints
+## Response cards
 
-- Parallel responses are not available when the message includes attachments. Mixed model capabilities across attachment types are not yet supported.
-- Each model in the parallel set is billed as a separate request.
+A card appears for each requested response and shows its model and current
+state. Select a card to make that response the active conversation path.
+
+After selecting a response, new messages continue from that branch. The other
+responses remain available, including any that are still generating.
+
+## Current constraints
+
+- Attachments cannot be combined with parallel responses yet.
+- Each response is billed as a separate model request.
+- Stopping the selected response does not stop other active runs. Use the
+  branch controls to select another response, or stop all runs through the
+  package API with `chat.tree.stopAll()`.
 
 ## Related
 
-- [Branching](/features/branching) - how the underlying thread tree works
-- [Multi-Model Support](/core/multi-model) - configuring which models are available
+- [useThread](../core/use-thread)
+- [Branching](./branching)
+- [Multi-Model Support](../core/multi-model)

--- a/apps/docs/features/parallel-responses.mdx
+++ b/apps/docs/features/parallel-responses.mdx
@@ -26,9 +26,10 @@ three models with a count of one creates one reply from each model.
 
 ## Independent runs
 
-ChatJS reserves a message ID for each response and attaches it to an
-independent branch. In an active conversation, secondary responses use
-`useThread` runs with their own streaming state and stop control.
+ChatJS assigns each response a stable message ID and starts an independent
+`useThread` run. The tree node appears when the first stream write arrives. In
+an active conversation, secondary responses keep their own streaming state and
+stop control.
 
 ```mermaid
 flowchart TD

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -112,3 +112,4 @@ npx @chat-js/cli@latest create my-app
 - [Streamdown](https://streamdown.ai/) - Markdown for AI streaming
 - [AI Elements](https://ai-sdk.dev/elements/overview) - AI-native Components
 - [AI SDK Tools](https://ai-sdk-tools.dev/) - Developer tools for AI SDK
+- [`@chatjs/thread`](./core/use-thread) - Branching conversations with a `useChat`-compatible interface

--- a/apps/docs/reference/config.mdx
+++ b/apps/docs/reference/config.mdx
@@ -134,6 +134,8 @@ export type Config = {
   features: {
     /** File attachments (requires durable file storage) */
     attachments: boolean;
+    /** Generate multiple independent responses for one message */
+    parallelResponses: boolean;
   };
 
   pricing?: PricingConfig;
@@ -205,6 +207,7 @@ Feature flags live under `ai.tools`, `features`, and `authentication`. They're v
 ### Features
 
 - **`features.attachments`**: requires a configured file storage provider - file uploads (images and PDFs)
+- **`features.parallelResponses`**: no extra environment variables - generate multiple independent responses for one message
 
 ### Authentication
 

--- a/apps/docs/reference/config.mdx
+++ b/apps/docs/reference/config.mdx
@@ -128,13 +128,13 @@ export type Config = {
 
   /**
    * Feature flags.
-   * Set to true to enable - requires corresponding env vars.
+   * Set to true to enable. Some flags require corresponding env vars.
    * Validated at build time via scripts/check-env.ts.
    */
   features: {
     /** File attachments (requires durable file storage) */
     attachments: boolean;
-    /** Generate multiple independent responses for one message */
+    /** Generate multiple independent responses for one message. Defaults to true. */
     parallelResponses: boolean;
   };
 
@@ -207,7 +207,7 @@ Feature flags live under `ai.tools`, `features`, and `authentication`. They're v
 ### Features
 
 - **`features.attachments`**: requires a configured file storage provider - file uploads (images and PDFs)
-- **`features.parallelResponses`**: no extra environment variables - generate multiple independent responses for one message
+- **`features.parallelResponses`**: defaults to `true`. No extra environment variables. Generate multiple independent responses for one message.
 
 ### Authentication
 


### PR DESCRIPTION
## Summary
- Documents how ChatJS mounts `useThread` in its existing runtime slot.
- Explains branch navigation, parallel response grouping, first-message provisioning, and stopping.
- Keeps application persistence guidance out of the package architecture document.

## Behavior
Documentation only.

## Verification
- Docs lint passes at the stack tip.

## Review focus
Clarity of the app integration versus the reusable package architecture.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents ChatJS threaded conversations, parallel response runs, and race-safe stream cancellation behavior, and pins npm 11 in the CLI scaffold CI to avoid an arborist crash.

- Adds `/core/use-thread` with the `useChat`-compatible API, tree/cursor/active-path/run model, editing, controls, and snapshot persistence.
- Documents parallel response counts, reserved assistant nodes, acknowledgment-gated secondary runs, and `features.parallelResponses`.
- Updates branching, architecture, configuration, and reference docs, and links the guide from the navigation and index.
- Documents `stopStream` cancellation via `type: "request"` and `type: "message"` modes, including clearing `activeStreamId` and requiring `canceledAt IS NULL` during finalization.
- Pins npm to v11 in `cli-scaffold.yml` because npm 10 crashes resolving `vitest@^4` after Vitest 5.

<sup>Written for commit 597c0c26344be2c9b6ff25a8089d5065cb145990. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Document ChatJS threaded conversations, parallel response runs, and race-safe stream cancellation behavior.

New Features:
- Add user-facing documentation for the `useThread` React API, including branching, independent response runs, controls, and tree persistence.
- Document parallel response configuration and behavior across models and alternative replies.

Bug Fixes:
- Clarify resumable stream cancellation and finalization behavior to prevent canceled responses from being persisted during races.

Enhancements:
- Update architecture and branching documentation to describe cursor-based navigation and response runs that continue independently across branch switches.

Documentation:
- Link the new `useThread` guide from the documentation navigation, index, and related feature pages.
- Update branching, parallel response, architecture, configuration, and reference documentation to reflect current ChatJS behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added documentation for the `useThread` hook, covering branching conversations, message trees, parallel responses, controls, and persistence.
  - Updated architecture and branching guides to explain conversation paths, navigation, message editing, and independent response runs.
  - Expanded stop-stream guidance to cover cancelling persisted messages and unpublished requests.
  - Documented the `parallelResponses` configuration option, including its default, and added it to documentation navigation and the package overview.
  - Reworked parallel-response guidance with updated request flows, response cards, and current constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->