### PR TITLE
fix(release): publish @chatjs/thread after OIDC first-publish failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,8 @@ jobs:
           echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
 
       - name: Create Release Pull Request or Publish
+        id: changesets
+        continue-on-error: true
         uses: changesets/action@v1
         with:
           publish: bun run release
@@ -48,3 +50,56 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+
+      # Trusted publishing cannot create a package's first version, and it is
+      # only configured for @chat-js/cli today. Finish any unpublished packages
+      # with the classic token so a partial Changesets publish cannot leave
+      # @chatjs/thread (or similar first releases) off npm.
+      - name: Publish first-time packages
+        if: always() && (steps.changesets.outcome == 'success' || steps.changesets.outcome == 'failure')
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: false
+        run: |
+          set -euo pipefail
+          printf '//registry.npmjs.org/:_authToken=%s\n' "$NODE_AUTH_TOKEN" > "$HOME/.npmrc"
+
+          publish_if_missing() {
+            local workspace_dir="$1"
+            local name version tag
+            name="$(node -p "require('./${workspace_dir}/package.json').name")"
+            version="$(node -p "require('./${workspace_dir}/package.json').version")"
+            tag="${name}@${version}"
+
+            if npm view "${name}@${version}" version >/dev/null 2>&1; then
+              echo "${tag} already on npm"
+              return 0
+            fi
+
+            echo "Publishing ${tag} (first publish cannot use OIDC)"
+            bun --filter "${name}" build
+            npm publish --workspace "${name}" --access public --no-provenance
+
+            if git rev-parse "${tag}" >/dev/null 2>&1; then
+              echo "tag ${tag} already exists"
+            else
+              git tag "${tag}"
+              git push origin "${tag}"
+            fi
+
+            if gh release view "${tag}" >/dev/null 2>&1; then
+              echo "GitHub release ${tag} already exists"
+            else
+              gh release create "${tag}" --title "${tag}" --notes-file "${workspace_dir}/CHANGELOG.md"
+            fi
+          }
+
+          publish_if_missing packages/thread
+
+      - name: Confirm thread package published
+        if: always() && (steps.changesets.outcome == 'success' || steps.changesets.outcome == 'failure')
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./packages/thread/package.json').version")"
+          npm view "@chatjs/thread@${version}" version

--- a/packages/thread/package.json
+++ b/packages/thread/package.json
@@ -5,7 +5,7 @@
 	"license": "Apache-2.0",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/franciscomoretti/chat-js.git",
+		"url": "git+https://github.com/FranciscoMoretti/chat-js.git",
 		"directory": "packages/thread"
 	},
 	"homepage": "https://github.com/franciscomoretti/chat-js/tree/main/packages/thread",


### PR DESCRIPTION
## Summary
- `@chat-js/cli@0.8.0` already published via trusted publishing from #271.
- `@chatjs/thread@0.1.0` cannot be created with OIDC (no trusted publisher on a package that does not exist yet). Finish that first publish with `NPM_TOKEN`, then tag/release.
- Align the thread `repository.url` with the other public packages so later OIDC publishes can match the GitHub repo.

## Test plan
- [x] Confirm `@chat-js/cli@0.8.0` is on npm and includes Instant Navigations + the sibling-switch flush.
- [ ] After merge, Release workflow publishes `@chatjs/thread@0.1.0`.
- [ ] `npm view @chatjs/thread version` is `0.1.0`.


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Complete first-time package releases when OIDC publishing fails, while keeping subsequent releases compatible with trusted publishing.

New Features:
- Add a fallback workflow to publish previously unpublished packages with an npm token and create their associated tags and releases.

Bug Fixes:
- Ensure first-time package publication completes when trusted publishing cannot create the initial npm version.
- Verify that the thread package is available on npm after the release workflow runs.

Enhancements:
- Align the thread package repository metadata with the repository format used by the other public packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release workflow so first-time package publications complete when trusted publishing (OIDC) can't create the initial version. The workflow now falls back to a classic npm token for packages not yet on npm, then creates tags and releases. Also aligns the thread package's repository URL with the other packages.

<sup>Written for commit f36156fbf48fc5f75fffda02032d39c91c37884e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Improvements**
  - Automated publishing now supports first-time releases of the thread package.
  - Published versions are verified on npm, with corresponding Git tags and GitHub releases created from the changelog.
  - Release workflows continue safely when a package is already published.

- **Chores**
  - Updated the thread package’s repository metadata for improved source linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->