### PR TITLE
fix(release): report failed package publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,40 +75,39 @@ jobs:
             local lookup
             if lookup="$(npm view "${name}@${version}" version --json)"; then
               echo "${tag} already on npm"
-              return 0
-            fi
+            else
+              # Only a genuine missing version should trigger publication.
+              if ! printf '%s' "$lookup" | node -e '
+                let input = "";
+                process.stdin.on("data", chunk => input += chunk);
+                process.stdin.on("end", () => {
+                  try { process.exit(JSON.parse(input).error?.code === "E404" ? 0 : 1); }
+                  catch { process.exit(1); }
+                });
+              '; then
+                echo "::error::Could not query npm for ${tag}; refusing to treat a registry/authentication failure as a missing version."
+                return 1
+              fi
 
-            # Only a genuine missing version should trigger publication.
-            if ! printf '%s' "$lookup" | node -e '
-              let input = "";
-              process.stdin.on("data", chunk => input += chunk);
-              process.stdin.on("end", () => {
-                try { process.exit(JSON.parse(input).error?.code === "E404" ? 0 : 1); }
-                catch { process.exit(1); }
-              });
-            '; then
-              echo "::error::Could not query npm for ${tag}; refusing to treat a registry/authentication failure as a missing version."
-              return 1
-            fi
+              echo "Publishing ${tag} (first publish cannot use OIDC)"
+              bun --filter "${name}" build
+              if ! npm publish --workspace "${name}" --access public --no-provenance; then
+                echo "::error::Could not publish ${tag}. Create it once locally with 2FA (npm publish --access public --no-provenance in ${workspace_dir}), then add GitHub Actions as a trusted publisher on npmjs.com."
+                return 1
+              fi
 
-            echo "Publishing ${tag} (first publish cannot use OIDC)"
-            bun --filter "${name}" build
-            if ! npm publish --workspace "${name}" --access public --no-provenance; then
-              echo "::error::Could not publish ${tag}. Create it once locally with 2FA (npm publish --access public --no-provenance in ${workspace_dir}), then add GitHub Actions as a trusted publisher on npmjs.com."
-              return 1
-            fi
-
-            if [ "$(npm view "${tag}" version)" != "$version" ]; then
-              echo "::error::Published version ${tag} could not be verified on npm."
-              return 1
+              if [ "$(npm view "${tag}" version)" != "$version" ]; then
+                echo "::error::Published version ${tag} could not be verified on npm."
+                return 1
+              fi
             fi
 
             if git rev-parse "${tag}" >/dev/null 2>&1; then
               echo "tag ${tag} already exists"
             else
               git tag "${tag}"
-              git push origin "${tag}"
             fi
+            git push origin "${tag}"
 
             if gh release view "${tag}" >/dev/null 2>&1; then
               echo "GitHub release ${tag} already exists"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,6 @@ jobs:
 
       - name: Create Release Pull Request or Publish
         id: changesets
-        continue-on-error: true
         uses: changesets/action@v1
         with:
           publish: bun run release
@@ -54,9 +53,10 @@ jobs:
       # Trusted publishing cannot create a package's first version, and it is
       # only configured for @chat-js/cli today. Finish any unpublished packages
       # with the classic token so a partial Changesets publish cannot leave
-      # @chat-js/thread (or similar first releases) off npm.
+      # @chat-js/thread (or similar first releases) off npm. Do not publish
+      # the old version while Changesets is still preparing a version PR.
       - name: Publish first-time packages
-        if: always() && (steps.changesets.outcome == 'success' || steps.changesets.outcome == 'failure')
+        if: always() && steps.changesets.outputs.hasChangesets == 'false' && (steps.changesets.outcome == 'success' || steps.changesets.outcome == 'failure')
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -72,16 +72,35 @@ jobs:
             version="$(node -p "require('./${workspace_dir}/package.json').version")"
             tag="${name}@${version}"
 
-            if npm view "${name}@${version}" version >/dev/null 2>&1; then
+            local lookup
+            if lookup="$(npm view "${name}@${version}" version --json)"; then
               echo "${tag} already on npm"
               return 0
+            fi
+
+            # Only a genuine missing version should trigger publication.
+            if ! printf '%s' "$lookup" | node -e '
+              let input = "";
+              process.stdin.on("data", chunk => input += chunk);
+              process.stdin.on("end", () => {
+                try { process.exit(JSON.parse(input).error?.code === "E404" ? 0 : 1); }
+                catch { process.exit(1); }
+              });
+            '; then
+              echo "::error::Could not query npm for ${tag}; refusing to treat a registry/authentication failure as a missing version."
+              return 1
             fi
 
             echo "Publishing ${tag} (first publish cannot use OIDC)"
             bun --filter "${name}" build
             if ! npm publish --workspace "${name}" --access public --no-provenance; then
-              echo "::warning::Could not publish ${tag}. Create it once locally with 2FA (npm publish --access public --no-provenance in ${workspace_dir}), then add GitHub Actions as a trusted publisher on npmjs.com."
-              return 0
+              echo "::error::Could not publish ${tag}. Create it once locally with 2FA (npm publish --access public --no-provenance in ${workspace_dir}), then add GitHub Actions as a trusted publisher on npmjs.com."
+              return 1
+            fi
+
+            if [ "$(npm view "${tag}" version)" != "$version" ]; then
+              echo "::error::Published version ${tag} could not be verified on npm."
+              return 1
             fi
 
             if git rev-parse "${tag}" >/dev/null 2>&1; then

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -40,9 +40,10 @@ jobs:
             fi
           fi
       - uses: oven-sh/setup-bun@v2
-        if: steps.affected.outputs.run == 'true'
         with:
           bun-version: 1.3.1
