### PR TITLE
Allow chat layouts to compose under existing providers

### DIFF
--- a/apps/chat/app/(chat)/chat-route-host.tsx
+++ b/apps/chat/app/(chat)/chat-route-host.tsx
@@ -8,6 +8,7 @@ import {
   useSearchParams,
 } from "next/navigation";
 import { type ReactNode, useEffect, useMemo } from "react";
+import { Chat } from "@/components/chat";
 import { ChatLoadingShell } from "@/components/chat-loading-shell";
 import { ChatSystem } from "@/components/chat-system";
 import {
@@ -452,24 +453,32 @@ function HostedChatRoute({ route }: { route: HostedParsedChatRoute }) {
     return <ChatLoadingShell />;
   }
 
+  const projectId = getProjectIdForChatSystem({
+    persistedRoute,
+    projectId: projectQuery.data?.id,
+    route,
+  });
+
   return (
     <ChatSystem
-      chat={persistedChat ?? null}
       id={id}
       initialMessages={initialMessages}
       initialTool={initialTool}
       isReadonly={false}
       overrideModelId={overrideModelId}
-      projectId={getProjectIdForChatSystem({
-        persistedRoute,
-        projectId: projectQuery.data?.id,
-        route,
-      })}
-      routeSource={route.source}
+      projectId={projectId}
       runtimeKey={liveRuntime.runtimeId}
       store={liveStore}
       thread={liveRuntime.data.thread}
-    />
+    >
+      <Chat
+        chat={persistedChat ?? null}
+        id={id}
+        isReadonly={false}
+        projectId={projectId}
+        routeSource={route.source}
+      />
+    </ChatSystem>
   );
 }
 

--- a/apps/chat/app/(chat)/share/[id]/shared-chat-page.tsx
+++ b/apps/chat/app/(chat)/share/[id]/shared-chat-page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { notFound } from "next/navigation";
+import { Chat } from "@/components/chat";
 import { ChatSystem } from "@/components/chat-system";
 import { WithSkeleton } from "@/components/with-skeleton";
 import { useChatSystemInitialState } from "@/hooks/use-chat-system-initial-state";
@@ -63,9 +64,10 @@ export function SharedChatPage({ id }: { id: string }) {
         initialMessages={initialState.initialMessages}
         initialTree={initialState.initialTree}
         isReadonly={true}
-        routeSource="share"
         runtimeKey={`share:${chat.id}`}
-      />
+      >
+        <Chat id={chat.id} isReadonly routeSource="share" />
+      </ChatSystem>
     </WithSkeleton>
   );
 }

--- a/apps/chat/components/chat-system.tsx
+++ b/apps/chat/components/chat-system.tsx
@@ -1,23 +1,20 @@
 "use client";
 
 import type { MessageTreeSnapshot } from "@chat-js/thread";
-import { memo } from "react";
-import { Chat } from "@/components/chat";
+import { memo, type ReactNode } from "react";
 import { DataStreamHandler } from "@/components/data-stream-handler";
 import { ArtifactProvider } from "@/hooks/use-artifact";
 import type { AppModelId } from "@/lib/ai/app-models";
 import type { ChatMessage, UiToolName } from "@/lib/ai/types";
 import type { ApplicationThread } from "@/lib/application-thread";
-import type { ChatRouteSource } from "@/lib/chat-route";
 import {
   type CustomChatStoreApi,
   CustomStoreProvider,
 } from "@/lib/stores/custom-store-provider";
