### PR TITLE
docs: explain standalone Thread adoption and compatibility

### DIFF
--- a/apps/docs/blume.config.ts
+++ b/apps/docs/blume.config.ts
@@ -154,6 +154,7 @@ export default defineConfig({
           root: "/cookbook",
           items: [
             "/cookbook",
+            "/cookbook/threaded-chat",
             "/cookbook/resumable-streams",
             "/cookbook/stop-resumable-streams",
             "/cookbook/tool-part",

--- a/apps/docs/cookbook/index.mdx
+++ b/apps/docs/cookbook/index.mdx
@@ -13,6 +13,9 @@ The Cookbook contains self-contained, portable patterns you can copy into any AI
 Patterns for handling real-time AI response streams.
 
 <CardGroup cols={2}>
+  <Card title="Threaded Chat" href="./threaded-chat">
+    Add branching and independent responses to an existing AI SDK app
+  </Card>
   <Card title="Resumable Streams" href="/cookbook/resumable-streams">
     Continue AI responses after connection interruptions using Redis pub/sub
   </Card>

--- a/apps/docs/cookbook/threaded-chat.mdx
+++ b/apps/docs/cookbook/threaded-chat.mdx
@@ -1,0 +1,169 @@
+---
+title: "Add branching to an existing app"
+description: "Connect useThread to your AI SDK endpoint and navigate independent response branches"
+---
+
+Use `@chat-js/thread` inside your own React application without installing the
+ChatJS starter. You need Node.js 22 or later, React 18 or later and an AI SDK 7
+endpoint that returns UI message streams. The repository tests use React 19.2.3.
+
+## Install
+
+```bash
+bun add @chat-js/thread ai@^7.0.93 @ai-sdk/react@^4.0.96 react
+```
+
+AI SDK 6 applications need to upgrade their SDK and provider packages first.
+The package version is independent of the ChatJS application and CLI versions.
+
+## Connect your server
+
+Keep your existing AI SDK endpoint if it accepts the selected `messages` path
+and returns a UI message stream. Each response runs a separate request. Your
+endpoint must allow concurrent requests for the same conversation.
+
+This minimal Next.js route demonstrates the protocol. Set `AI_GATEWAY_API_KEY`
+on your server and choose an enabled model in your gateway. For a local example,
+place this in `app/api/chat/route.ts`:
+
+```ts
+import { convertToModelMessages, streamText, validateUIMessages } from "ai";
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const messages = await validateUIMessages({ messages: body.messages });
+  const result = streamText({
+    model: "openai/gpt-4.1-mini",
+    messages: await convertToModelMessages(messages),
+    abortSignal: request.signal,
+  });
+
+  return result.toUIMessageStreamResponse();
+}
+```
+
+Before exposing this endpoint publicly, apply your app's authentication,
+request limits and model-access policy. Validate ownership before reading or
+writing saved conversations. Client-supplied message IDs and paths are input,
+not authorization. This minimal route does not persist or resume streams.
+
+## Render and navigate branches
+
+The message list below shows the selected path. Selecting a message and sending
+continues from that node. “Another response” starts a sibling response while
+leaving the selected path unchanged.
+
+```tsx
+"use client";
+
+import { useThread } from "@chat-js/thread/react";
+import { DefaultChatTransport } from "ai";
+import { useState } from "react";
+
+export function Conversation() {
+  const [text, setText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  function reportError(cause: unknown) {
+    setError(cause instanceof Error ? cause.message : "Request failed");
+  }
+  const chat = useThread({
+    transport: new DefaultChatTransport({ api: "/api/chat" }),
+    concurrency: { maxActiveRuns: 3 },
+  });
+
+  return (
+    <section aria-label="Branching conversation">
+      {chat.messages.map((message) => (
+        <article key={message.id}>
+          <strong>{message.role}</strong>
+          {message.parts.map((part, index) =>
+            part.type === "text" ? <p key={index}>{part.text}</p> : null
+          )}
+          <button type="button" onClick={() => chat.tree.setCursor(message.id)}>
+            Continue from here
+          </button>
+          {chat.tree.getSiblings(message.id).map((sibling, index) => (
+            <button
+              key={sibling.id}
+              type="button"
+              onClick={() => chat.tree.setCursor(sibling.id)}
+            >
+              Branch {index + 1}
+            </button>
+          ))}
+          {message.role === "user" && (
+            <button
+              type="button"
+              disabled={chat.tree.activeRuns.length >= 3}
+              onClick={() => {
+                void chat.tree.startRun({ from: message.id, follow: false }).catch(reportError);
+              }}
+            >
+              Another response
+            </button>
+          )}
+        </article>
+      ))}
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (!text.trim()) return;
+          setError(null);
+          void chat.sendMessage({ text }).catch(reportError);
+          setText("");
+        }}
+      >
+        <label>
+          Message
+          <input value={text} onChange={(event) => setText(event.target.value)} />
+        </label>
+        <button type="submit" disabled={chat.tree.activeRuns.length >= 3}>
+          Send
+        </button>
+      </form>
+      {chat.tree.activeRuns.map((run) => (
+        <button key={run.id} type="button" onClick={() => chat.tree.stopRun(run.id)}>
+          Stop response {run.id}
+        </button>
+      ))}
+      {error && <p role="alert">{error}</p>}
+      {chat.tree.runs.filter((run) => run.error).map((run) => (
+        <p key={run.id} role="alert">{run.error?.message}</p>
+      ))}
+    </section>
+  );
+}
+```
+
+Try sending a prompt, starting another response from its user message, switching
+between assistant siblings, and stopping one response. The other response
+continues. Choosing an earlier message and sending creates a new path while
+preserving its descendants. To edit a user message, select its parent and send
+the edited text as a new message.
+
+## Preserve state and restore history
+
+Save `chat.tree.getSnapshot()`, not just `chat.messages`. The snapshot contains
+the complete ordered tree as `{ version: 1, cursorId, nodes }`. Restore that
+snapshot through `initialTree` when creating the controller, using the same
+conversation `id`. Loading a different conversation should create or select
+that conversation's controller rather than overwrite an active one.
+
+Persist each message ID together with its parent from `nodes`. If your server
+stores responses individually, capture the response ID from the UI message
+stream and retain the parent for that request. Do not infer the parent from
+whichever branch happens to be selected when a request finishes. Apply your
+authorization policy to both conversation and parent IDs.
+
+For controller state that survives component unmounts, create a `Thread` in your
+application runtime and pass it to `useThread({ thread })`. Keep a separate
+controller for each conversation. Your runtime decides when to stop and release
+it. A process-global server singleton would mix users and is not appropriate.
+
+Saved history and resumable execution are separate. `resume: true` or
+`resumeStream()` reconnects the selected assistant only when your server and
+transport implement stream resumption. A tree snapshot does not serialize live
+requests, retain server streams, or automatically resume all siblings.
+
+See [useThread](../core/use-thread) for the state model and
+[resumable streams](./resumable-streams) for ChatJS's server-side implementation.

--- a/apps/docs/core/use-thread.mdx
+++ b/apps/docs/core/use-thread.mdx
@@ -14,11 +14,19 @@ move between branches while responses continue streaming.
 ## Install
 
 ```bash
-bun add @chat-js/thread ai @ai-sdk/react react
+bun add @chat-js/thread ai@^7.0.93 @ai-sdk/react@^4.0.96 react
 ```
 
-Replace the `useChat` import without changing your existing message list or
-composer:
+You need Node.js 22 or later and AI SDK 7. The React adapter requires
+`@ai-sdk/react ^4.0.96` and React 18 or later. The repository tests use React
+19.2.3. AI SDK 6 applications must upgrade their SDK and provider packages
+before using this version.
+
+The headless `@chat-js/thread` entry point needs only `ai`. React applications
+import the hook from `@chat-js/thread/react`.
+
+For a compatible AI SDK application, replace the `useChat` import while keeping
+your existing message list and composer:
 
 ```diff
 - import { useChat } from "@ai-sdk/react";
@@ -30,6 +38,11 @@ composer:
 
 The top-level helpers remain compatible with `UseChatHelpers`, including
 `messages`, `sendMessage`, `regenerate`, `stop`, `status`, tools, and approvals.
+
+The hook manages client state. Your application still supplies the AI SDK
+transport, server endpoint, authentication, storage and branch controls.
+See the [existing-app recipe](../cookbook/threaded-chat) for a complete client
+and server example.
 
 ## Mental model
 
@@ -154,5 +167,17 @@ const chat = useThread({
 The snapshot is `{ version: 1, cursorId, nodes }`. Runtime indexes, active
 requests, and run adapters are not persisted.
 
-The package README documents the complete interface, transport metadata, and
-`Thread` exports.
+Restoring the tree does not restart every response. `resume: true` or
+`resumeStream()` reconnects the selected assistant through your transport's
+reconnect endpoint. Active request objects and run IDs are not durable jobs.
+Your server must retain a resumable stream and route it to the correct
+conversation and assistant. `tree.resumeRun(runId)` addresses a run that still
+exists in the live controller.
+
+The hook owns its default controller for its component lifetime. To keep
+responses running across component unmounts, retain a controller in your
+application runtime and pass `useThread({ thread })`. Do not share a
+server-side controller between users.
+
+See the [package README](https://github.com/FranciscoMoretti/chat-js/tree/main/packages/thread)
+for the external state contract and full interface.

--- a/packages/thread/README.md
+++ b/packages/thread/README.md
@@ -35,6 +35,16 @@ For React:
 bun add @chat-js/thread ai@^7.0.93 @ai-sdk/react@^4.0.96 react
 ```
 
+Requires Node.js 22 or later. This version targets AI SDK `^7.0.93` and
+`@ai-sdk/react ^4.0.96`. React peers allow 18 or later; repository tests use
+React 19.2.3. Upgrade AI SDK 6 and its provider packages before adopting this
+version. The headless core can be installed without React.
+
+The hook provides client tree and run state. Your app still owns the transport,
+server execution, authentication and storage. Start with the
+[existing-app recipe](https://chatjs.dev/docs/cookbook/threaded-chat) for a
+client/server example, then add your persistence and reconnect implementation.
+
 ## Use
 
 ```tsx


### PR DESCRIPTION
Add an existing-React-app recipe with an AI SDK endpoint, branching controls, independent responses and error handling. Align the guide and package README with SDK 7 and Node 22 requirements, and explain application-owned authentication, storage, controller lifetime and selected-assistant reconnect limits. Register and cross-link the recipe.

Validation before splitting this independent PR: `bun lint`, `bun test:types` and `bun docs:links` passed; both recipe code blocks type-check against the current dependencies. Provider-backed execution could not be verified because the local AI Gateway credentials return 401.

## Summary by Sourcery

Document how to integrate standalone Thread support into an existing AI SDK React application with branching conversations and application-managed state.

New Features:
- Add a standalone existing-app cookbook recipe demonstrating threaded conversations with branching, independent responses, concurrency controls, stopping responses, and error handling.

Enhancements:
- Clarify standalone Thread adoption requirements, application-owned authentication and persistence, controller lifetime, tree snapshots, and reconnect limitations.

Documentation:
- Register and cross-link the threaded chat cookbook recipe and align the guide and package README with Node.js 22, AI SDK 7, React compatibility, and package installation requirements.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents how to add standalone Thread to an existing AI SDK React app, with a new cookbook recipe for branching conversations and clarified compatibility requirements.

**Documentation**
- Adds a `threaded-chat` recipe covering endpoint setup, branching controls, concurrency limits, and error handling.
- Aligns install commands with Node.js 22, AI SDK 7 (`ai@^7.0.93`), and `@ai-sdk/react ^4.0.96`; AI SDK 6 apps must upgrade first.
- Clarifies application-owned authentication and storage, controller lifetime across unmounts, and that tree snapshots do not resume live streams.
- Registers and cross-links the recipe in the cookbook index.
- Provider-backed execution wasn't verified because local AI Gateway credentials return 401.

<sup>Written for commit 9de42cab9bd91a80ecccb4c311f369317a7965fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

