### PR TITLE
Threads 14: Add cancellable request gates

### DIFF
--- a/apps/chat/lib/gated-chat-transport.test.ts
+++ b/apps/chat/lib/gated-chat-transport.test.ts
@@ -72,4 +72,44 @@ describe("createGatedChatTransport", () => {
     await assert.rejects(request, { name: "AbortError" });
     assert.equal(sendMessages.mock.calls.length, 0);
   });
+
+  it("does not forward a request when its gate rejects", async () => {
+    const gateError = new Error("User message was not persisted");
+    const sendMessages = vi.fn(() =>
+      Promise.resolve(new ReadableStream<UIMessageChunk>())
+    );
+    const transport = createGatedChatTransport<UIMessage>({
+      reconnectToStream: async () => null,
+      sendMessages,
+    });
+
+    const request = transport.sendMessages(
+      requestOptions(gateChatRequest(Promise.reject(gateError)).metadata)
+    );
+
+    await assert.rejects(request, gateError);
+    assert.equal(sendMessages.mock.calls.length, 0);
+  });
+
+  it("does not forward a request that was already stopped", async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+    const sendMessages = vi.fn(() =>
+      Promise.resolve(new ReadableStream<UIMessageChunk>())
+    );
+    const transport = createGatedChatTransport<UIMessage>({
+      reconnectToStream: async () => null,
+      sendMessages,
+    });
+
+    const request = transport.sendMessages(
+      requestOptions(
+        gateChatRequest(Promise.resolve()).metadata,
+        abortController.signal
+      )
+    );
+
+    await assert.rejects(request, { name: "AbortError" });
+    assert.equal(sendMessages.mock.calls.length, 0);
+  });
 });

--- a/apps/chat/lib/gated-chat-transport.test.ts
+++ b/apps/chat/lib/gated-chat-transport.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import type { ChatTransport, UIMessage, UIMessageChunk } from "ai";
+import { describe, it, vi } from "vitest";
+import {
+  createGatedChatTransport,
+  gateChatRequest,
+} from "./gated-chat-transport";
+
+function requestOptions(
+  metadata: unknown,
+  abortSignal?: AbortSignal
+): Parameters<ChatTransport<UIMessage>["sendMessages"]>[0] {
+  return {
+    abortSignal,
+    chatId: "chat-1",
+    messageId: undefined,
+    messages: [],
+    metadata,
+    trigger: "submit-message",
+  };
+}
+
+describe("createGatedChatTransport", () => {
+  it("waits before forwarding a request and restores its metadata", async () => {
+    let release: () => void = () => undefined;
+    const ready = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const stream = new ReadableStream<UIMessageChunk>();
+    let forwardedMetadata: unknown;
+    const sendMessages = vi.fn(
+      (options: Parameters<ChatTransport<UIMessage>["sendMessages"]>[0]) => {
+        forwardedMetadata = options.metadata;
+        return Promise.resolve(stream);
+      }
+    );
+    const transport = createGatedChatTransport<UIMessage>({
+      reconnectToStream: async () => null,
+      sendMessages,
+    });
+    const originalMetadata = { source: "secondary" };
+
+    const request = transport.sendMessages(
+      requestOptions(gateChatRequest(ready, originalMetadata).metadata)
+    );
+
+    await Promise.resolve();
+    assert.equal(sendMessages.mock.calls.length, 0);
+
+    release();
+    assert.equal(await request, stream);
+    assert.equal(sendMessages.mock.calls.length, 1);
+    assert.equal(forwardedMetadata, originalMetadata);
+  });
+
+  it("does not forward a request stopped while waiting", async () => {
+    const ready = new Promise<void>(() => undefined);
+    const sendMessages = vi.fn(() =>
+      Promise.resolve(new ReadableStream<UIMessageChunk>())
+    );
+    const transport = createGatedChatTransport<UIMessage>({
+      reconnectToStream: async () => null,
+      sendMessages,
+    });
+    const abortController = new AbortController();
+    const request = transport.sendMessages(
+      requestOptions(gateChatRequest(ready).metadata, abortController.signal)
+    );
+
+    abortController.abort();
+
+    await assert.rejects(request, { name: "AbortError" });
+    assert.equal(sendMessages.mock.calls.length, 0);
+  });
+});