-import type { UIChat } from "@/lib/types/ui-chat";
 import { ChatInputProvider } from "@/providers/chat-input-provider";
 
 export const ChatSystem = memo(function PureChatSystem({
-  chat,
+  children,
   id,
   initialMessages,
   initialTree,
@@ -25,12 +22,11 @@ export const ChatSystem = memo(function PureChatSystem({
   initialTool = null,
   overrideModelId,
   projectId,
-  routeSource = projectId ? "project" : "chat",
   runtimeKey,
   store,
   thread,
 }: {
-  chat?: UIChat | null;
+  children: ReactNode;
   id: string;
   initialMessages: ChatMessage[];
   initialTree?: MessageTreeSnapshot<ChatMessage>;
@@ -38,7 +34,6 @@ export const ChatSystem = memo(function PureChatSystem({
   initialTool?: UiToolName | null;
   overrideModelId?: AppModelId;
   projectId?: string;
-  routeSource?: ChatRouteSource;
   runtimeKey: string;
   store?: CustomChatStoreApi<ChatMessage>;
   thread?: ApplicationThread;
@@ -54,14 +49,7 @@ export const ChatSystem = memo(function PureChatSystem({
         threadId={id}
       >
         {isReadonly ? (
-          <Chat
-            chat={chat}
-            id={id}
-            isReadonly={isReadonly}
-            key={runtimeKey}
-            projectId={projectId}
-            routeSource={routeSource}
-          />
+          children
         ) : (
           <ChatInputProvider
             initialTool={initialTool ?? null}
@@ -70,14 +58,7 @@ export const ChatSystem = memo(function PureChatSystem({
             overrideModelId={overrideModelId}
           >
             <DataStreamHandler key={`stream:${runtimeKey}`} />
-            <Chat
-              chat={chat}
-              id={id}
-              isReadonly={isReadonly}
-              key={runtimeKey}
-              projectId={projectId}
-              routeSource={routeSource}
-            />
+            {children}
           </ChatInputProvider>
         )}
       </CustomStoreProvider>

--- a/apps/chat/components/chat.tsx
+++ b/apps/chat/components/chat.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ChatContent } from "@/components/chat/chat-content";
 import {
   ChatLayout,
   ChatLayoutHandle,
@@ -8,9 +9,12 @@ import {
 } from "@/components/chat/chat-layout";
 import { MainChatPanel } from "@/components/chat/main-chat-panel";
 import { SecondaryChatPanel } from "@/components/chat/secondary-chat-panel";
+import { ChatHeader } from "@/components/chat-header";
 import { useArtifactSelector } from "@/hooks/use-artifact";
 import type { ChatRouteSource } from "@/lib/chat-route";
+import { useMessageIds } from "@/lib/stores/hooks-base";
 import type { UIChat } from "@/lib/types/ui-chat";
+import { useSession } from "@/providers/session-provider";
 
 export function Chat({
   chat,
@@ -25,6 +29,8 @@ export function Chat({
   projectId?: string;
   routeSource: ChatRouteSource;
 }) {
+  const { data: session } = useSession();
+  const hasMessages = useMessageIds().length > 0;
   const isSecondaryPanelVisible = useArtifactSelector(
     (state) => state.isVisible
   );
@@ -32,14 +38,24 @@ export function Chat({
   return (
     <ChatLayout isSecondaryPanelVisible={isSecondaryPanelVisible}>
       <ChatLayoutMain>
-        <MainChatPanel
-          chat={chat}
-          chatId={id}
-          className="flex h-full min-w-0 flex-1 flex-col"
-          isReadonly={isReadonly}
-          projectId={projectId}
-          routeSource={routeSource}
-        />
+        <MainChatPanel>
+          <ChatHeader
+            chat={chat}
+            chatId={id}
+            className="h-(--header-height) shrink-0"
+            hasMessages={hasMessages}
+            isReadonly={isReadonly}
+            projectId={projectId}
+            routeSource={routeSource}
+            user={session?.user}
+          />
+          <ChatContent
+            chatId={id}
+            className="min-h-0 flex-1"
+            isReadonly={isReadonly}
+            projectId={projectId}
+          />
+        </MainChatPanel>
       </ChatLayoutMain>
 
       <ChatLayoutHandle />

--- a/apps/chat/components/chat/main-chat-panel.tsx
+++ b/apps/chat/components/chat/main-chat-panel.tsx
@@ -1,50 +1,11 @@
-"use client";
+import type { ComponentProps } from "react";
+import { cn } from "@/lib/utils";
 
-import { ChatHeader } from "@/components/chat-header";
-import type { ChatRouteSource } from "@/lib/chat-route";
-import { useMessageIds } from "@/lib/stores/hooks-base";
-import type { UIChat } from "@/lib/types/ui-chat";
-import { useSession } from "@/providers/session-provider";
-import { ChatContent } from "./chat-content";
-
-export function MainChatPanel({
-  chat,
-  chatId,
-  projectId,
-  isReadonly,
-  className,
-  routeSource,
-}: {
-  chat?: UIChat | null;
-  chatId: string;
-  projectId?: string;
-  isReadonly: boolean;
-  className?: string;
-  routeSource: ChatRouteSource;
-}) {
-  const { data: session } = useSession();
-  const messageIds = useMessageIds() as string[];
-  const hasMessages = messageIds.length > 0;
-
+export function MainChatPanel({ className, ...props }: ComponentProps<"div">) {
   return (
-    <div className={className}>
-      <ChatHeader
-        chat={chat}
-        chatId={chatId}
-        className={"h-(--header-height)"}
-        hasMessages={hasMessages}
-        isReadonly={isReadonly}
-        projectId={projectId}
-        routeSource={routeSource}
-        user={session?.user}
-      />
-
-      <ChatContent
-        chatId={chatId}
-        className="h-[calc(100dvh_-_var(--header-height))]"
-        isReadonly={isReadonly}
-        projectId={projectId}
-      />
-    </div>
+    <div
+      className={cn("flex h-full min-h-0 min-w-0 flex-1 flex-col", className)}
+      {...props}
+    />
   );
 }


### PR DESCRIPTION
`ChatSystem` previously chose the chat layout internally, and `MainChatPanel` hardcoded its header and content. Routes now provide ordinary JSX children under the existing chat providers, while `Chat` explicitly composes its header and content inside a plain main-panel container. A route can replace the layout without replacing runtime initialization, artifact state or composer state.

Content uses the panel's remaining flex height instead of subtracting a fixed header height, so removing the header does not leave an empty header-sized gap. The reference layout and shared-chat route retain their existing UI.

Validation:
- `bun lint`, `bun test:types` and all 149 app unit tests pass.
- Authenticated browser check on this worktree verified the default desktop layout, a temporary plain layout without header/split panels, retained composer draft, and the restored default at 390px mobile width. No document overflow in either viewport.
- Next compilation and runtime diagnostics are empty. React tree inspection confirmed the existing provider-backed composer.

This is a first layout composition slice: five files, no new state store, factory, layout registry, runtime changes, or permanent alternative design. Full-page sidebar alternatives and finer transcript/composer placement remain separate work. Temporary browser variants and evidence are not included in the diff.

## Before / after browser verification

This is primarily a composition refactor, with one intentional sizing change: fixed `100dvh - header` content height becomes flex sizing and the header cannot shrink. No new end-user feature is enabled by the default layout.

Compared base `81786507` with PR head `ecdf3bcf` in the same authenticated development browser, using the same stored conversation/draft and collapsed sidebar. Desktop: 1200×900. Mobile: 390×844. Development overlays were hidden for captures; screenshots were not edited. Conversation screenshots are scrolled to the end.

Observed: header remains 52px high; composer stays visible; messages scroll inside their container; page dimensions match the viewport with no document overflow. Header/composer geometry matches between the two versions in these four scenarios. Provider/remount/readonly paths were also reviewed by a Luna subagent. Project and artifact-panel interactions were not part of this screenshot comparison, and these captures do not establish successful new model execution.

| Scenario | Before | After |
| --- | --- | --- |
| Home · desktop | ![Before: Home · desktop](https://raw.githubusercontent.com/FranciscoMoretti/chat-js/134da550032050d694f750e354d35cd8f87584f4/.github/pr-assets/327/before-desktop-home.png) | ![After: Home · desktop](https://raw.githubusercontent.com/FranciscoMoretti/chat-js/134da550032050d694f750e354d35cd8f87584f4/.github/pr-assets/327/after-desktop-home.png) |
| Home · mobile | ![Before: Home · mobile](https://raw.githubusercontent.com/FranciscoMoretti/chat-js/134da550032050d694f750e354d35cd8f87584f4/.github/pr-assets/327/before-mobile-home.png) | ![After: Home · mobile](https://raw.githubusercontent.com/FranciscoMoretti/chat-js/134da550032050d694f750e354d35cd8f87584f4/.github/pr-assets/327/after-mobile-home.png) |
| Existing conversation · desktop | ![Before: Existing conversation · desktop](https://raw.githubusercontent.com/FranciscoMoretti/chat-js/134da550032050d694f750e354d35cd8f87584f4/.github/pr-assets/327/before-desktop-chat.png) | ![After: Existing conversation · desktop](https://raw.githubusercontent.com/FranciscoMoretti/chat-js/134da550032050d694f750e354d35cd8f87584f4/.github/pr-assets/327/after-desktop-chat.png) |
| Existing conversation · mobile | ![Before: Existing conversation · mobile](https://raw.githubusercontent.com/FranciscoMoretti/chat-js/134da550032050d694f750e354d35cd8f87584f4/.github/pr-assets/327/before-mobile-chat.png) | ![After: Existing conversation · mobile](https://raw.githubusercontent.com/FranciscoMoretti/chat-js/134da550032050d694f750e354d35cd8f87584f4/.github/pr-assets/327/after-mobile-chat.png) |

Screenshots are pinned to evidence commit `134da550` on `codex/pr-327-browser-evidence`; the code PR remains five files. Published and embedded using the GitHub CLI.

## Summary by Sourcery

Decouple chat layout composition from runtime initialization by letting routes provide children beneath ChatSystem providers while preserving the default and shared-chat experiences.

Bug Fixes:
- Use flex-based content sizing so removing or replacing the chat header does not leave an empty header-sized gap.

Enhancements:
- Allow routes to compose custom chat layouts as children while preserving the existing provider-backed runtime, artifact state, and composer state.
- Move default chat header and content composition into the standard Chat layout while making MainChatPanel a reusable plain container.
- Update authenticated and shared-chat routes to provide their layouts under ChatSystem without changing their existing user-facing layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Chat pages now provide a more consistent experience across standard and shared read-only conversations.
  * Chat headers better reflect the current session and whether messages are available.
  * Shared conversations continue to open in read-only mode with their existing conversation context preserved.
  * Chat layouts now support more flexible content and presentation across different views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->