### PR TITLE
fix(thread): restore declarations from cached type checks

### DIFF
--- a/packages/thread/turbo.json
+++ b/packages/thread/turbo.json
@@ -1,0 +1,8 @@
+{
+	"extends": ["//"],
+	"tasks": {
+		"test:types": {
+			"outputs": ["dist/**"]
+		}
+	}
+}


### PR DESCRIPTION
The Thread `test:types` script builds declarations used by dependent applications. Turbo previously cached task success without its outputs, so a cache hit after removing `dist` left consumers without declarations. Declare `dist/**` as this package task’s output so Turbo restores those files.

Validation on current main81786507:
- `bun lint` and `bun test:types` passed (all type tasks executed).
- Thread tests:65 passed,198 assertions.
- Run filtered type task with a fresh cache, remove generated `packages/thread/dist`, rerun identical task:full cache hit restores `dist/index.d.ts`. The same baseline experiment without this fix previously reproduced missing declarations.

One package-local Turbo configuration; no application/runtime changes. This is the standalone defect from #319, not completion of the superseded combined-app integration scope.

## Summary by Sourcery

Configure Turbo to restore thread declaration outputs from cached type-check tasks.

Bug Fixes:
- Ensure cached thread type-check tasks restore generated declaration files when the package's build output has been removed.

Build:
- Declare the thread package's `dist/**` files as outputs of its type-check task.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `thread` type-check caching so dependent apps get declarations restored from Turbo's cache. `packages/thread/turbo.json` now declares `dist/**` as an output of `test:types`.

- Previously, Turbo cached task success without its outputs, so removing `dist` left consumers without declarations.
- No application or runtime changes; only the package-local Turbo configuration.
- Validated by rerunning the type task with a fresh cache and confirming `dist/index.d.ts` is restored.

<sup>Written for commit 75d3e7ed057d4243b9464ff93919e45f2bb97f33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added package-level build configuration for type testing and generated distribution outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->