--- a/apps/chat/lib/gated-chat-transport.ts
+++ b/apps/chat/lib/gated-chat-transport.ts
@@ -1,0 +1,57 @@
+import type { ChatRequestOptions, ChatTransport, UIMessage } from "ai";
+
+type GateEntry = {
+  metadata: unknown;
+  ready: Promise<void>;
+};
+
+const gateEntries = new WeakMap<object, GateEntry>();
+
+function waitForGate(ready: Promise<void>, signal?: AbortSignal) {
+  if (!signal) {
+    return ready;
+  }
+  if (signal.aborted) {
+    return Promise.reject(new DOMException("Aborted", "AbortError"));
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    const abort = () => reject(new DOMException("Aborted", "AbortError"));
+    signal.addEventListener("abort", abort, { once: true });
+    ready.then(resolve, reject).finally(() => {
+      signal.removeEventListener("abort", abort);
+    });
+  });
+}
+
+export function gateChatRequest(
+  ready: Promise<void>,
+  metadata?: unknown
+): Pick<ChatRequestOptions, "metadata"> {
+  const token = {};
+  gateEntries.set(token, { metadata, ready });
+  return { metadata: token };
+}
+
+export function createGatedChatTransport<TMessage extends UIMessage>(
+  transport: ChatTransport<TMessage>
+): ChatTransport<TMessage> {
+  return {
+    reconnectToStream: (options) => transport.reconnectToStream(options),
+    sendMessages: async (options) => {
+      const gate =
+        typeof options.metadata === "object" && options.metadata !== null
+          ? gateEntries.get(options.metadata)
+          : undefined;
+      if (!gate) {
+        return transport.sendMessages(options);
+      }
+
+      await waitForGate(gate.ready, options.abortSignal);
+      return transport.sendMessages({
+        ...options,
+        metadata: gate.metadata,
+      });
+    },
+  };
+}

