### PR TITLE
fix: authorize document writes and return persisted revision dates

### DIFF
--- a/apps/chat/lib/db/document-writes.test.ts
+++ b/apps/chat/lib/db/document-writes.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  rows: [{ userId: "owner", kind: "text", messageId: "message" }],
+  saved: { createdAt: new Date("2020-01-01") },
+  insert: vi.fn(),
+  values: vi.fn(),
+  lock: vi.fn(),
+}));
+vi.mock("@/lib/env", () => ({ env: { AUTH_SECRET: "fixture-only" } }));
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/file-storage", () => ({}));
+vi.mock("@/lib/logger", () => ({ createModuleLogger: () => ({}) }));
+vi.mock("@/lib/message-conversion", () => ({}));
+vi.mock("@/lib/utils/message-mapping", () => ({}));
+vi.mock("./client", () => {
+  const tx = {
+    select: () => ({
+      from: () => ({ where: () => ({ orderBy: () => ({ for: state.lock }) }) }),
+    }),
+    insert: state.insert,
+  };
+  return {
+    db: {
+      ...tx,
+      transaction: async (run: (db: typeof tx) => unknown) => await run(tx),
+    },
+  };
+});
+
+import { saveDocument, updateDocument } from "./queries";
+
+const input = {
+  id: "document",
+  title: "Title",
+  kind: "text",
+  content: "body",
+  userId: "owner",
+  messageId: "message",
+} satisfies Parameters<typeof saveDocument>[0];
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.rows = [
+    { userId: "owner", kind: "text", messageId: "original-message" },
+  ];
+  state.lock.mockImplementation(() => state.rows);
+  state.insert.mockReturnValue({ values: state.values });
+  state.values.mockReturnValue({ returning: () => [state.saved] });
+});
+it("owner edit returns persisted row and preserves original message for API edits", async () => {
+  const { messageId: _, ...edit } = input;
+  expect(await updateDocument(edit)).toEqual(state.saved);
+  expect(state.lock).toHaveBeenCalledWith("update");
+  expect(state.values).toHaveBeenCalledWith(
+    expect.objectContaining({ userId: "owner", messageId: "original-message" })
+  );
+});
+it.each([
+  [],
+  [{ userId: "other", kind: "text", messageId: "message" }],
+  [
+    { userId: "owner", kind: "text", messageId: "message" },
+    { userId: "other", kind: "text", messageId: "message" },
+  ],
+  [{ userId: "owner", kind: "code", messageId: "message" }],
+])("denies missing, foreign, mixed-owner and mismatched-kind history", async (...rows) => {
+  state.rows = rows;
+  expect(await updateDocument(input)).toBeNull();
+  expect(state.insert).not.toHaveBeenCalled();
+});
+it("missing owner is rejected before any write", async () => {
+  expect(await updateDocument({ ...input, userId: "" })).toBeNull();
+  await expect(saveDocument({ ...input, userId: "" })).rejects.toThrow(
+    "Document owner required"
+  );
+  expect(state.insert).not.toHaveBeenCalled();
+});
+it("create returns inserted identity", async () => {
+  expect(await saveDocument(input)).toEqual(state.saved);
+});

