### PR TITLE
fix(chat): stop sibling-switch user-message flicker

### DIFF
--- a/apps/chat/lib/stores/with-thread-state.ts
+++ b/apps/chat/lib/stores/with-thread-state.ts
@@ -16,6 +16,19 @@ export type ThreadStateStore<TMessage extends UIMessage> =
     ) => void;
   };
 
+function haveSelectedPathIdsChanged<TMessage extends { id: string }>(
+  previous: TMessage[] | null | undefined,
+  next: TMessage[]
+): boolean {
+  const previousMessages = previous ?? [];
+  if (previousMessages.length !== next.length) {
+    return true;
+  }
+  return previousMessages.some(
+    (message, index) => message.id !== next[index]?.id
+  );
+}
+
 export const withThreadState =
   <TMessage extends UIMessage, TState extends BaseChatStoreState<TMessage>>(
     creator: StateCreator<TState, [], []>,
@@ -37,8 +50,17 @@ export const withThreadState =
       status: threadSnapshot.status,
       threadSnapshot,
       updateThreadSnapshot: (updater) => {
+        let didChangeSelectedPath = false;
         set((state) => {
           const threadSnapshot = updater(state.threadSnapshot);
+          // Sibling switches change the rendered ids. Flush throttled
+          // messages in the same update so UserMessage can still resolve
+          // the ids it is currently rendering; otherwise it returns null
+          // and the assistant jumps up for a frame.
+          didChangeSelectedPath = haveSelectedPathIdsChanged(
+            state._throttledMessages ?? state.messages,
+            threadSnapshot.messages
+          );
           state._messageIndex.update(threadSnapshot.messages);
 
           return {
@@ -48,9 +70,14 @@ export const withThreadState =
             messages: threadSnapshot.messages,
             status: threadSnapshot.status,
             threadSnapshot,
+            ...(didChangeSelectedPath
+              ? { _throttledMessages: threadSnapshot.messages }
+              : {}),
           };
         });
-        get()._scheduleThrottledMessagesUpdate();
+        if (!didChangeSelectedPath) {
+          get()._scheduleThrottledMessagesUpdate();
+        }
       },
     };
   };

--- a/apps/chat/lib/stores/zustand-thread-state.test.ts
+++ b/apps/chat/lib/stores/zustand-thread-state.test.ts
@@ -1,5 +1,5 @@
 import type { UIMessage } from "ai";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ChatMessage } from "@/lib/ai/types";
 import { ApplicationThread } from "@/lib/application-thread";
 import { createCustomChatStore } from "./custom-store-provider";
@@ -149,5 +149,84 @@ describe("ZustandThreadState", () => {
     expect(store.getState().threadSnapshot.messages).toBe(
       store.getState().messages
     );
+  });
+
+  describe("selected path rendering", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("keeps rendered message ids resolvable when switching user siblings", () => {
+      vi.useFakeTimers();
+      const userA = chatMessage("user-a", "A");
+      const assistantA = chatMessage("assistant-a", "Reply A", "assistant");
+      const userB = chatMessage("user-b", "B");
+      const assistantB = chatMessage("assistant-b", "Reply B", "assistant");
+      const store = createCustomChatStore<ChatMessage>([userA]);
+      const thread = new ApplicationThread({
+        id: "chat-1",
+        state: new ZustandThreadState(store),
+      });
+
+      thread.addMessage(assistantA, userA.id);
+      thread.addMessage(userB, null);
+      thread.addMessage(assistantB, userB.id);
+      thread.setCursor(assistantA.id);
+      vi.advanceTimersByTime(50);
+      store.getState()._scheduleThrottledMessagesUpdate();
+
+      expect(store.getState().getMessageIds()).toEqual([
+        userA.id,
+        assistantA.id,
+      ]);
+
+      thread.setCursor(assistantB.id);
+
+      const renderedIds = store.getState().getMessageIds();
+      expect(renderedIds).toEqual([userB.id, assistantB.id]);
+      for (const id of renderedIds) {
+        expect(store.getState().getMessageById(id)?.id).toBe(id);
+      }
+      expect(
+        store.getState()._throttledMessages?.map((message) => message.id)
+      ).toEqual(renderedIds);
+    });
+
+    it("still throttles in-place streaming updates", () => {
+      vi.useFakeTimers();
+      const user = chatMessage("user-1", "Hello");
+      const assistant = chatMessage("assistant-1", "Hi", "assistant");
+      const store = createCustomChatStore<ChatMessage>([user]);
+      const thread = new ApplicationThread({
+        id: "chat-1",
+        state: new ZustandThreadState(store),
+      });
+
+      thread.addMessage(assistant, user.id);
+      thread.setCursor(assistant.id);
+      vi.advanceTimersByTime(50);
+      store.getState()._scheduleThrottledMessagesUpdate();
+
+      thread.upsertMessage(
+        chatMessage("assistant-1", "Hi there", "assistant"),
+        user.id
+      );
+
+      expect(store.getState().messages.at(-1)?.parts[0]).toEqual({
+        text: "Hi there",
+        type: "text",
+      });
+      expect(store.getState()._throttledMessages?.at(-1)?.parts[0]).toEqual({
+        text: "Hi",
+        type: "text",
+      });
+
+      vi.advanceTimersByTime(50);
+
+      expect(store.getState()._throttledMessages?.at(-1)?.parts[0]).toEqual({
+        text: "Hi there",
+        type: "text",
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Flush `_throttledMessages` in the same Zustand update when the selected path ids change (sibling navigation, new messages).
- Keeps the rendered id list aligned with the message index so `UserMessage` does not return `null` for a frame and shove the assistant up.

## Test plan
- [x] `bun vitest run lib/stores/zustand-thread-state.test.ts`
- [x] `bun lint` on the changed files
- [x] `bun test:types` in `apps/chat`
- [ ] In the chat UI, create user-message siblings (edit + resend), switch 1/2 ↔ 2/2, and confirm the assistant does not jump up as if the user bubble was missing


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Keep selected thread rendering synchronized during sibling navigation without disrupting throttled streaming updates.

Bug Fixes:
- Prevent user-message flicker and assistant repositioning when navigating between sibling message paths.
- Keep rendered message identifiers synchronized with the selected thread path during navigation and new-message updates.

Tests:
- Add coverage for sibling-path rendering consistency and preservation of throttled streaming updates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes user-message flicker when switching sibling message paths so the assistant bubble no longer jumps while the UI updates.

- Flushes throttled streaming updates in the same Zustand update that selects a sibling path, keeping rendered message ids aligned with the message index.

<sup>Written for commit 227014e212713c1e7c594cf5687e260b6cc8b1de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message rendering when switching between sibling conversation branches, ensuring currently displayed messages remain available.
  - Preserved throttling behavior for in-place streaming updates.
- **Tests**
  - Added coverage for branch switching and streamed message updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->