--- a/apps/chat/lib/gated-chat-transport.ts
+++ b/apps/chat/lib/gated-chat-transport.ts
@@ -7,20 +7,33 @@ type GateEntry = {
 
 const gateEntries = new WeakMap<object, GateEntry>();
 
+function createAbortError() {
+  return new DOMException("Aborted", "AbortError");
+}
+
 function waitForGate(ready: Promise<void>, signal?: AbortSignal) {
   if (!signal) {
     return ready;
   }
   if (signal.aborted) {
-    return Promise.reject(new DOMException("Aborted", "AbortError"));
+    ready.catch(() => undefined);
+    return Promise.reject(createAbortError());
   }
 
   return new Promise<void>((resolve, reject) => {
-    const abort = () => reject(new DOMException("Aborted", "AbortError"));
+    const abort = () => reject(createAbortError());
+    const cleanup = () => signal.removeEventListener("abort", abort);
     signal.addEventListener("abort", abort, { once: true });
-    ready.then(resolve, reject).finally(() => {
-      signal.removeEventListener("abort", abort);
-    });
+    ready.then(
+      () => {
+        cleanup();
+        resolve();
+      },
+      (error: unknown) => {
+        cleanup();
+        reject(error);
+      }
+    );
   });
 }
 
@@ -48,6 +61,9 @@ export function createGatedChatTransport<TMessage extends UIMessage>(
       }
 
       await waitForGate(gate.ready, options.abortSignal);
+      if (options.abortSignal?.aborted) {
+        throw createAbortError();
+      }
       return transport.sendMessages({
         ...options,
         metadata: gate.metadata,

--- a/apps/chat/lib/provisional-chat-confirmations.test.ts
+++ b/apps/chat/lib/provisional-chat-confirmations.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "vitest";
+import {
+  acknowledgeProvisionalUserMessagePersistence,
+  claimConfirmedProvisionalChat,
+  clearProvisionalChatConfirmations,
+  registerProvisionalChatConfirmation,
+} from "./provisional-chat-confirmations";
+
+describe("provisional chat confirmations", () => {
+  afterEach(clearProvisionalChatConfirmations);
+
+  it("releases only after the expected user message and group are persisted", () => {
+    registerProvisionalChatConfirmation("chat-1", {
+      parallelGroupId: "group-1",
+      userMessageId: "user-1",
+    });
+
+    assert.equal(claimConfirmedProvisionalChat("chat-1"), false);
+    assert.equal(
+      acknowledgeProvisionalUserMessagePersistence({
+        chatId: "chat-1",
+        parallelGroupId: "wrong-group",
+        userMessageId: "user-1",
+      }),
+      false
+    );
+    assert.equal(claimConfirmedProvisionalChat("chat-1"), false);
+
+    assert.equal(
+      acknowledgeProvisionalUserMessagePersistence({
+        chatId: "chat-1",
+        parallelGroupId: "group-1",
+        userMessageId: "user-1",
+      }),
+      true
+    );
+    assert.equal(claimConfirmedProvisionalChat("chat-1"), true);
+    assert.equal(claimConfirmedProvisionalChat("chat-1"), false);
+  });
+});

--- a/apps/chat/lib/provisional-chat-confirmations.test.ts
+++ b/apps/chat/lib/provisional-chat-confirmations.test.ts
@@ -26,6 +26,15 @@ describe("provisional chat confirmations", () => {
       false
     );
     assert.equal(claimConfirmedProvisionalChat("chat-1"), false);
+    assert.equal(
+      acknowledgeProvisionalUserMessagePersistence({
+        chatId: "chat-1",
+        parallelGroupId: "group-1",
+        userMessageId: "wrong-user",
+      }),
+      false
+    );
+    assert.equal(claimConfirmedProvisionalChat("chat-1"), false);
 
     assert.equal(
       acknowledgeProvisionalUserMessagePersistence({

--- a/apps/chat/lib/provisional-chat-confirmations.ts
+++ b/apps/chat/lib/provisional-chat-confirmations.ts
@@ -1,0 +1,52 @@
+interface UserMessagePersistenceAcknowledgment {
+  chatId: string;
+  parallelGroupId: string | null;
+  userMessageId: string;
+}
+
+interface ProvisionalChatConfirmation {
+  acknowledged: boolean;
+  parallelGroupId: string | null;
+  userMessageId: string;
+}
+
+const pendingConfirmations = new Map<string, ProvisionalChatConfirmation>();
+
+export function registerProvisionalChatConfirmation(
+  chatId: string,
+  confirmation: Omit<ProvisionalChatConfirmation, "acknowledged">
+) {
+  pendingConfirmations.set(chatId, {
+    ...confirmation,
+    acknowledged: false,
+  });
+}
+
+export function acknowledgeProvisionalUserMessagePersistence(
+  acknowledgment: UserMessagePersistenceAcknowledgment
+) {
+  const entry = pendingConfirmations.get(acknowledgment.chatId);
+  if (
+    !entry ||
+    entry.userMessageId !== acknowledgment.userMessageId ||
+    entry.parallelGroupId !== acknowledgment.parallelGroupId
+  ) {
+    return false;
+  }
+
+  entry.acknowledged = true;
+  return true;
+}
+
+export function claimConfirmedProvisionalChat(chatId: string) {
+  const entry = pendingConfirmations.get(chatId);
+  if (!entry?.acknowledged) {
+    return false;
+  }
+  pendingConfirmations.delete(chatId);
+  return true;
+}
+
+export function clearProvisionalChatConfirmations() {
+  pendingConfirmations.clear();
+}


### PR DESCRIPTION
## Summary

- add a transport wrapper that delays requests behind an abort-aware promise
- preserve the original request metadata after a gate opens
- add provisional persistence confirmation primitives
- cover release, rejection, cancellation, and confirmation identity matching

This PR contains no chat-flow integration. It isolates the synchronization primitives used by the next PR.

## Summary by Sourcery

Introduce standalone synchronization primitives for cancellable chat request gating and provisional persistence confirmations.

New Features:
- Add abort-aware chat request gates that delay forwarding until readiness and restore original request metadata when released.
- Add provisional chat persistence confirmation primitives with identity matching and single-use claims.

Enhancements:
- Preserve reconnect-to-stream behavior while isolating synchronization primitives for future chat-flow integration.

Tests:
- Add coverage for gated request release, metadata restoration, cancellation, persistence confirmation matching, and single-use claims.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds abort-aware request gates to the `ai` chat transport. Previously `sendMessages` forwarded requests immediately; now gated requests wait for readiness or abort without calling the transport.

- Opt in via `gateChatRequest(ready, metadata?)` and `createGatedChatTransport`; gates use a metadata token, restore the original metadata on release, and leave `reconnectToStream` unchanged.
- Waiting respects `AbortSignal`: aborted requests reject with `AbortError`.
- Adds provisional persistence confirmations: `registerProvisionalChatConfirmation`, `acknowledgeProvisionalUserMessagePersistence`, single-use `claimConfirmedProvisionalChat`, and `clearProvisionalChatConfirmations`; acknowledgment must match `chatId`, `userMessageId`, and nullable `parallelGroupId`.
- No chat-flow integration yet; this isolates the primitives for the next PR.

<sup>Written for commit 2ff16a527d57ae8b1c79920dca8d0ba5c2688647. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for temporarily holding chat requests until required readiness conditions are met.
  - Preserves request details and handles cancellations while requests are waiting.
  - Added provisional chat confirmation tracking to ensure messages are persisted before chats become available.
  - Prevents chats from being released until matching persistence confirmations are received.

- **Tests**
  - Added coverage for gated requests, cancellation behavior, rejected requests, and provisional confirmation validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->