--- a/apps/chat/lib/db/queries.ts
+++ b/apps/chat/lib/db/queries.ts
@@ -653,19 +653,84 @@ export async function saveDocument({
   messageId: string;
 }) {
   try {
-    return await db.insert(document).values({
-      id,
-      title,
-      kind,
-      content,
-      userId,
-      messageId,
-      createdAt: new Date(),
-    });
+    if (!userId) {
+      throw new Error("Document owner required");
+    }
+    const [saved] = await db
+      .insert(document)
+      .values({
+        id,
+        title,
+        kind,
+        content,
+        userId,
+        messageId,
+        createdAt: new Date(),
+      })
+      .returning();
+    if (!saved) {
+      throw new Error("Document was not saved");
+    }
+    return saved;
   } catch (error) {
     console.error("Failed to save document in database", error);
     throw error;
   }
+}
+
+// Write permission is owner-only, even when some revisions are publicly readable.
+// Refuse inconsistent historical ownership rather than adopting the newest owner.
+export async function updateDocument({
+  id,
+  title,
+  kind,
+  content,
+  userId,
+  messageId,
+}: {
+  id: string;
+  title: string;
+  kind: ArtifactKind;
+  content: string;
+  userId: string;
+  messageId?: string;
+}) {
+  if (!userId) {
+    return null;
+  }
+  return await db.transaction(async (tx) => {
+    const revisions = await tx
+      .select()
+      .from(document)
+      .where(eq(document.id, id))
+      .orderBy(desc(document.createdAt))
+      .for("update");
+    const latest = revisions[0];
+    if (
+      !latest ||
+      revisions.some(
+        (revision) => revision.userId !== userId || revision.kind !== kind
+      )
+    ) {
+      return null;
+    }
+    const [saved] = await tx
+      .insert(document)
+      .values({
+        id,
+        title,
+        kind,
+        content,
+        userId: latest.userId,
+        messageId: messageId ?? latest.messageId,
+        createdAt: new Date(),
+      })
+      .returning();
+    if (!saved) {
+      throw new Error("Document was not saved");
+    }
+    return saved;
+  });
 }
 
 async function _getDocumentsById({ id }: { id: string }) {

--- a/apps/chat/tools/platform/documents/create-code-document.ts
+++ b/apps/chat/tools/platform/documents/create-code-document.ts
@@ -27,24 +27,25 @@ ${codeGuidelines}`,
     }),
 
     async execute({ title, content }): Promise<DocumentToolResult> {
+      if (!session.user?.id) {
+        return { status: "error", error: "Authentication required" };
+      }
       const id = generateUUID();
 
-      if (session.user?.id) {
-        await saveDocument({
-          id,
-          title,
-          content,
-          kind: "code",
-          userId: session.user.id,
-          messageId,
-        });
-      }
+      const saved = await saveDocument({
+        id,
+        title,
+        content,
+        kind: "code",
+        userId: session.user.id,
+        messageId,
+      });
 
       return {
         status: "success",
         documentId: id,
         result: "A document was created and is now visible to the user.",
-        date: new Date().toISOString(),
+        date: saved.createdAt.toISOString(),
       };
     },
   });

--- a/apps/chat/tools/platform/documents/create-sheet-document.ts
+++ b/apps/chat/tools/platform/documents/create-sheet-document.ts
@@ -26,24 +26,25 @@ The spreadsheet will be created with proper column headers and data.`,
     }),
 
     async execute({ title, content }): Promise<DocumentToolResult> {
+      if (!session.user?.id) {
+        return { status: "error", error: "Authentication required" };
+      }
       const id = generateUUID();
 
-      if (session.user?.id) {
-        await saveDocument({
-          id,
-          title,
-          content,
-          kind: "sheet",
-          userId: session.user.id,
-          messageId,
-        });
-      }
+      const saved = await saveDocument({
+        id,
+        title,
+        content,
+        kind: "sheet",
+        userId: session.user.id,
+        messageId,
+      });
 
       return {
         status: "success",
         documentId: id,
         result: "A document was created and is now visible to the user.",
-        date: new Date().toISOString(),
+        date: saved.createdAt.toISOString(),
       };
     },
   });

