### PR TITLE
fix(thread): validate isolated package installs and include license

### DIFF
--- a/packages/thread/LICENSE
+++ b/packages/thread/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/thread/test/package-smoke.test.ts
+++ b/packages/thread/test/package-smoke.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 const packageDirectory = resolve(import.meta.dir, "..");
@@ -11,7 +12,7 @@ function run(command: string[], cwd: string) {
 		killSignal: "SIGKILL",
 		stderr: "pipe",
 		stdout: "pipe",
-		timeout: 25_000,
+		timeout: 60_000,
 	});
 	if (result.exitCode !== 0) {
 		throw new Error(
@@ -26,7 +27,7 @@ function run(command: string[], cwd: string) {
 
 test("the packed package loads its core and React entry points", async () => {
 	const temporaryDirectory = await mkdtemp(
-		join(packageDirectory, ".package-smoke-"),
+		join(tmpdir(), "chatjs-thread-package-"),
 	);
 
 	try {
@@ -47,20 +48,49 @@ test("the packed package loads its core and React entry points", async () => {
 		const installedPackage = join(
 			temporaryDirectory,
 			"node_modules",
-			"@chatjs",
+			"@chat-js",
 			"thread",
 		);
-		await mkdir(installedPackage, { recursive: true });
+		const metadata = await Bun.file(
+			join(packageDirectory, "package.json"),
+		).json();
+		await writeFile(
+			join(temporaryDirectory, "package.json"),
+			JSON.stringify({
+				private: true,
+				type: "module",
+				dependencies: {
+					"@chat-js/thread": "file:./thread.tgz",
+					ai: metadata.devDependencies.ai,
+				},
+			}),
+		);
+		run(["bun", "install", "--ignore-scripts"], temporaryDirectory);
+
+		const coreConsumerPath = join(temporaryDirectory, "core.mjs");
+		await writeFile(
+			coreConsumerPath,
+			`
+import assert from "node:assert/strict";
+import { Thread } from "@chat-js/thread";
+assert.equal(import.meta.resolve("@chat-js/thread"), new URL("./node_modules/@chat-js/thread/dist/index.js", import.meta.url).href);
+assert.equal(typeof new Thread().id, "string");
+assert.throws(() => import.meta.resolve("react"), { code: "ERR_MODULE_NOT_FOUND" });
+assert.throws(() => import.meta.resolve("@ai-sdk/react"), { code: "ERR_MODULE_NOT_FOUND" });
+`,
+		);
+		run(["node", coreConsumerPath], temporaryDirectory);
 		run(
 			[
-				"tar",
-				"-xzf",
-				join(temporaryDirectory, "thread.tgz"),
-				"-C",
-				installedPackage,
-				"--strip-components=1",
+				"bun",
+				"add",
+				"--ignore-scripts",
+				`react@${metadata.devDependencies.react}`,
+				`@ai-sdk/react@${metadata.devDependencies["@ai-sdk/react"]}`,
+				`@types/react@${metadata.devDependencies["@types/react"]}`,
+				`typescript@${metadata.devDependencies.typescript}`,
 			],
-			packageDirectory,
+			temporaryDirectory,
 		);
 
 		const indexSource = await readFile(
@@ -103,6 +133,17 @@ if (typeof chat.id !== "string" || typeof useThread !== "function") {
   throw new Error("Package exports did not load");
 }
 `;
+		const resolutionConsumerPath = join(temporaryDirectory, "resolution.mjs");
+		await writeFile(
+			resolutionConsumerPath,
+			`
+import assert from "node:assert/strict";
+for (const [specifier, file] of [["@chat-js/thread", "index.js"], ["@chat-js/thread/react", "react.js"]]) {
+  assert.equal(import.meta.resolve(specifier), new URL("./node_modules/@chat-js/thread/dist/" + file, import.meta.url).href);
+}
+`,
+		);
+		run(["node", resolutionConsumerPath], temporaryDirectory);
 		const runtimeConsumerPath = join(temporaryDirectory, "consumer.mjs");
 		const typeConsumerPath = join(temporaryDirectory, "consumer.ts");
 		await Promise.all([
@@ -113,7 +154,7 @@ if (typeof chat.id !== "string" || typeof useThread !== "function") {
 		run(["node", runtimeConsumerPath], temporaryDirectory);
 		run(
 			[
-				join(packageDirectory, "node_modules/.bin/tsc"),
+				join(temporaryDirectory, "node_modules/.bin/tsc"),
 				"--ignoreConfig",
 				"--noEmit",
 				"--strict",
@@ -131,4 +172,4 @@ if (typeof chat.id !== "string" || typeof useThread !== "function") {
 	} finally {
 		await rm(temporaryDirectory, { force: true, recursive: true });
 	}
-}, 30_000);
+}, 180_000);

--- a/packages/thread/test/package-smoke.test.ts
+++ b/packages/thread/test/package-smoke.test.ts
@@ -1,8 +1,16 @@
 import { expect, test } from "bun:test";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+	mkdir,
+	mkdtemp,
+	readFile,
+	rm,
+	symlink,
+	writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
+const smokeTimeout = 180_000;
 const packageDirectory = resolve(import.meta.dir, "..");
 
 function run(command: string[], cwd: string) {
@@ -12,7 +20,7 @@ function run(command: string[], cwd: string) {
 		killSignal: "SIGKILL",
 		stderr: "pipe",
 		stdout: "pipe",
-		timeout: 60_000,
+		timeout: smokeTimeout,
 	});
 	if (result.exitCode !== 0) {
 		throw new Error(
@@ -25,52 +33,73 @@ function run(command: string[], cwd: string) {
 	}
 }
 
-test("the packed package loads its core and React entry points", async () => {
-	const temporaryDirectory = await mkdtemp(
-		join(tmpdir(), "chatjs-thread-package-"),
-	);
-
-	try {
-		run(["bun", "run", "build"], packageDirectory);
-		run(
-			[
-				"bun",
-				"pm",
-				"pack",
-				"--filename",
-				join(temporaryDirectory, "thread.tgz"),
-				"--ignore-scripts",
-				"--quiet",
-			],
-			packageDirectory,
+test(
+	"the packed package loads its core and React entry points",
+	async () => {
+		const temporaryDirectory = await mkdtemp(
+			join(tmpdir(), "chatjs-thread-package-"),
 		);
 
-		const installedPackage = join(
-			temporaryDirectory,
-			"node_modules",
-			"@chat-js",
-			"thread",
-		);
-		const metadata = await Bun.file(
-			join(packageDirectory, "package.json"),
-		).json();
-		await writeFile(
-			join(temporaryDirectory, "package.json"),
-			JSON.stringify({
-				private: true,
-				type: "module",
-				dependencies: {
-					"@chat-js/thread": "file:./thread.tgz",
-					ai: metadata.devDependencies.ai,
-				},
-			}),
-		);
-		run(["bun", "install", "--ignore-scripts"], temporaryDirectory);
+		try {
+			run(["bun", "run", "build"], packageDirectory);
+			run(
+				[
+					"bun",
+					"pm",
+					"pack",
+					"--filename",
+					join(temporaryDirectory, "thread.tgz"),
+					"--ignore-scripts",
+					"--quiet",
+				],
+				packageDirectory,
+			);
 
-		const coreConsumerPath = join(temporaryDirectory, "core.mjs");
-		await writeFile(
-			coreConsumerPath,
-			`
+			const installedPackage = join(
+				temporaryDirectory,
+				"node_modules",
+				"@chat-js",
+				"thread",
+			);
+			await writeFile(
+				join(temporaryDirectory, "package.json"),
+				JSON.stringify({
+					private: true,
+					type: "module",
+					dependencies: {
+						"@chat-js/thread": "file:./thread.tgz",
+					},
+				}),
+			);
+			// Unpack the actual distribution outside the workspace. Linking only the
+			// lockfile-installed peers keeps this check independent of npm availability.
+			await mkdir(installedPackage, { recursive: true });
+			run(
+				[
+					"tar",
+					"-xzf",
+					join(temporaryDirectory, "thread.tgz"),
+					"--strip-components=1",
+					"-C",
+					installedPackage,
+				],
+				temporaryDirectory,
+			);
+			async function linkDependency(name: string) {
+				const destination = join(temporaryDirectory, "node_modules", name);
+				await mkdir(dirname(destination), { recursive: true });
+				await symlink(
+					dirname(Bun.resolveSync(`${name}/package.json`, packageDirectory)),
+					destination,
+					"dir",
+				);
+			}
+			await linkDependency("ai");
+
+			const coreConsumerPath = join(temporaryDirectory, "core.mjs");
+			await writeFile(
+				coreConsumerPath,
+				`
 import assert from "node:assert/strict";
 import { Thread } from "@chat-js/thread";
 assert.equal(import.meta.resolve("@chat-js/thread"), new URL("./node_modules/@chat-js/thread/dist/index.js", import.meta.url).href);
@@ -78,53 +107,46 @@ assert.equal(typeof new Thread().id, "string");
 assert.throws(() => import.meta.resolve("react"), { code: "ERR_MODULE_NOT_FOUND" });
 assert.throws(() => import.meta.resolve("@ai-sdk/react"), { code: "ERR_MODULE_NOT_FOUND" });
 `,
-		);
-		run(["node", coreConsumerPath], temporaryDirectory);
-		run(
-			[
-				"bun",
-				"add",
-				"--ignore-scripts",
-				`react@${metadata.devDependencies.react}`,
-				`@ai-sdk/react@${metadata.devDependencies["@ai-sdk/react"]}`,
-				`@types/react@${metadata.devDependencies["@types/react"]}`,
-				`typescript@${metadata.devDependencies.typescript}`,
-			],
-			temporaryDirectory,
-		);
+			);
+			run(["node", coreConsumerPath], temporaryDirectory);
+			await Promise.all(
+				["react", "@ai-sdk/react", "@types/react", "typescript"].map(
+					linkDependency,
+				),
+			);
 
-		const indexSource = await readFile(
-			join(installedPackage, "dist/index.js"),
-			"utf8",
-		);
-		const reactSource = await readFile(
-			join(installedPackage, "dist/react.js"),
-			"utf8",
-		);
-		const packageMetadata = await Bun.file(
-			join(installedPackage, "package.json"),
-		).json();
-		const indexChunk = indexSource.match(/from "(\.\/chunk-[^"]+\.js)"/)?.[1];
-		const reactChunk = reactSource.match(/from "(\.\/chunk-[^"]+\.js)"/)?.[1];
+			const indexSource = await readFile(
+				join(installedPackage, "dist/index.js"),
+				"utf8",
+			);
+			const reactSource = await readFile(
+				join(installedPackage, "dist/react.js"),
+				"utf8",
+			);
+			const packageMetadata = await Bun.file(
+				join(installedPackage, "package.json"),
+			).json();
+			const indexChunk = indexSource.match(/from "(\.\/chunk-[^"]+\.js)"/)?.[1];
+			const reactChunk = reactSource.match(/from "(\.\/chunk-[^"]+\.js)"/)?.[1];
 
-		expect(packageMetadata.peerDependenciesMeta).toEqual({
-			"@ai-sdk/react": { optional: true },
-			react: { optional: true },
-		});
-		expect(reactSource.startsWith('"use client";')).toBeTrue();
-		expect(reactSource.match(/"use client";/g)).toHaveLength(1);
-		expect(indexChunk).toBeDefined();
-		expect(reactChunk).toBe(indexChunk);
-		expect(reactSource).not.toContain("class Thread");
-		if (!reactChunk) throw new Error("Expected a shared package chunk");
-		const coreChunkPath = resolve(installedPackage, "dist", reactChunk);
-		expect(await Bun.file(coreChunkPath).exists()).toBeTrue();
-		const coreChunkSource = await readFile(coreChunkPath, "utf8");
-		expect(indexSource).not.toContain('from "react"');
-		expect(coreChunkSource).not.toContain('from "react"');
-		expect(coreChunkSource).not.toContain('from "@ai-sdk/react"');
+			expect(packageMetadata.peerDependenciesMeta).toEqual({
+				"@ai-sdk/react": { optional: true },
+				react: { optional: true },
+			});
+			expect(reactSource.startsWith('"use client";')).toBeTrue();
+			expect(reactSource.match(/"use client";/g)).toHaveLength(1);
+			expect(indexChunk).toBeDefined();
+			expect(reactChunk).toBe(indexChunk);
+			expect(reactSource).not.toContain("class Thread");
+			if (!reactChunk) throw new Error("Expected a shared package chunk");
+			const coreChunkPath = resolve(installedPackage, "dist", reactChunk);
+			expect(await Bun.file(coreChunkPath).exists()).toBeTrue();
+			const coreChunkSource = await readFile(coreChunkPath, "utf8");
+			expect(indexSource).not.toContain('from "react"');
+			expect(coreChunkSource).not.toContain('from "react"');
+			expect(coreChunkSource).not.toContain('from "@ai-sdk/react"');
 
-		const consumerSource = `
+			const consumerSource = `
 import { Thread } from "@chat-js/thread";
 import { useThread } from "@chat-js/thread/react";
 
@@ -133,43 +155,46 @@ if (typeof chat.id !== "string" || typeof useThread !== "function") {
   throw new Error("Package exports did not load");
 }
 `;
-		const resolutionConsumerPath = join(temporaryDirectory, "resolution.mjs");
-		await writeFile(
-			resolutionConsumerPath,
-			`
+			const resolutionConsumerPath = join(temporaryDirectory, "resolution.mjs");
+			await writeFile(
+				resolutionConsumerPath,
+				`
 import assert from "node:assert/strict";
 for (const [specifier, file] of [["@chat-js/thread", "index.js"], ["@chat-js/thread/react", "react.js"]]) {
   assert.equal(import.meta.resolve(specifier), new URL("./node_modules/@chat-js/thread/dist/" + file, import.meta.url).href);
 }
 `,
-		);
-		run(["node", resolutionConsumerPath], temporaryDirectory);
-		const runtimeConsumerPath = join(temporaryDirectory, "consumer.mjs");
-		const typeConsumerPath = join(temporaryDirectory, "consumer.ts");
-		await Promise.all([
-			writeFile(runtimeConsumerPath, consumerSource),
-			writeFile(typeConsumerPath, consumerSource),
-		]);
+			);
+			run(["node", resolutionConsumerPath], temporaryDirectory);
+			const runtimeConsumerPath = join(temporaryDirectory, "consumer.mjs");
+			const typeConsumerPath = join(temporaryDirectory, "consumer.ts");
+			await Promise.all([
+				writeFile(runtimeConsumerPath, consumerSource),
+				writeFile(typeConsumerPath, consumerSource),
+			]);
 
-		run(["node", runtimeConsumerPath], temporaryDirectory);
-		run(
-			[
-				join(temporaryDirectory, "node_modules/.bin/tsc"),
-				"--ignoreConfig",
-				"--noEmit",
-				"--strict",
-				"--skipLibCheck",
-				"--target",
-				"ES2022",
-				"--module",
-				"ESNext",
-				"--moduleResolution",
-				"Bundler",
-				typeConsumerPath,
-			],
-			temporaryDirectory,
-		);
-	} finally {
-		await rm(temporaryDirectory, { force: true, recursive: true });
-	}
-}, 180_000);
+			run(["node", runtimeConsumerPath], temporaryDirectory);
+			run(
+				[
+					"node",
+					join(temporaryDirectory, "node_modules/typescript/bin/tsc"),
+					"--ignoreConfig",
+					"--noEmit",
+					"--strict",
+					"--skipLibCheck",
+					"--target",
+					"ES2022",
+					"--module",
+					"ESNext",
+					"--moduleResolution",
+					"Bundler",
+					typeConsumerPath,
+				],
+				temporaryDirectory,
+			);
+		} finally {
+			await rm(temporaryDirectory, { force: true, recursive: true });
+		}
+	},
+	smokeTimeout,
+);


### PR DESCRIPTION
The package smoke test extracted the tarball under the old npm scope and could resolve workspace code instead of the packed artifact. It now unpacks the distribution outside the repository, verifies Node resolves those exports, and checks core-only usage without React plus React entry-point and consumer type loading. It reuses lockfile-installed peers so CI does not depend on registry availability. Include the Apache license in the distribution.

Validation: all 65 package tests, `bun lint`, and `bun test:types` pass. Pack dry-run includes LICENSE. Subprocess and test timeouts share a 180-second budget. This verifies the packed artifact; a live registry installation remains a publication check.