### PR TITLE
fix(thread): publish @chat-js/thread under the owned npm scope

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
       # Trusted publishing cannot create a package's first version, and it is
       # only configured for @chat-js/cli today. Finish any unpublished packages
       # with the classic token so a partial Changesets publish cannot leave
-      # @chatjs/thread (or similar first releases) off npm.
+      # @chat-js/thread (or similar first releases) off npm.
       - name: Publish first-time packages
         if: always() && (steps.changesets.outcome == 'success' || steps.changesets.outcome == 'failure')
         env:
@@ -101,5 +101,6 @@ jobs:
         if: always() && (steps.changesets.outcome == 'success' || steps.changesets.outcome == 'failure')
         run: |
           set -euo pipefail
+          name="$(node -p "require('./packages/thread/package.json').name")"
           version="$(node -p "require('./packages/thread/package.json').version")"
-          npm view "@chatjs/thread@${version}" version
+          npm view "${name}@${version}" version

--- a/apps/chat/CHANGELOG.md
+++ b/apps/chat/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Patch Changes
 
 - Updated dependencies [[`8b3bba3`](https://github.com/FranciscoMoretti/chat-js/commit/8b3bba3a226cd7d487083cfc7021b1cee976ff5a)]:
-  - @chatjs/thread@0.1.0
+  - @chat-js/thread@0.1.0
 
 ## 0.2.0
 

--- a/apps/chat/components/chat-system.tsx
+++ b/apps/chat/components/chat-system.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { MessageTreeSnapshot } from "@chatjs/thread";
+import type { MessageTreeSnapshot } from "@chat-js/thread";
 import { memo } from "react";
 import { Chat } from "@/components/chat";
 import { DataStreamHandler } from "@/components/data-stream-handler";

--- a/apps/chat/lib/ai/complete-data-part.ts
+++ b/apps/chat/lib/ai/complete-data-part.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import type { AbstractThread } from "@chatjs/thread";
+import type { AbstractThread } from "@chat-js/thread";
 import { type DataUIPart, safeValidateUIMessages } from "ai";
 import { z } from "zod";
 import {

--- a/apps/chat/lib/app-chat-runtime.ts
+++ b/apps/chat/lib/app-chat-runtime.ts
@@ -1,4 +1,4 @@
-import type { MessageTreeSnapshot } from "@chatjs/thread";
+import type { MessageTreeSnapshot } from "@chat-js/thread";
 import {
   createContext,
   createElement,

--- a/apps/chat/lib/application-thread.ts
+++ b/apps/chat/lib/application-thread.ts
@@ -1,4 +1,4 @@
-import { AbstractThread, type ThreadState } from "@chatjs/thread";
+import { AbstractThread, type ThreadState } from "@chat-js/thread";
 import type { ChatMessage } from "@/lib/ai/types";
 import { generateUUID } from "@/lib/utils";
 

--- a/apps/chat/lib/parallel-chat-requests.test.ts
+++ b/apps/chat/lib/parallel-chat-requests.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { Thread } from "@chatjs/thread";
+import { Thread } from "@chat-js/thread";
 import type { ChatTransport, UIMessageChunk } from "ai";
 import { afterEach, describe, it, vi } from "vitest";
 import type { ChatMessage } from "@/lib/ai/types";

--- a/apps/chat/lib/parallel-chat-requests.ts
+++ b/apps/chat/lib/parallel-chat-requests.ts
@@ -1,4 +1,4 @@
-import type { TreeHelpers } from "@chatjs/thread/react";
+import type { TreeHelpers } from "@chat-js/thread/react";
 import type { AppModelId } from "@/lib/ai/app-model-id";
 import type { ChatMessage } from "@/lib/ai/types";
 import type { ParallelRequestSpec } from "./draft-chat-submission";

--- a/apps/chat/lib/stores/base/hooks.ts
+++ b/apps/chat/lib/stores/base/hooks.ts
@@ -3,7 +3,7 @@
 "use client";
 
 import type { UIMessage, UseChatHelpers } from "@ai-sdk/react";
-import type { UseThreadHelpers } from "@chatjs/thread/react";
+import type { UseThreadHelpers } from "@chat-js/thread/react";
 import type { ChatStatus } from "ai";
 import * as React from "react";
 import { createContext, useCallback, useContext, useRef } from "react";

--- a/apps/chat/lib/stores/base/use-chat.ts
+++ b/apps/chat/lib/stores/base/use-chat.ts
@@ -5,12 +5,12 @@ import {
   type UseChatHelpers,
   type UseChatOptions,
 } from "@ai-sdk/react";
-import { type AbstractThread, type MessageTreeSnapshot } from "@chatjs/thread";
+import { type AbstractThread, type MessageTreeSnapshot } from "@chat-js/thread";
 import {
   type UseThreadHelpers,
   type UseThreadOptions,
   useThread as useOriginalChat,
-} from "@chatjs/thread/react";
+} from "@chat-js/thread/react";
 import type { ChatInit } from "ai";
 import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { type StoreState, useChatStoreApi } from "./hooks";

--- a/apps/chat/lib/stores/custom-store-provider.tsx
+++ b/apps/chat/lib/stores/custom-store-provider.tsx
@@ -4,7 +4,7 @@ import type { UIMessage } from "@ai-sdk/react";
 import {
   createThreadStateSnapshot,
   type MessageTreeSnapshot,
-} from "@chatjs/thread";
+} from "@chat-js/thread";
 import {
   createContext,
   type PropsWithChildren,

--- a/apps/chat/lib/stores/hooks-threads.ts
+++ b/apps/chat/lib/stores/hooks-threads.ts
@@ -1,4 +1,4 @@
-import type { ThreadRun } from "@chatjs/thread";
+import type { ThreadRun } from "@chat-js/thread";
 import { useCallback } from "react";
 import { useStoreWithEqualityFn } from "zustand/traditional";
 import type { ChatMessage } from "../ai/types";

--- a/apps/chat/lib/stores/with-thread-state.ts
+++ b/apps/chat/lib/stores/with-thread-state.ts
@@ -1,7 +1,7 @@
 import {
   createThreadStateSnapshot,
   type ThreadStateSnapshot,
-} from "@chatjs/thread";
+} from "@chat-js/thread";
 import type { UIMessage } from "ai";
 import type { StateCreator } from "zustand";
 import type { StoreState as BaseChatStoreState } from "@/lib/stores/base";

--- a/apps/chat/lib/stores/zustand-thread-state.ts
+++ b/apps/chat/lib/stores/zustand-thread-state.ts
@@ -1,4 +1,4 @@
-import type { ThreadState } from "@chatjs/thread";
+import type { ThreadState } from "@chat-js/thread";
 import type { UIMessage } from "ai";
 import type { CustomChatStoreApi } from "./custom-store-provider";
 

--- a/apps/chat/lib/thread-utils.test.ts
+++ b/apps/chat/lib/thread-utils.test.ts
@@ -1,4 +1,4 @@
-import { createThreadStateSnapshot } from "@chatjs/thread";
+import { createThreadStateSnapshot } from "@chat-js/thread";
 import { describe, expect, it } from "vitest";
 import type { ChatMessage } from "@/lib/ai/types";
 import {

--- a/apps/chat/lib/thread-utils.ts
+++ b/apps/chat/lib/thread-utils.ts
@@ -1,4 +1,4 @@
-import type { MessageTreeSnapshot } from "@chatjs/thread";
+import type { MessageTreeSnapshot } from "@chat-js/thread";
 import type { UIMessage } from "ai";
 
 // Generic message type that works for both DB and anonymous messages

--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
-    "prebuild": "bun --filter @chatjs/thread build && bun run check-env",
+    "prebuild": "bun --filter @chat-js/thread build && bun run check-env",
     "dev": "bun run check-env && bash scripts/with-db.sh next dev",
     "dev:inspect": "bash scripts/with-db.sh next dev --inspect",
     "build": "tsx lib/db/migrate && next build",
@@ -47,7 +47,7 @@
     "@ai-sdk/openai-compatible": "2.0.56",
     "@ai-sdk/provider": "3.0.13",
     "@ai-sdk/react": "3.0.246",
-    "@chatjs/thread": "workspace:*",
+    "@chat-js/thread": "workspace:*",
     "@better-auth/core": "1.5.6",
     "@better-auth/electron": "^1.5.6",
     "@codemirror/lang-javascript": "^6.2.2",

--- a/apps/docs/core/use-thread.mdx
+++ b/apps/docs/core/use-thread.mdx
@@ -14,7 +14,7 @@ move between branches while responses continue streaming.
 ## Install
 
 ```bash
-bun add @chatjs/thread ai @ai-sdk/react react
+bun add @chat-js/thread ai @ai-sdk/react react
 ```
 
 Replace the `useChat` import without changing your existing message list or
@@ -22,7 +22,7 @@ composer:
 
 ```diff
 - import { useChat } from "@ai-sdk/react";
-+ import { useThread } from "@chatjs/thread/react";
++ import { useThread } from "@chat-js/thread/react";
 
 - const chat = useChat({ transport });
 + const chat = useThread({ transport });

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -112,4 +112,4 @@ npx @chat-js/cli@latest create my-app
 - [Streamdown](https://streamdown.ai/) - Markdown for AI streaming
 - [AI Elements](https://ai-sdk.dev/elements/overview) - AI-native Components
 - [AI SDK Tools](https://ai-sdk-tools.dev/) - Developer tools for AI SDK
-- [`@chatjs/thread`](./core/use-thread) - Branching conversations with a `useChat`-compatible interface
+- [`@chat-js/thread`](./core/use-thread) - Branching conversations with a `useChat`-compatible interface

--- a/apps/site/CHANGELOG.md
+++ b/apps/site/CHANGELOG.md
@@ -5,4 +5,4 @@
 ### Patch Changes
 
 - Updated dependencies [[`8b3bba3`](https://github.com/FranciscoMoretti/chat-js/commit/8b3bba3a226cd7d487083cfc7021b1cee976ff5a)]:
-  - @chatjs/thread@0.1.0
+  - @chat-js/thread@0.1.0

--- a/apps/site/app/threads/page.tsx
+++ b/apps/site/app/threads/page.tsx
@@ -166,7 +166,7 @@ export default function ThreadsPage() {
                     {"\n"}
                     <span className="text-foreground">
                       + import {"{ useThread }"} from
-                      &quot;@chatjs/thread/react&quot;;
+                      &quot;@chat-js/thread/react&quot;;
                     </span>
                     {"\n\n"}
                     <span className="text-muted-foreground">- </span>

--- a/apps/site/components/thread-playground-model.ts
+++ b/apps/site/components/thread-playground-model.ts
@@ -1,5 +1,5 @@
-import { getMessageText, type MessageTreeSnapshot } from "@chatjs/thread";
-import type { UseThreadHelpers } from "@chatjs/thread/react";
+import { getMessageText, type MessageTreeSnapshot } from "@chat-js/thread";
+import type { UseThreadHelpers } from "@chat-js/thread/react";
 import type { ChatTransport, UIMessage, UIMessageChunk } from "ai";
 
 export interface PlaygroundMetadata {

--- a/apps/site/components/thread-showcase.tsx
+++ b/apps/site/components/thread-showcase.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { getMessageText, type ThreadRunHandle } from "@chatjs/thread";
-import { useThread } from "@chatjs/thread/react";
+import { getMessageText, type ThreadRunHandle } from "@chat-js/thread";
+import { useThread } from "@chat-js/thread/react";
 import {
   Check,
   ChevronLeft,
@@ -21,7 +21,7 @@ import {
   PlaygroundTransport,
 } from "./thread-playground-model";
 
-const INSTALL_COMMAND = "bun add @chatjs/thread ai @ai-sdk/react";
+const INSTALL_COMMAND = "bun add @chat-js/thread ai @ai-sdk/react";
 const MAX_ACTIVE_RUNS = 8;
 
 const STATUS_CLASS = {

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "private": true,
   "scripts": {
-    "prebuild": "bun --filter @chatjs/thread build",
+    "prebuild": "bun --filter @chat-js/thread build",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.152",
-    "@chatjs/thread": "workspace:*",
+    "@chat-js/thread": "workspace:*",
     "@vercel/analytics": "^1.5.0",
     "ai": "^6.0.150",
     "class-variance-authority": "^0.7.1",

--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
         "@ai-sdk/react": "3.0.246",
         "@better-auth/core": "1.5.6",
         "@better-auth/electron": "^1.5.6",
-        "@chatjs/thread": "workspace:*",
+        "@chat-js/thread": "workspace:*",
         "@codemirror/lang-javascript": "^6.2.2",
         "@codemirror/lang-python": "^6.1.6",
         "@codemirror/state": "^6.5.0",
@@ -189,7 +189,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@ai-sdk/react": "^3.0.152",
-        "@chatjs/thread": "workspace:*",
+        "@chat-js/thread": "workspace:*",
         "@vercel/analytics": "^1.5.0",
         "ai": "^6.0.150",
         "class-variance-authority": "^0.7.1",
@@ -241,7 +241,7 @@
       },
     },
     "packages/thread": {
-      "name": "@chatjs/thread",
+      "name": "@chat-js/thread",
       "version": "0.0.0",
       "devDependencies": {
         "@ai-sdk/react": "^3.0.246",
@@ -493,7 +493,7 @@
 
     "@chatjs/site": ["@chatjs/site@workspace:apps/site"],
 
-    "@chatjs/thread": ["@chatjs/thread@workspace:packages/thread"],
+    "@chat-js/thread": ["@chat-js/thread@workspace:packages/thread"],
 
     "@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@12.0.0", "", { "dependencies": { "@chevrotain/gast": "12.0.0", "@chevrotain/types": "12.0.0" } }, "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg=="],
 
@@ -3691,7 +3691,7 @@
 
     "@chatjs/site/typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
-    "@chatjs/thread/typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
+    "@chat-js/thread/typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "@chevrotain/cst-dts-gen/@chevrotain/types": ["@chevrotain/types@12.0.0", "", {}, "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA=="],
 

--- a/packages/cli/src/helpers/scaffold.test.ts
+++ b/packages/cli/src/helpers/scaffold.test.ts
@@ -205,9 +205,9 @@ describe("scaffoldFromTemplate", () => {
 		expect(packageJson.dependencies["@better-auth/core"]).toBe("1.5.6");
 		expect(packageJson.dependencies["@better-auth/electron"]).toBe("1.5.6");
 		expect(packageJson.dependencies["better-auth"]).toBe("1.5.6");
-		expect(packageJson.dependencies["@chatjs/thread"]).toBeUndefined();
+		expect(packageJson.dependencies["@chat-js/thread"]).toBeUndefined();
 		expect(packageJson.overrides?.["@better-auth/core"]).toBe("1.5.6");
-		expect(packageJson.scripts?.prebuild).not.toContain("@chatjs/thread");
+		expect(packageJson.scripts?.prebuild).not.toContain("@chat-js/thread");
 		expect(existsSync(join(destination, "lib", "thread", "react.ts"))).toBe(
 			true,
 		);

--- a/packages/cli/src/helpers/vendor-thread-package.ts
+++ b/packages/cli/src/helpers/vendor-thread-package.ts
@@ -2,8 +2,8 @@ import { cp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { extname, join } from "node:path";
 
 const THREAD_IMPORT_REPLACEMENTS = [
-	["@chatjs/thread/react", "@/lib/thread/react"],
-	["@chatjs/thread", "@/lib/thread"],
+	["@chat-js/thread/react", "@/lib/thread/react"],
+	["@chat-js/thread", "@/lib/thread"],
 ] as const;
 
 async function rewriteThreadImports(directory: string): Promise<void> {
@@ -47,11 +47,11 @@ export async function vendorThreadPackage(options: {
 		scripts?: Record<string, string>;
 	};
 	if (packageJson.dependencies) {
-		delete packageJson.dependencies["@chatjs/thread"];
+		delete packageJson.dependencies["@chat-js/thread"];
 	}
 	if (packageJson.scripts?.prebuild) {
 		packageJson.scripts.prebuild = packageJson.scripts.prebuild.replace(
-			"bun --filter @chatjs/thread build && ",
+			"bun --filter @chat-js/thread build && ",
 			"",
 		);
 	}

--- a/packages/thread/ARCHITECTURE.md
+++ b/packages/thread/ARCHITECTURE.md
@@ -2,8 +2,8 @@
 
 ## Purpose
 
-`@chatjs/thread` is the headless, framework-independent threaded conversation
-engine. `@chatjs/thread/react` adapts that engine to React through `useThread`.
+`@chat-js/thread` is the headless, framework-independent threaded conversation
+engine. `@chat-js/thread/react` adapts that engine to React through `useThread`.
 The hook keeps the standard AI SDK `useChat` interface for the selected
 conversation path and adds a `tree` namespace for branching, navigation, and
 concurrent responses.
@@ -543,7 +543,7 @@ not leave an extra user message behind.
 
 ## Package Boundary
 
-`@chatjs/thread` owns:
+`@chat-js/thread` owns:
 
 - the `useThread` React contract
 - tree topology and cursor projection
@@ -575,5 +575,5 @@ The package integration suite must verify that:
 Run the package coverage with:
 
 ```bash
-bun --filter @chatjs/thread test
+bun --filter @chat-js/thread test
 ```

--- a/packages/thread/CHANGELOG.md
+++ b/packages/thread/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @chatjs/thread
+# @chat-js/thread
 
 ## 0.1.0
 

--- a/packages/thread/README.md
+++ b/packages/thread/README.md
@@ -1,4 +1,4 @@
-# @chatjs/thread
+# @chat-js/thread
 
 Build branching AI SDK conversations without mounting one `useChat` hook per
 branch.
@@ -9,11 +9,11 @@ run-specific cancellation.
 
 ## Package Layers
 
-`@chatjs/thread` is the headless core. It exports the framework-independent
+`@chat-js/thread` is the headless core. It exports the framework-independent
 `AbstractThread`, default memory-backed `Thread`, `ThreadState` contract, tree
 management, and stream orchestration.
 
-`@chatjs/thread/react` is the React adapter. It exports `useThread` and owns
+`@chat-js/thread/react` is the React adapter. It exports `useThread` and owns
 React subscriptions, render throttling, and hook lifecycle behavior. The core
 entry point does not import React.
 
@@ -26,19 +26,19 @@ the core.
 For the headless core:
 
 ```bash
-bun add @chatjs/thread ai
+bun add @chat-js/thread ai
 ```
 
 For React:
 
 ```bash
-bun add @chatjs/thread ai @ai-sdk/react react
+bun add @chat-js/thread ai @ai-sdk/react react
 ```
 
 ## Use
 
 ```tsx
-import { useThread } from "@chatjs/thread/react";
+import { useThread } from "@chat-js/thread/react";
 import { DefaultChatTransport } from "ai";
 
 function Conversation() {
@@ -132,7 +132,7 @@ By default, `useThread` creates and retains a `Thread` for the hook lifetime.
 Create the controller yourself when it must outlive a particular component:
 
 ```ts
-import { createThread } from "@chatjs/thread";
+import { createThread } from "@chat-js/thread";
 import { DefaultChatTransport } from "ai";
 
 const transport = new DefaultChatTransport({ api: "/api/chat" });
@@ -153,7 +153,7 @@ import {
   AbstractThread,
   createThreadStateSnapshot,
   type ThreadState,
-} from "@chatjs/thread";
+} from "@chat-js/thread";
 import {
   type ChatTransport,
   DefaultChatTransport,

--- a/packages/thread/build.ts
+++ b/packages/thread/build.ts
@@ -12,7 +12,7 @@ const result = await Bun.build({
 
 if (!result.success) {
 	for (const log of result.logs) console.error(log);
-	throw new Error("Failed to build @chatjs/thread");
+	throw new Error("Failed to build @chat-js/thread");
 }
 
 const reactPath = `${import.meta.dir}/dist/react.js`;

--- a/packages/thread/package.json
+++ b/packages/thread/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@chatjs/thread",
+	"name": "@chat-js/thread",
 	"version": "0.1.0",
 	"description": "Headless threaded chat engine for AI SDK UI messages",
 	"license": "Apache-2.0",

--- a/packages/thread/test/package-smoke.test.ts
+++ b/packages/thread/test/package-smoke.test.ts
@@ -95,8 +95,8 @@ test("the packed package loads its core and React entry points", async () => {
 		expect(coreChunkSource).not.toContain('from "@ai-sdk/react"');
 
 		const consumerSource = `
-import { Thread } from "@chatjs/thread";
-import { useThread } from "@chatjs/thread/react";
+import { Thread } from "@chat-js/thread";
+import { useThread } from "@chat-js/thread/react";
 
 const chat = new Thread();
 if (typeof chat.id !== "string" || typeof useThread !== "function") {


### PR DESCRIPTION
## Summary
- First publish of `@chatjs/thread@0.1.0` 404'd: we do not own the `@chatjs` npm org.
- Rename to `@chat-js/thread` so it publishes next to `@chat-js/cli` / `@chat-js/registry`.
- `@chat-js/cli@0.8.0` is already on npm with current scaffold behavior (Instant Navigations + sibling-switch flush). This ships the standalone thread package.

## Test plan
- [x] `bun --filter @chat-js/thread test:unit`
- [x] `bun --filter @chat-js/cli test:unit`
- [ ] After merge, Release publishes `@chat-js/thread@0.1.0`


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Publish the standalone thread package under the owned `@chat-js` npm scope and update all consumers to use the new package name.

Bug Fixes:
- Correct the thread package scope from `@chatjs/thread` to the owned `@chat-js/thread` scope so first-time publication and release verification succeed.

Enhancements:
- Update application, CLI scaffolding, documentation, tests, and package metadata to consistently consume the renamed thread package.

Deployment:
- Adjust release automation to resolve and verify the renamed thread package dynamically during publication.

Documentation:
- Update thread package documentation and usage examples to reference `@chat-js/thread`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the thread package from `@chatjs/thread` to `@chat-js/thread` so it publishes under the npm scope we own.

- Updates all imports, docs, tests, package metadata, and lockfile references.
- Makes release verification read the package name dynamically instead of hardcoding it.

<sup>Written for commit 614d589f3cea71e678151b984bb0eaa382e928bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Package Updates**
  * Renamed the thread package to `@chat-js/thread`.
  * Updated application dependencies, imports, build commands, and package checks to use the new name.

* **Documentation**
  * Updated installation instructions, examples, changelogs, and package references across the documentation.

* **Tests**
  * Updated package smoke tests and dependency assertions to reflect the renamed package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->