--- a/apps/chat/tools/platform/documents/create-text-document.ts
+++ b/apps/chat/tools/platform/documents/create-text-document.ts
@@ -27,24 +27,25 @@ The title should be descriptive of the content.`,
     // TODO: Optimize what's rendered to the model by excluding content from messages !== curMessage
     // toModelOutput: ({input}) => (),
     async execute({ title, content }): Promise<DocumentToolResult> {
+      if (!session.user?.id) {
+        return { status: "error", error: "Authentication required" };
+      }
       const id = generateUUID();
 
-      if (session.user?.id) {
-        await saveDocument({
-          id,
-          title,
-          content,
-          kind: "text",
-          userId: session.user.id,
-          messageId,
-        });
-      }
+      const saved = await saveDocument({
+        id,
+        title,
+        content,
+        kind: "text",
+        userId: session.user.id,
+        messageId,
+      });
 
       return {
         status: "success",
         documentId: id,
         result: "A document was created and is now visible to the user.",
-        date: new Date().toISOString(),
+        date: saved.createdAt.toISOString(),
       };
     },
   });

--- a/apps/chat/tools/platform/documents/document-writes.test.ts
+++ b/apps/chat/tools/platform/documents/document-writes.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createCodeDocumentTool } from "./create-code-document";
+import { createSheetDocumentTool } from "./create-sheet-document";
+import { createTextDocumentTool } from "./create-text-document";
+import { editCodeDocumentTool } from "./edit-code-document";
+import { editSheetDocumentTool } from "./edit-sheet-document";
+import { editTextDocumentTool } from "./edit-text-document";
+
+const queries = vi.hoisted(() => ({
+  saveDocument: vi.fn(),
+  updateDocument: vi.fn(),
+}));
+vi.mock("@/lib/db/queries", () => queries);
+vi.mock("@/lib/utils", () => ({ generateUUID: () => "new-document" }));
+const factories = [
+  createTextDocumentTool,
+  createCodeDocumentTool,
+  createSheetDocumentTool,
+  editTextDocumentTool,
+  editCodeDocumentTool,
+  editSheetDocumentTool,
+];
+const savedAt = new Date("2020-01-02T03:04:05.000Z");
+beforeEach(() => {
+  vi.resetAllMocks();
+  queries.saveDocument.mockResolvedValue({ createdAt: savedAt });
+  queries.updateDocument.mockResolvedValue({ createdAt: savedAt });
+});
+describe.each(factories)("document tool %s", (factory) => {
+  const execute = (user = true) => {
+    const tool = factory({
+      session: user ? { user: { id: "owner" } } : {},
+      messageId: "message",
+      selectedModel: "openai/gpt-4.1",
+    });
+    if (!tool.execute) {
+      throw new Error("Missing execute");
+    }
+    return tool.execute(
+      { title: "Title", content: "body", documentId: "existing" },
+      { toolCallId: "call", messages: [], context: {} }
+    );
+  };
+  it("returns persisted identity", async () => {
+    expect(await execute()).toMatchObject({
+      status: "success",
+      date: savedAt.toISOString(),
+    });
+  });
+  it("rejects missing caller without saving", async () => {
+    expect(await execute(false)).toMatchObject({ status: "error" });
+    expect(queries.saveDocument).not.toHaveBeenCalled();
+    expect(queries.updateDocument).not.toHaveBeenCalled();
+  });
+  it("propagates save failure", async () => {
+    queries.saveDocument.mockRejectedValue(new Error("save failed"));
+    queries.updateDocument.mockRejectedValue(new Error("save failed"));
+    await expect(execute()).rejects.toThrow("save failed");
+  });
+});
+it.each([
+  editTextDocumentTool,
+  editCodeDocumentTool,
+  editSheetDocumentTool,
+])("rejects inaccessible edits", async (factory) => {
+  queries.updateDocument.mockResolvedValue(null);
+  const tool = factory({
+    session: { user: { id: "other" } },
+    messageId: "message",
+    selectedModel: "openai/gpt-4.1",
+  });
+  if (!tool.execute) {
+    throw new Error("Missing execute");
+  }
+  expect(
+    await tool.execute(
+      { title: "Title", content: "body", documentId: "foreign" },
+      { toolCallId: "call", messages: [], context: {} }
+    )
+  ).toEqual({ status: "error", error: "Document not found" });
+  expect(queries.updateDocument).toHaveBeenCalledWith(
+    expect.objectContaining({ userId: "other", id: "foreign" })
+  );
+});

--- a/apps/chat/tools/platform/documents/edit-code-document.ts
+++ b/apps/chat/tools/platform/documents/edit-code-document.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
-import { getDocumentById, saveDocument } from "@/lib/db/queries";
+import { updateDocument } from "@/lib/db/queries";
 import { codeGuidelines } from "./code-guidelines";
 import type { DocumentToolContext, DocumentToolResult } from "./types";
 
@@ -33,32 +33,26 @@ Avoid:
     }),
 
     async execute({ documentId, title, content }): Promise<DocumentToolResult> {
-      const document = await getDocumentById({ id: documentId });
-
-      if (!document) {
+      if (!session.user?.id) {
+        return { status: "error", error: "Authentication required" };
+      }
+      const saved = await updateDocument({
+        id: documentId,
+        title,
+        content,
+        kind: "code",
+        userId: session.user.id,
+        messageId,
+      });
+      if (!saved) {
         return { status: "error", error: "Document not found" };
-      }
-
-      if (document.kind !== "code") {
-        return { status: "error", error: "Document is not a code document" };
-      }
-
-      if (session.user?.id) {
-        await saveDocument({
-          id: documentId,
-          title,
-          content,
-          kind: "code",
-          userId: session.user.id,
-          messageId,
-        });
       }
 
       return {
         status: "success",
         documentId,
         result: "The document was updated and is now visible to the user.",
-        date: new Date().toISOString(),
+        date: saved.createdAt.toISOString(),
       };
     },
   });

--- a/apps/chat/tools/platform/documents/edit-sheet-document.ts
+++ b/apps/chat/tools/platform/documents/edit-sheet-document.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
-import { getDocumentById, saveDocument } from "@/lib/db/queries";
+import { updateDocument } from "@/lib/db/queries";
 import { sheetGuidelines } from "./sheet-guidelines";
 import type { DocumentToolContext, DocumentToolResult } from "./types";
 
@@ -30,32 +30,26 @@ Avoid:
     }),
 
     async execute({ documentId, title, content }): Promise<DocumentToolResult> {
-      const document = await getDocumentById({ id: documentId });
-
-      if (!document) {
+      if (!session.user?.id) {
+        return { status: "error", error: "Authentication required" };
+      }
+      const saved = await updateDocument({
+        id: documentId,
+        title,
+        content,
+        kind: "sheet",
+        userId: session.user.id,
+        messageId,
+      });
+      if (!saved) {
         return { status: "error", error: "Document not found" };
-      }
-
-      if (document.kind !== "sheet") {
-        return { status: "error", error: "Document is not a spreadsheet" };
-      }
-
-      if (session.user?.id) {
-        await saveDocument({
-          id: documentId,
-          title,
-          content,
-          kind: "sheet",
-          userId: session.user.id,
-          messageId,
-        });
       }
 
       return {
         status: "success",
         documentId,
         result: "The document was updated and is now visible to the user.",
-        date: new Date().toISOString(),
+        date: saved.createdAt.toISOString(),
       };
     },
   });

--- a/apps/chat/tools/platform/documents/edit-text-document.ts
+++ b/apps/chat/tools/platform/documents/edit-text-document.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
-import { getDocumentById, saveDocument } from "@/lib/db/queries";
+import { updateDocument } from "@/lib/db/queries";
 import { textGuidelines } from "./text-guidelines";
 import type { DocumentToolContext, DocumentToolResult } from "./types";
 
@@ -29,32 +29,26 @@ Avoid:
     }),
 
     async execute({ documentId, title, content }): Promise<DocumentToolResult> {
-      const document = await getDocumentById({ id: documentId });
-
-      if (!document) {
+      if (!session.user?.id) {
+        return { status: "error", error: "Authentication required" };
+      }
+      const saved = await updateDocument({
+        id: documentId,
+        title,
+        content,
+        kind: "text",
+        userId: session.user.id,
+        messageId,
+      });
+      if (!saved) {
         return { status: "error", error: "Document not found" };
-      }
-
-      if (document.kind !== "text") {
-        return { status: "error", error: "Document is not a text document" };
-      }
-
-      if (session.user?.id) {
-        await saveDocument({
-          id: documentId,
-          title,
-          content,
-          kind: "text",
-          userId: session.user.id,
-          messageId,
-        });
       }
 
       return {
         status: "success",
         documentId,
         result: "The document was updated and is now visible to the user.",
-        date: new Date().toISOString(),
+        date: saved.createdAt.toISOString(),
       };
     },
   });

--- a/apps/chat/trpc/routers/document.router.test.ts
+++ b/apps/chat/trpc/routers/document.router.test.ts
@@ -1,0 +1,64 @@
+import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
+import { beforeEach, expect, it, vi } from "vitest";
+
+const queries = vi.hoisted(() => ({ updateDocument: vi.fn() }));
+vi.mock("@/lib/db/queries", () => queries);
+vi.mock("@/lib/auth", () => ({ auth: {} }));
+
+import { documentRouter } from "./document.router";
+
+const user = {
+  id: "owner",
+  name: "Owner",
+  email: "owner@example.test",
+  emailVerified: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+const input = {
+  id: "document",
+  content: "body",
+  title: "Title",
+  kind: "text",
+} satisfies Parameters<
+  ReturnType<typeof documentRouter.createCaller>["saveDocument"]
+>[0];
+beforeEach(() => {
+  vi.resetAllMocks();
+  queries.updateDocument.mockResolvedValue({ createdAt: new Date() });
+});
+it("uses verified owner for writes", async () => {
+  expect(
+    await documentRouter.createCaller({ user }).saveDocument(input)
+  ).toEqual({ success: true });
+  expect(queries.updateDocument).toHaveBeenCalledWith({
+    ...input,
+    userId: user.id,
+  });
+});
+it("denies inaccessible and publicly readable foreign documents alike", async () => {
+  queries.updateDocument.mockResolvedValue(null);
+  await expect(
+    documentRouter.createCaller({ user }).saveDocument(input)
+  ).rejects.toMatchObject({ code: "NOT_FOUND" });
+});
+it("rejects missing authentication before writing", async () => {
+  await expect(
+    documentRouter.createCaller({ user: undefined }).saveDocument(input)
+  ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  expect(queries.updateDocument).not.toHaveBeenCalled();
+});
+it("validates artifact kinds at runtime", async () => {
+  const response = await fetchRequestHandler({
+    endpoint: "/trpc",
+    router: documentRouter,
+    createContext: () => ({ user }),
+    req: new Request("http://fixture/trpc/saveDocument", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ json: { ...input, kind: "not-an-artifact" } }),
+    }),
+  });
+  expect(response.status).toBe(400);
+  expect(queries.updateDocument).not.toHaveBeenCalled();
+});

--- a/apps/chat/trpc/routers/document.router.ts
+++ b/apps/chat/trpc/routers/document.router.ts
@@ -1,11 +1,10 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import type { ArtifactKind } from "@/lib/artifacts/artifact-kind";
+import { artifactKinds } from "@/lib/artifacts/artifact-kind";
 import {
-  getDocumentById,
   getDocumentsById,
   getPublicDocumentsById,
-  saveDocument,
+  updateDocument,
 } from "@/lib/db/queries";
 import {
   createTRPCRouter,
@@ -53,24 +52,23 @@ export const documentRouter = createTRPCRouter({
         id: z.string(),
         content: z.string(),
         title: z.string(),
-        kind: z.custom<ArtifactKind>(),
+        kind: z.enum(artifactKinds),
       })
     )
     .mutation(async ({ input, ctx }) => {
-      const lastDocument = await getDocumentById({ id: input.id });
-
-      if (!lastDocument) {
-        throw new Error("Document not found");
-      }
-
-      const _document = await saveDocument({
+      const saved = await updateDocument({
         id: input.id,
         content: input.content,
         title: input.title,
         kind: input.kind,
         userId: ctx.user.id,
-        messageId: lastDocument.messageId,
       });
+      if (!saved) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Document not found",
+        });
+      }
 
       return { success: true };
     }),

--- a/research/document-write-repair/README.md
+++ b/research/document-write-repair/README.md
@@ -1,6 +1,6 @@
 # Existing-app document write repair
 
-Base: `4aec0f05c6ed1ea9ba5a8bbacf39b1726583d523` (origin/main fetched for this work). Local branch `codex/document-write-repair`. No dependency on PR317/318; neither feature worktree changed. No push, PR, schema migration, runtime/provider replacement or data cleanup.
+Base: `8178650771aed69e75421a988e6c57f69ac131ca` (origin/main refreshed 2026-09-07; includes merged #317). Branch `codex/document-write-repair`. The original local repair396e151f was rebased without conflicts; neither feature worktree changed. This is a separate review slice for #323. No schema migration, runtime/provider replacement or data cleanup.
 
 Changes:
 
@@ -10,6 +10,8 @@ Changes:
 - Existing read/share/delete behavior and schema remain unchanged. No stale-base/CAS guarantee is added. Locking existing revision rows is not a stable parent-owner lock and does not solve historical branching or externally injected inconsistent ownership. Inconsistent existing histories fail closed, with no automatic repair.
 
 ## Verification
+
+Refreshed 2026-09-07: all checks below and the actual PostgreSQL proof were rerun after the conflict-free rebase onto current main.
 
 - Root `bun lint`: passed (app executed; three unrelated tasks cached).
 - Root `bun test:types`: passed (app executed; two unrelated tasks cached).

--- a/research/document-write-repair/README.md
+++ b/research/document-write-repair/README.md
@@ -1,0 +1,49 @@
+# Existing-app document write repair
+
+Base: `4aec0f05c6ed1ea9ba5a8bbacf39b1726583d523` (origin/main fetched for this work). Local branch `codex/document-write-repair`. No dependency on PR317/318; neither feature worktree changed. No push, PR, schema migration, runtime/provider replacement or data cleanup.
+
+Changes:
+
+- tRPC and text/code/sheet edits share `updateDocument`, which locks existing revisions in a transaction, rejects missing or inconsistent ownership/kind, and appends using the existing owner. Public readability never authorizes a write.
+- Missing tool caller returns an error before persistence. Creation requires an owner. Success dates come from the inserted row returned by PostgreSQL, not a second clock read.
+- tRPC artifact kind uses the existing runtime enum.
+- Existing read/share/delete behavior and schema remain unchanged. No stale-base/CAS guarantee is added. Locking existing revision rows is not a stable parent-owner lock and does not solve historical branching or externally injected inconsistent ownership. Inconsistent existing histories fail closed, with no automatic repair.
+
+## Verification
+
+- Root `bun lint`: passed (app executed; three unrelated tasks cached).
+- Root `bun test:types`: passed (app executed; two unrelated tasks cached).
+- `bun run --filter @chatjs/chat test:unit`: **35 files / 181 tests passed**, including **32 new regressions** for query authorization, actual tool entrypoints and tRPC input/auth behavior.
+- `git diff --check`: passed.
+- Actual PostgreSQL17 proof imports the changed queries and real Drizzle/Postgres implementation: persisted timestamp matches stored timestamp, valid edit preserves original message link, foreign/kind/mixed-owner edits are denied without adding rows, save failure rejects and leaves row count unchanged. A disposable unix-socket-only PostgreSQL cluster was used and stopped afterward.
+
+Initial root types failed because the existing shared Thread task cache restored success without `dist` declarations. Ran the existing `bun run --filter @chat-js/thread build` to materialize the dependency output, then reran root checks successfully. No production app build and no cache/config fix included.
+
+The PostgreSQL proof deliberately creates only the Document table shape, without app User/Message foreign keys or production authentication. It validates real query behavior rather than full application database provisioning. Other imported services are mocked to throw if used. Run this standalone in its own Bun process; do not import it into a shared test process, because its Bun module substitutions are process-wide. Normal committed regression tests use Vitest isolation and the complete app unit suite passed.
+
+Reproduce unit checks after `bun install --frozen-lockfile --ignore-scripts`:
+
+```sh
+bun run --filter @chat-js/thread build
+bun lint
+bun test:types
+bun run --filter @chatjs/chat test:unit
+```
+
+Reproduce the PostgreSQL proof with a new disposable cluster (requires local PostgreSQL binaries; example Homebrew17):
+
+```sh
+task_pg_dir=$(mktemp -d /tmp/chatjs-document-pg.XXXXXX)
+/opt/homebrew/opt/postgresql@17/bin/initdb -D "$task_pg_dir/data" -A trust --no-locale
+/opt/homebrew/opt/postgresql@17/bin/pg_ctl -D "$task_pg_dir/data" -l "$task_pg_dir/server.log" -o "-k $task_pg_dir -c listen_addresses=''" -w start
+DOCUMENT_PROOF_SOCKET="$task_pg_dir" bun research/document-write-repair/postgres-proof.ts
+/opt/homebrew/opt/postgresql@17/bin/pg_ctl -D "$task_pg_dir/data" -m fast -w stop
+```
+
+The proof intentionally injects a database exception; the existing query logger prints it before the final success message. Earlier harness attempts were corrected for raw timestamp-without-timezone parsing (interpret as UTC, matching Drizzle) and Drizzle wrapping PostgreSQL errors in `cause`; final invocation passed. No real credentials or user content are used.
+
+## Remaining limits
+
+Browser was not rerun. Source inspection confirms `components/part/document-tool.tsx:60` passes the returned date and `components/artifact-panel.tsx:406` displays it. The artifact panel still selects the latest revision for `messageId`, falling back to latest overall (`:96–121`), rather than selecting by exact date. This repair therefore fixes emitted persisted identity, not the broader exact historical-revision UI contract.
+
+File ownership/catalog authorization, stale draft recovery, exact-base conflict semantics, operation retry deduplication, stable document parent schema, retention/sharing decisions and historical execution remain separate work. Existing timestamp-key collision behavior is unchanged.

--- a/research/document-write-repair/postgres-proof.ts
+++ b/research/document-write-repair/postgres-proof.ts
@@ -1,0 +1,95 @@
+import { mock } from "bun:test";
+import { strict as assert } from "node:assert";
+import { drizzle } from "../../apps/chat/node_modules/drizzle-orm/postgres-js";
+import postgres from "../../apps/chat/node_modules/postgres";
+const socket = process.env.DOCUMENT_PROOF_SOCKET;
+if (!socket?.startsWith("/tmp/chatjs-document-pg."))
+	throw new Error(
+		"DOCUMENT_PROOF_SOCKET must name an isolated PostgreSQL socket directory",
+	);
+const sql = postgres({ host: socket, database: "postgres", max: 2 });
+mock.module("server-only", () => ({}));
+mock.module("../../apps/chat/lib/env", () => ({
+	env: { AUTH_SECRET: "disposable-test-only" },
+}));
+mock.module("../../apps/chat/lib/db/client", () => ({ db: drizzle(sql) }));
+mock.module("../../apps/chat/lib/file-storage", () => ({
+	deleteFilesByUrls: () => {
+		throw new Error("Not in proof scope");
+	},
+}));
+mock.module("../../apps/chat/lib/logger", () => ({
+	createModuleLogger: () => ({}),
+}));
+mock.module("../../apps/chat/lib/message-conversion", () => ({
+	chatMessageToDbMessage: () => {
+		throw new Error("Not in proof scope");
+	},
+}));
+mock.module("../../apps/chat/lib/utils/message-mapping", () => ({
+	mapDBPartsToUIParts: () => {
+		throw new Error("Not in proof scope");
+	},
+	mapUIMessagePartsToDBParts: () => {
+		throw new Error("Not in proof scope");
+	},
+}));
+const { saveDocument, updateDocument } = await import(
+	"../../apps/chat/lib/db/queries"
+);
+try {
+	await sql`DROP TABLE IF EXISTS "Document"`;
+	await sql`DROP FUNCTION IF EXISTS reject_save()`;
+	await sql`CREATE TABLE "Document" (id uuid NOT NULL, "createdAt" timestamp NOT NULL, title text NOT NULL, content text, kind varchar NOT NULL, "userId" text NOT NULL, "messageId" uuid NOT NULL, PRIMARY KEY(id,"createdAt"))`;
+	const input = {
+		id: crypto.randomUUID(),
+		title: "T",
+		content: "one",
+		kind: "text",
+		userId: "owner",
+		messageId: crypto.randomUUID(),
+	} satisfies Parameters<typeof saveDocument>[0];
+	const saved = await saveDocument(input);
+	const persisted =
+		await sql`SELECT "createdAt" FROM "Document" WHERE id=${input.id}`;
+	assert.equal(
+		saved.createdAt.toISOString(),
+		new Date(`${persisted[0]?.createdAt}Z`).toISOString(),
+	);
+	assert.equal(await updateDocument({ ...input, userId: "other" }), null);
+	assert.equal(await updateDocument({ ...input, kind: "code" }), null);
+	assert.equal(
+		Number((await sql`SELECT count(*) AS n FROM "Document"`)[0]?.n),
+		1,
+	);
+	await new Promise((resolve) => setTimeout(resolve, 5));
+	const updated = await updateDocument({
+		...input,
+		content: "two",
+		messageId: undefined,
+	});
+	assert.equal(updated?.messageId, input.messageId);
+	assert.equal(updated?.content, "two");
+	await sql`INSERT INTO "Document" VALUES (${input.id}, '2000-01-01', 'mixed', 'bad', 'text', 'other', ${input.messageId})`;
+	assert.equal(await updateDocument(input), null);
+	assert.equal(await updateDocument({ ...input, userId: "other" }), null);
+	const count = Number((await sql`SELECT count(*) AS n FROM "Document"`)[0]?.n);
+	await sql`CREATE FUNCTION reject_save() RETURNS trigger LANGUAGE plpgsql AS $$BEGIN RAISE EXCEPTION 'injected save failure'; END;$$`;
+	await sql`CREATE TRIGGER reject_save BEFORE INSERT ON "Document" FOR EACH ROW EXECUTE FUNCTION reject_save()`;
+	await assert.rejects(
+		() => saveDocument({ ...input, id: crypto.randomUUID() }),
+		(error: unknown) =>
+			error instanceof Error &&
+			error.cause instanceof Error &&
+			error.cause.message === "injected save failure",
+	);
+	assert.equal(
+		Number((await sql`SELECT count(*) AS n FROM "Document"`)[0]?.n),
+		count,
+	);
+	console.log(
+		"PostgreSQL actual-query proof: persisted identity, owner write, foreign/kind/mixed-owner denial, message retention and failure checks passed",
+	);
+} finally {
+	await sql.end();
+}


### PR DESCRIPTION
Document edits now authorize against the existing owner before appending a revision. Both tRPC and the text/code/sheet edit tools use the same transaction; missing documents and inconsistent ownership/kind histories fail closed. Public readability continues to be separate from write permission.

Create/edit tools now reject missing caller identity and return the inserted revision's timestamp instead of a second clock reading. The tRPC mutation also validates artifact kinds at runtime.

Validation: root lint and types pass; all 181 app unit tests pass, including 32 new regressions. A disposable PostgreSQL17 proof imports the changed queries and verifies persisted timestamps, owner writes, denied writes without added rows, retained message identity, and persistence failure. Rebased onto main81786507 without conflicts. Reproduction and limitations are in `research/document-write-repair/README.md`.

This is the narrow current-app repair from #323. Schema, existing providers/runtime, and read/share/delete policies are unchanged. Exact historical UI selection, stale-base conflict handling and retry deduplication remain separate. Browser was not rerun; the database proof uses the Document table shape without the full app's foreign-key/auth setup.

Refs #323. Keep that investigation open for its remaining integration work.

## Summary by Sourcery

Secure document creation and revision writes while returning the database-persisted revision identity to callers.

Bug Fixes:
- Authorize document edits against the existing revision history so only consistent owners can append revisions, while denying missing, foreign, mixed-owner, or mismatched-kind writes without adding rows.
- Require authenticated callers for document creation and editing across tRPC and text, code, and sheet tools.
- Return persisted revision timestamps and preserve the original message identity when edits omit a message ID.

Enhancements:
- Share transactional document-write authorization across tRPC and document tools, keeping public readability separate from write permission.
- Validate tRPC artifact kinds at runtime and fail closed when a document write cannot be authorized.

Documentation:
- Add a research note documenting the repair scope, verification results, reproduction steps, and remaining limitations.

Tests:
- Add regression coverage for database authorization, persisted identities, caller authentication, tool behavior, tRPC validation, and write failures, including an isolated PostgreSQL proof.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document edits now authorize against the existing owner before appending a revision, and create/edit tools return the persisted revision's timestamp instead of a second clock reading.

- tRPC and text/code/sheet edit tools share one transactional `updateDocument` query that locks existing revisions and rejects missing, foreign-owner, mixed-owner, and mismatched-kind histories.
- Public readability no longer grants write permission; create and edit tools error when caller identity is missing.
- The tRPC mutation validates artifact kinds at runtime and raises `NOT_FOUND` for denied writes.
- 32 new regression tests cover query authorization, tool entrypoints, and tRPC behavior; all 181 app unit tests pass.
- A disposable PostgreSQL proof verifies persisted timestamps, owner writes, denied writes without added rows, retained message identity, and persistence failure.
- Schema, read/share/delete policies, and existing providers are unchanged; stale-base conflict handling and retry deduplication remain separate from #323 — keep that investigation open.

<sup>Written for commit a98d105d465c1aa0193eaac62466f5e79663ca74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document creation and editing now require authentication.
  * Document updates securely preserve ownership, revision history, and document type.
  * Saved document timestamps are used in success responses.
  * Invalid document types and unauthorized access are rejected with clearer errors.

* **Bug Fixes**
  * Prevented unauthenticated or unauthorized document writes.
  * Improved handling of missing documents and inconsistent document histories.

* **Tests**
  * Added coverage for document creation, editing, authorization, validation, persistence, and rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->