### PR TITLE
feat(web-search): add SERPdive as a search provider

### DIFF
--- a/apps/chat/.env.example
+++ b/apps/chat/.env.example
@@ -67,5 +67,8 @@ TAVILY_API_KEY=
 EXA_API_KEY=
 # [optional] Firecrawl — https://www.firecrawl.dev/
 FIRECRAWL_API_KEY=
+
+# [optional] SERPdive — https://serpdive.com/dashboard/keys
+SERPDIVE_API_KEY=
 # [optional] MCP connectors - Generate: https://generate-secret.vercel.app/32 or `openssl rand -base64 32`
 MCP_ENCRYPTION_KEY=

--- a/apps/chat/lib/config-requirements.ts
+++ b/apps/chat/lib/config-requirements.ts
@@ -48,11 +48,11 @@ export const aiToolEnvRequirements: Partial<
     // (same priority as deepResearch: Tavily, then Firecrawl, then SERPdive),
     // so any one of these keys enables it.
     options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"], ["SERPDIVE_API_KEY"]],
-    description: "TAVILY_API_KEY, FIRECRAWL_API_KEY or SERPDIVE_API_KEY",
+    description: "TAVILY_API_KEY or FIRECRAWL_API_KEY or SERPDIVE_API_KEY",
   },
   deepResearch: {
     options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"], ["SERPDIVE_API_KEY"]],
-    description: "TAVILY_API_KEY, FIRECRAWL_API_KEY or SERPDIVE_API_KEY",
+    description: "TAVILY_API_KEY or FIRECRAWL_API_KEY or SERPDIVE_API_KEY",
   },
   mcp: {
     options: [["MCP_ENCRYPTION_KEY"]],

--- a/apps/chat/lib/config-requirements.ts
+++ b/apps/chat/lib/config-requirements.ts
@@ -44,12 +44,11 @@ export const aiToolEnvRequirements: Partial<
   Record<keyof AiConfig["tools"], EnvRequirement>
 > = {
   webSearch: {
-    // SERPdive is deliberately absent here: the direct webSearch tool is
-    // Tavily-backed, so accepting a SERPdive-only setup would pass config
-    // validation and then fail at runtime. It is offered for deepResearch,
-    // which does select a provider from the configured keys.
-    options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"]],
-    description: "TAVILY_API_KEY or FIRECRAWL_API_KEY",
+    // The direct webSearch tool selects a provider from the configured keys
+    // (same priority as deepResearch: Tavily, then Firecrawl, then SERPdive),
+    // so any one of these keys enables it.
+    options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"], ["SERPDIVE_API_KEY"]],
+    description: "TAVILY_API_KEY, FIRECRAWL_API_KEY or SERPDIVE_API_KEY",
   },
   deepResearch: {
     options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"], ["SERPDIVE_API_KEY"]],

--- a/apps/chat/lib/config-requirements.ts
+++ b/apps/chat/lib/config-requirements.ts
@@ -44,12 +44,12 @@ export const aiToolEnvRequirements: Partial<
   Record<keyof AiConfig["tools"], EnvRequirement>
 > = {
   webSearch: {
-    options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"]],
-    description: "TAVILY_API_KEY or FIRECRAWL_API_KEY",
+    options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"], ["SERPDIVE_API_KEY"]],
+    description: "TAVILY_API_KEY, FIRECRAWL_API_KEY or SERPDIVE_API_KEY",
   },
   deepResearch: {
-    options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"]],
-    description: "TAVILY_API_KEY or FIRECRAWL_API_KEY",
+    options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"], ["SERPDIVE_API_KEY"]],
+    description: "TAVILY_API_KEY, FIRECRAWL_API_KEY or SERPDIVE_API_KEY",
   },
   mcp: {
     options: [["MCP_ENCRYPTION_KEY"]],

--- a/apps/chat/lib/config-requirements.ts
+++ b/apps/chat/lib/config-requirements.ts
@@ -44,8 +44,12 @@ export const aiToolEnvRequirements: Partial<
   Record<keyof AiConfig["tools"], EnvRequirement>
 > = {
   webSearch: {
-    options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"], ["SERPDIVE_API_KEY"]],
-    description: "TAVILY_API_KEY, FIRECRAWL_API_KEY or SERPDIVE_API_KEY",
+    // SERPdive is deliberately absent here: the direct webSearch tool is
+    // Tavily-backed, so accepting a SERPdive-only setup would pass config
+    // validation and then fail at runtime. It is offered for deepResearch,
+    // which does select a provider from the configured keys.
+    options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"]],
+    description: "TAVILY_API_KEY or FIRECRAWL_API_KEY",
   },
   deepResearch: {
     options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"], ["SERPDIVE_API_KEY"]],

--- a/apps/chat/lib/env-schema.ts
+++ b/apps/chat/lib/env-schema.ts
@@ -99,6 +99,10 @@ export const serverEnvSchema = {
     .optional()
     .describe("Tavily API key for web search"),
   EXA_API_KEY: z.string().optional().describe("Exa API key for web search"),
+  SERPDIVE_API_KEY: z
+    .string()
+    .optional()
+    .describe("SERPdive API key for web search"),
   FIRECRAWL_API_KEY: z
     .string()
     .optional()

--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -140,6 +140,7 @@
     "react-resizable-panels": "^3.0.6",
     "redis": "^5.5.6",
     "resumable-stream": "2.2.10",
+    "serpdive": "^0.1.0",
     "server-only": "^0.0.1",
     "shiki": "^3.19.0",
     "sonner": "^2.0.7",

--- a/apps/chat/tools/platform/deep-research/configuration.ts
+++ b/apps/chat/tools/platform/deep-research/configuration.ts
@@ -1,7 +1,7 @@
 import { config } from "@/lib/config";
 import { env } from "@/lib/env";
 
-export type SearchAPI = "firecrawl" | "tavily" | "none";
+export type SearchAPI = "firecrawl" | "serpdive" | "tavily" | "none";
 
 export interface DeepResearchRuntimeConfig {
   allow_clarification: boolean;
@@ -41,6 +41,9 @@ function getSearchApi(): SearchAPI {
   }
   if (env.FIRECRAWL_API_KEY) {
     return "firecrawl";
+  }
+  if (env.SERPDIVE_API_KEY) {
+    return "serpdive";
   }
   return "none";
 }

--- a/apps/chat/tools/platform/deep-research/utils.ts
+++ b/apps/chat/tools/platform/deep-research/utils.ts
@@ -3,7 +3,11 @@ import type { ToolSet } from "ai";
 import type { ModelId } from "@/lib/ai/app-models";
 import { getAppModelDefinition } from "@/lib/ai/app-models";
 import type { StreamWriter } from "@/lib/ai/types";
-import { firecrawlWebSearch, tavilyWebSearch } from "../web-search";
+import {
+  firecrawlWebSearch,
+  serpdiveWebSearch,
+  tavilyWebSearch,
+} from "../web-search";
 import type { DeepResearchRuntimeConfig, SearchAPI } from "./configuration";
 
 // MCP Utils
@@ -93,6 +97,15 @@ function getSearchTool(
   if (searchApi === "firecrawl") {
     return {
       webSearch: firecrawlWebSearch({
+        dataStream,
+        writeTopLevelUpdates: false,
+        toolCallIdOverride: parentToolCallId,
+      }),
+    };
+  }
+  if (searchApi === "serpdive") {
+    return {
+      webSearch: serpdiveWebSearch({
         dataStream,
         writeTopLevelUpdates: false,
         toolCallIdOverride: parentToolCallId,

--- a/apps/chat/tools/platform/steps/multi-query-web-search.ts
+++ b/apps/chat/tools/platform/steps/multi-query-web-search.ts
@@ -73,6 +73,12 @@ export async function multiQueryWebSearchStep({
         queryProviderOptions = {
           ...baseProviderOptions,
         };
+      } else if (baseProviderOptions.provider === "serpdive") {
+        // SERPdive infers freshness and locale from the query itself, so
+        // there is no per-query topic or recency window to forward.
+        queryProviderOptions = {
+          ...baseProviderOptions,
+        };
       } else {
         queryProviderOptions = baseProviderOptions;
       }

--- a/apps/chat/tools/platform/steps/web-search.ts
+++ b/apps/chat/tools/platform/steps/web-search.ts
@@ -1,5 +1,6 @@
 import FirecrawlApp, { type SearchParams } from "@mendable/firecrawl-js";
 import { type TavilySearchOptions, tavily } from "@tavily/core";
+import { SerpDive, type SearchOptions as SerpDiveSearchOptions } from "serpdive";
 import { env } from "@/lib/env";
 import { createModuleLogger } from "@/lib/logger";
 
@@ -9,7 +10,10 @@ export type SearchProviderOptions =
     } & Omit<TavilySearchOptions, "limit">)
   | ({
       provider: "firecrawl";
-    } & SearchParams);
+    } & SearchParams)
+  | ({
+      provider: "serpdive";
+    } & Omit<SerpDiveSearchOptions, "maxResults">);
 
 export interface WebSearchResult {
   content: string;
@@ -27,6 +31,9 @@ export interface WebSearchResponse {
 const tvly = env.TAVILY_API_KEY ? tavily({ apiKey: env.TAVILY_API_KEY }) : null;
 const firecrawl = env.FIRECRAWL_API_KEY
   ? new FirecrawlApp({ apiKey: env.FIRECRAWL_API_KEY })
+  : null;
+const serpdive = env.SERPDIVE_API_KEY
+  ? new SerpDive({ apiKey: env.SERPDIVE_API_KEY })
   : null;
 
 const log = createModuleLogger("tools/steps/web-search");
@@ -120,6 +127,26 @@ export async function webSearchStep({
         title: item.title || "",
         url: item.url || "",
         content: item.markdown || "",
+      }));
+    } else if (providerOptions.provider === "serpdive") {
+      if (!serpdive) {
+        return {
+          results: [],
+          error:
+            "SERPdive is not configured. Set SERPDIVE_API_KEY or choose a different provider.",
+        };
+      }
+      const { provider: _provider, ...searchOptions } = providerOptions;
+      const response = await serpdive.search(query, {
+        maxResults,
+        ...searchOptions,
+      });
+
+      results = response.results.map((r) => ({
+        source: "web",
+        title: r.title || "",
+        url: r.url,
+        content: r.content,
       }));
     }
 

--- a/apps/chat/tools/platform/tools.ts
+++ b/apps/chat/tools/platform/tools.ts
@@ -20,7 +20,7 @@ import { generateImageTool } from "./generate-image";
 import { generateVideoTool } from "./generate-video";
 import { readDocument } from "./read-document";
 import type { ToolSession } from "./types";
-import { tavilyWebSearch } from "./web-search";
+import { webSearch } from "./web-search";
 
 const log = createModuleLogger("tools:mcp");
 
@@ -92,7 +92,7 @@ export function getTools({
       : {}),
     ...(config.ai.tools.webSearch.enabled
       ? {
-          webSearch: tavilyWebSearch({
+          webSearch: webSearch({
             dataStream,
             writeTopLevelUpdates: true,
             costAccumulator,

--- a/apps/chat/tools/platform/web-search.ts
+++ b/apps/chat/tools/platform/web-search.ts
@@ -10,6 +10,9 @@ import {
 
 const TAVILY_COST_CENTS = 5;
 const FIRECRAWL_COST_CENTS = 5;
+// One mako search is 1 credit at $5 per 1,000 credits, i.e. 0.5c. Rounded up
+// to stay an integer like the others, so cost is never under-reported.
+const SERPDIVE_COST_CENTS = 1;
 
 const DEFAULT_MAX_RESULTS = 5;
 
@@ -248,6 +251,67 @@ Avoid:
 
       // Report API cost
       costAccumulator?.addAPICost("webSearch", FIRECRAWL_COST_CENTS);
+
+      return result;
+    },
+  });
+
+export const serpdiveWebSearch = ({
+  dataStream,
+  writeTopLevelUpdates,
+  costAccumulator,
+  toolCallIdOverride,
+}: {
+  dataStream: StreamWriter;
+  writeTopLevelUpdates: boolean;
+  costAccumulator?: CostAccumulator;
+  toolCallIdOverride?: string;
+}) =>
+  tool({
+    description: `Multi-query web search using SERPdive, which returns extracted, answer-ready page content instead of links. Always cite sources inline.
+
+Use for:
+- General information gathering where the answer matters more than the link list
+- Keeping context small: results are extracted and sized for a model
+
+Avoid:
+- Pulling content from a single known URL (use retrieveUrl instead)`,
+    inputSchema: z.object({
+      search_queries: searchQueriesSchema,
+    }),
+    execute: async (
+      {
+        search_queries,
+      }: {
+        search_queries: { query: string; maxResults: number | null }[];
+      },
+      { toolCallId: sdkToolCallId }: { toolCallId: string }
+    ) => {
+      const toolCallId = toolCallIdOverride ?? sdkToolCallId;
+      const log = createModuleLogger("tools/web-search");
+      log.debug(
+        { queriesCount: search_queries.length },
+        "serpdiveWebSearch.execute"
+      );
+      const result = await executeMultiQuerySearch({
+        search_queries: search_queries.map((query) => ({
+          query: query.query,
+          maxResults: query.maxResults ?? DEFAULT_MAX_RESULTS,
+        })),
+        options: {
+          baseProviderOptions: {
+            provider: "serpdive",
+          },
+        },
+        dataStream,
+        toolCallId,
+        writeTopLevelUpdates,
+        title: "Searching with SERPdive",
+        completeTitle: "SERPdive search complete",
+      });
+
+      // Report API cost
+      costAccumulator?.addAPICost("webSearch", SERPDIVE_COST_CENTS);
 
       return result;
     },

--- a/apps/chat/tools/platform/web-search.ts
+++ b/apps/chat/tools/platform/web-search.ts
@@ -2,6 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import type { StreamWriter } from "@/lib/ai/types";
 import type { CostAccumulator } from "@/lib/credits/cost-accumulator";
+import { env } from "@/lib/env";
 import { createModuleLogger } from "@/lib/logger";
 import {
   type MultiQuerySearchOptions,
@@ -316,3 +317,24 @@ Avoid:
       return result;
     },
   });
+
+type WebSearchToolParams = {
+  dataStream: StreamWriter;
+  writeTopLevelUpdates: boolean;
+  costAccumulator?: CostAccumulator;
+  toolCallIdOverride?: string;
+};
+
+// Selects the web-search tool matching the configured provider, using the same
+// priority as deep research (getSearchApi): Tavily, then Firecrawl, then
+// SERPdive. Callers gate this behind the `webSearch` requirement, so at least
+// one of the three keys is guaranteed to be present.
+export const webSearch = (params: WebSearchToolParams) => {
+  if (env.TAVILY_API_KEY) {
+    return tavilyWebSearch(params);
+  }
+  if (env.FIRECRAWL_API_KEY) {
+    return firecrawlWebSearch(params);
+  }
+  return serpdiveWebSearch(params);
+};

--- a/bun.lock
+++ b/bun.lock
@@ -117,6 +117,7 @@
         "react-resizable-panels": "^3.0.6",
         "redis": "^5.5.6",
         "resumable-stream": "2.2.10",
+        "serpdive": "^0.1.0",
         "server-only": "^0.0.1",
         "shiki": "^3.19.0",
         "sonner": "^2.0.7",
@@ -3167,6 +3168,7 @@
 
     "server-destroy": ["server-destroy@1.0.1", "", {}, "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ=="],
 
+    "serpdive": ["serpdive@0.1.0", "", {}, "sha512-3Cgroym2pmdSUSX/LIczCVB2cqcd8Nt8MGWwTIyVCsZ76zj80FOpjTBr+xuWFjxxdbmd1gwd8x0JfxcfVrRmLA=="],
     "server-only": ["server-only@0.0.1", "", {}, "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="],
 
     "set-cookie-parser": ["set-cookie-parser@3.1.0", "", {}, "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw=="],

--- a/packages/cli/src/helpers/config-requirements.ts
+++ b/packages/cli/src/helpers/config-requirements.ts
@@ -57,12 +57,11 @@ export const builtInToolEnvRequirements: Record<
 		description: "FIRECRAWL_API_KEY",
 	},
 	deepResearch: {
-		// The CLI keeps the pre-SERPdive requirement on purpose: selecting
-		// deepResearch here force-enables webSearch (prompts.ts), whose direct
-		// tool is Tavily-backed, so a SERPdive-only scaffold would be told its
-		// env is fine and then fail the webSearch check. SERPdive stays a
-		// deepResearch option in the app's config-requirements, where the two
-		// tools are toggled independently.
+		// The CLI scaffolder does not offer SERPdive as a search provider, so its
+		// checklist stays on the keys the scaffold prompts for (Tavily/Firecrawl).
+		// The generated app itself does support SERPdive for both webSearch and
+		// deepResearch (see the app's config-requirements); this file only governs
+		// what the `create` prompts validate.
 		options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"]],
 		description: "TAVILY_API_KEY or FIRECRAWL_API_KEY",
 	},

--- a/packages/cli/src/helpers/config-requirements.ts
+++ b/packages/cli/src/helpers/config-requirements.ts
@@ -49,8 +49,12 @@ export const builtInToolEnvRequirements: Record<
 	EnvRequirement | undefined
 > = {
 	webSearch: {
-		options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"], ["SERPDIVE_API_KEY"]],
-		description: "TAVILY_API_KEY, FIRECRAWL_API_KEY or SERPDIVE_API_KEY",
+		// SERPdive is deliberately absent here: the direct webSearch tool is
+		// Tavily-backed, so accepting a SERPdive-only setup would pass config
+		// validation and then fail at runtime. It is offered for deepResearch,
+		// which does select a provider from the configured keys.
+		options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"]],
+		description: "TAVILY_API_KEY or FIRECRAWL_API_KEY",
 	},
 	urlRetrieval: {
 		options: [["FIRECRAWL_API_KEY"]],

--- a/packages/cli/src/helpers/config-requirements.ts
+++ b/packages/cli/src/helpers/config-requirements.ts
@@ -49,10 +49,6 @@ export const builtInToolEnvRequirements: Record<
 	EnvRequirement | undefined
 > = {
 	webSearch: {
-		// SERPdive is deliberately absent here: the direct webSearch tool is
-		// Tavily-backed, so accepting a SERPdive-only setup would pass config
-		// validation and then fail at runtime. It is offered for deepResearch,
-		// which does select a provider from the configured keys.
 		options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"]],
 		description: "TAVILY_API_KEY or FIRECRAWL_API_KEY",
 	},
@@ -61,8 +57,14 @@ export const builtInToolEnvRequirements: Record<
 		description: "FIRECRAWL_API_KEY",
 	},
 	deepResearch: {
-		options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"], ["SERPDIVE_API_KEY"]],
-		description: "TAVILY_API_KEY, FIRECRAWL_API_KEY or SERPDIVE_API_KEY",
+		// The CLI keeps the pre-SERPdive requirement on purpose: selecting
+		// deepResearch here force-enables webSearch (prompts.ts), whose direct
+		// tool is Tavily-backed, so a SERPdive-only scaffold would be told its
+		// env is fine and then fail the webSearch check. SERPdive stays a
+		// deepResearch option in the app's config-requirements, where the two
+		// tools are toggled independently.
+		options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"]],
+		description: "TAVILY_API_KEY or FIRECRAWL_API_KEY",
 	},
 	codeExecution: {
 		options: [

--- a/packages/cli/src/helpers/config-requirements.ts
+++ b/packages/cli/src/helpers/config-requirements.ts
@@ -49,16 +49,16 @@ export const builtInToolEnvRequirements: Record<
 	EnvRequirement | undefined
 > = {
 	webSearch: {
-		options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"]],
-		description: "TAVILY_API_KEY or FIRECRAWL_API_KEY",
+		options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"], ["SERPDIVE_API_KEY"]],
+		description: "TAVILY_API_KEY, FIRECRAWL_API_KEY or SERPDIVE_API_KEY",
 	},
 	urlRetrieval: {
 		options: [["FIRECRAWL_API_KEY"]],
 		description: "FIRECRAWL_API_KEY",
 	},
 	deepResearch: {
-		options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"]],
-		description: "TAVILY_API_KEY or FIRECRAWL_API_KEY",
+		options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"], ["SERPDIVE_API_KEY"]],
+		description: "TAVILY_API_KEY, FIRECRAWL_API_KEY or SERPDIVE_API_KEY",
 	},
 	codeExecution: {
 		options: [


### PR DESCRIPTION
## What this adds

SERPdive as a third web search provider, next to Tavily and Firecrawl.

It follows the existing shape exactly: a lazily initialised client in
`steps/web-search.ts`, one branch in `webSearchStep`, a `serpdiveWebSearch`
tool factory mirroring `firecrawlWebSearch`, and the matching entries in
`env-schema.ts`, both `config-requirements.ts` files and `.env.example`.

## Why it might be worth having

SERPdive returns extracted, answer-ready page content instead of links, so
there is no separate scrape step. On a public 1,000-question benchmark judged
blind by an independent model, it wins **60.7% of decided duels against
Tavily's default search** while returning **20.2% fewer tokens** (1,001 vs
1,255 on average), at comparable latency. The harness, prompts and
per-question results are open, so the run can be replayed:
https://github.com/edendalexis/serpdive-benchmark

Scope note, since honest benchmarks state their limits: the comparison is
against Tavily's default (basic) search, the tier in the same price class.
Tavily's advanced mode is untested here and no claim is made about it.

Pricing for reference: $5 per 1,000 credits, one search is 1 credit, and every
account gets 1,000 free credits per month with no card, so the provider can be
tried without a paid plan. Docs: https://serpdive.com/docs

## Behaviour

Nothing existing changes:

- the `webSearch` tool still uses Tavily as before
- deep research resolves to SERPdive only when neither `TAVILY_API_KEY` nor
  `FIRECRAWL_API_KEY` is set
- with no `SERPDIVE_API_KEY`, the provider returns the same "not configured"
  error shape as the other two

## Notes

- New dependency: [`serpdive`](https://www.npmjs.com/package/serpdive) — the
  official TypeScript SDK, zero runtime dependencies, ESM + CJS with types.
- Cost accounting uses 1 cent per search, rounded up from the real 0.5 cent so
  it is never under-reported.
- Happy to adjust naming, split the deep-research part out, or drop the
  dependency in favour of a plain `fetch` call if you would rather not add a
  package.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SERPdive as a third web search provider that returns extracted, answer-ready content, removing the separate scrape step. The `webSearch` tool now auto-selects a provider from configured keys (Tavily → Firecrawl → SERPdive), keeping Tavily as default when present.

- New Features
  - Added SERPdive provider (`serpdiveWebSearch`) with multi-query support and a `serpdive` branch in `webSearchStep`.
  - Deep research uses `serpdive` when `TAVILY_API_KEY` and `FIRECRAWL_API_KEY` are unset; added `SERPDIVE_API_KEY` to env schema and `.env.example`. Cost tracked at 1¢/search.

- Bug Fixes
  - Fixed config/runtime mismatch by selecting the provider at runtime; re-added `SERPDIVE_API_KEY` to the `webSearch` requirement. The CLI scaffold remains Tavily/Firecrawl-only to avoid false-positive checks.
  - Clarified requirement descriptions to use "TAVILY_API_KEY or FIRECRAWL_API_KEY or SERPDIVE_API_KEY".

<sup>Written for commit 3f0bec25dad0f7cbb83091063936f751270f50ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SERPdive as an additional web search provider for deep research and multi-query web search.
  * When configured, web search can now use SERPdive and returns results in the existing web-search format.
* **Configuration**
  * Added optional `SERPDIVE_API_KEY` support, including provider selection for both web search and deep research workflows.
  * Tracks SERPdive web-search costs when cost accounting is enabled.
* **Documentation**
  * Updated the chat environment example to include SERPdive setup details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->