### PR TITLE
fix(site): complete Thread playground response controls

### DIFF
--- a/apps/site/components/thread-showcase.tsx
+++ b/apps/site/components/thread-showcase.tsx
@@ -21,7 +21,8 @@ import {
   PlaygroundTransport,
 } from "./thread-playground-model";
 
-const INSTALL_COMMAND = "bun add @chat-js/thread ai @ai-sdk/react";
+const INSTALL_COMMAND =
+  "bun add @chat-js/thread ai@^7.0.93 @ai-sdk/react@^4.0.96 react";
 const MAX_ACTIVE_RUNS = 8;
 
 const STATUS_CLASS = {
@@ -90,7 +91,7 @@ function Conversation({
   responseCount: number;
 }) {
   return (
-    <section className="flex min-h-[43rem] min-w-0 flex-col">
+    <section className="flex h-[43rem] min-w-0 flex-col">
       <header className="flex min-h-16 flex-wrap items-center justify-between gap-3 border-border border-b px-5 py-3">
         <div>
           <p className="font-medium text-sm">Active conversation</p>
@@ -108,7 +109,7 @@ function Conversation({
         </div>
       </header>
 
-      <div className="flex-1 space-y-5 overflow-y-auto p-5 sm:p-7">
+      <div className="min-h-0 flex-1 space-y-5 overflow-y-auto p-5 sm:p-7">
         {chat.messages.map((message) => {
           const isUser = message.role === "user";
           const siblings = chat.tree.getSiblings(message.id);
@@ -226,6 +227,18 @@ function Conversation({
               </select>
             </label>
             <div className="flex items-center gap-1.5">
+              <button
+                aria-label="Stop selected response"
+                className="h-8 px-2 text-muted-foreground text-xs hover:bg-secondary hover:text-foreground disabled:opacity-30"
+                disabled={
+                  chat.status !== "submitted" && chat.status !== "streaming"
+                }
+                onClick={() => chat.stop()}
+                title="Stop selected response"
+                type="button"
+              >
+                Stop selected
+              </button>
               <button
                 aria-label="Stop all responses"
                 className="grid size-8 place-items-center text-muted-foreground hover:bg-secondary hover:text-foreground disabled:opacity-30"
@@ -481,7 +494,7 @@ export function ThreadPlayground() {
           playgroundError={playgroundError}
           responseCount={responseCount}
         />
-        <aside className="flex min-h-[43rem] min-w-0 flex-col border-border border-t bg-muted/15 lg:border-t-0 lg:border-l">
+        <aside className="flex h-[43rem] min-w-0 flex-col border-border border-t bg-muted/15 lg:border-t-0 lg:border-l">
           <header className="flex min-h-16 items-center justify-between border-border border-b px-5 py-3">
             <div>
               <p className="font-medium text-sm">Message tree</p>


### PR DESCRIPTION
The Threads page promised individual response cancellation, but the playground only exposed stop-all. Add a selected-response stop control, bound transcript/tree scrolling so growing branches keep the composer visible, and align the copied install command with SDK 7 peer requirements.

Validation before splitting this independent PR: `bun lint` and `bun test:types` passed. Playwright/Chromium on localhost:3012 verified three concurrent siblings, stopping the selected response while the other two continue, navigating during streaming, returning to preserved output, continuing from a sibling, and stop-all. Desktop and 390px mobile checks passed with no page errors or horizontal page overflow. The playground uses simulated local streams; these checks do not establish provider-backed persistence or reconnect.

## Summary by Sourcery

Complete the Thread playground’s response controls and scrolling behavior while aligning its installation guidance with current SDK requirements.

New Features:
- Add a control to stop the currently selected response independently of other active responses.

Bug Fixes:
- Keep the conversation and message tree panels bounded so streaming content scrolls within the playground and keeps the composer visible.

Enhancements:
- Update the copied installation command to include compatible SDK 7 peer dependencies.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Thread playground previously only offered stop-all; it now adds a stop-selected button for individual responses. The layout also keeps the composer visible while branches grow, and the install command aligns with SDK 7 peer requirements.

- Adds a "Stop selected" button that cancels only the selected response, letting sibling streams continue.
- Switches conversation and tree containers to fixed heights with `min-h-0` so scrolling keeps the composer visible.
- Updates the install command to `bun add @chat-js/thread ai@^7.0.93 @ai-sdk/react@^4.0.96 react`.

<sup>Written for commit 25f728641ff4a7b962dad9791bc4a9daca5fb718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