+      - name: Test release recovery
+        run: bun test scripts/release-fallback.test.ts
       - uses: actions/cache@v4
         if: steps.affected.outputs.run == 'true'
         with:

--- a/scripts/release-fallback.test.ts
+++ b/scripts/release-fallback.test.ts
@@ -1,0 +1,134 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Exercise the actual workflow function with fake external services. No credentials,
+// npm publication, GitHub writes, or changes to the checkout are involved.
+const workflow = Bun.YAML.parse(
+	await Bun.file(
+		new URL("../.github/workflows/release.yml", import.meta.url),
+	).text(),
+);
+const step = workflow.jobs.release.steps.find(
+	(step: { name?: string }) => step.name === "Publish first-time packages",
+);
+const fallback = step.run.slice(step.run.indexOf("publish_if_missing()"));
+
+const services = `
+node() {
+  if [ "$1" = "-p" ]; then
+    case "$2" in
+      *.name) echo '@chat-js/thread' ;;
+      *.version) echo '0.1.0' ;;
+      *) return 1 ;;
+    esac
+  else
+    command node "$@"
+  fi
+}
+npm() {
+  echo "npm $*" >> calls
+  if [ -f fail-lookup ]; then echo '{"error":{"code":"E401"}}'; return 1; fi
+  if [ "$1" = publish ]; then touch published; return 0; fi
+  if [ -f published ]; then
+    if [ "$#" = 3 ] && [ -f fail-verification ]; then return 1; fi
+    if [ "$#" = 3 ]; then echo '0.1.0'; else echo '"0.1.0"'; fi
+    return 0
+  fi
+  echo '{"error":{"code":"E404"}}'
+  return 1
+}
+bun() { echo "bun $*" >> calls; }
+git() {
+  echo "git $*" >> calls
+  case "$1" in
+    rev-parse) test -f tagged ;;
+    tag) touch tagged ;;
+    push) test ! -f fail-push ;;
+    *) return 1 ;;
+  esac
+}
+gh() {
+  echo "gh $*" >> calls
+  case "$2" in
+    view) test -f released ;;
+    create) touch released ;;
+    *) return 1 ;;
+  esac
+}
+`;
+
+test("retry repairs release metadata without republishing after verification fails", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "chatjs-release-test-"));
+	try {
+		const run = () =>
+			Bun.spawnSync(["bash", "-euo", "pipefail", "-c", services + fallback], {
+				cwd: directory,
+			});
+		await Bun.write(join(directory, "fail-verification"), "");
+		expect(run().exitCode).not.toBe(0);
+		expect(await Bun.file(join(directory, "published")).exists()).toBe(true);
+		expect(await Bun.file(join(directory, "tagged")).exists()).toBe(false);
+		await rm(join(directory, "fail-verification"));
+		expect(run().exitCode).toBe(0);
+		expect(await Bun.file(join(directory, "released")).exists()).toBe(true);
+		expect(run().exitCode).toBe(0);
+		const calls = await Bun.file(join(directory, "calls")).text();
+		expect(calls.match(/^npm publish /gm)).toHaveLength(1);
+		expect(calls.match(/^git tag /gm)).toHaveLength(1);
+		expect(calls.match(/^gh release create /gm)).toHaveLength(1);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("retry pushes an existing local tag after the first push fails", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "chatjs-release-test-"));
+	try {
+		const run = () =>
+			Bun.spawnSync(["bash", "-euo", "pipefail", "-c", services + fallback], {
+				cwd: directory,
+			});
+		await Bun.write(join(directory, "published"), "");
+		await Bun.write(join(directory, "fail-push"), "");
+		expect(run().exitCode).not.toBe(0);
+		expect(await Bun.file(join(directory, "tagged")).exists()).toBe(true);
+		expect(await Bun.file(join(directory, "released")).exists()).toBe(false);
+		await rm(join(directory, "fail-push"));
+		expect(run().exitCode).toBe(0);
+		expect(await Bun.file(join(directory, "released")).exists()).toBe(true);
+		const calls = await Bun.file(join(directory, "calls")).text();
+		expect(calls).not.toContain("npm publish");
+		expect(calls.match(/^git push /gm)).toHaveLength(2);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+for (const lookupFails of [false, true]) {
+	test(
+		lookupFails
+			? "registry authentication failure never triggers publication"
+			: "missing version publishes and creates release metadata",
+		async () => {
+			const directory = await mkdtemp(join(tmpdir(), "chatjs-release-test-"));
+			try {
+				if (lookupFails) await Bun.write(join(directory, "fail-lookup"), "");
+				const result = Bun.spawnSync(
+					["bash", "-euo", "pipefail", "-c", services + fallback],
+					{ cwd: directory },
+				);
+				expect(result.exitCode === 0).toBe(!lookupFails);
+				expect(await Bun.file(join(directory, "published")).exists()).toBe(
+					!lookupFails,
+				);
+				expect(await Bun.file(join(directory, "released")).exists()).toBe(
+					!lookupFails,
+				);
+			} finally {
+				await rm(directory, { recursive: true, force: true });
+			}
+		},
+	);
+}


### PR DESCRIPTION
Release workflows could report success when Changesets or the first-package fallback failed. Preserve those failures, distinguish npm E404 from authentication/network failures, and verify a newly published version before creating metadata. Skip the fallback while Changesets is preparing a version PR so it cannot publish an old version prematurely.

Retries now skip only an already-completed publication and continue creating missing tags and GitHub release metadata. An existing local tag is pushed again so a failed tag push is recoverable.

Validation: `bun lint`, `bun test:types`, and four regression tests pass. The tests execute the actual workflow function with mocked services and cover verification failure followed by retry without duplicate publication, tag push recovery, first publication, and authentication failure. Unit CI runs these tests on every PR. No actual package publication was performed.