### PR TITLE
Fix gateway registry installation and configuration review findings

### DIFF
--- a/apps/chat/lib/ai/gateways/registry.ts
+++ b/apps/chat/lib/ai/gateways/registry.ts
@@ -4,7 +4,7 @@ import { gatewayType } from "../gateway-model-defaults";
 import type { generatedForGateway, models } from "../models.generated";
 
 export type InstalledGateway = InstanceType<typeof Gateway>;
-export type GatewayType = InstalledGateway["type"];
+export type GatewayType = typeof gatewayType;
 export type GatewayProvider = GatewayProviderBase<GatewayType>;
 export const DEFAULT_GATEWAY = gatewayType;
 export type DefaultGateway = GatewayType;

--- a/apps/chat/scripts/check-env.ts
+++ b/apps/chat/scripts/check-env.ts
@@ -210,8 +210,7 @@ function resolveToolsDir(toolsPath: string): string {
 }
 
 function validateGatewayKey(env: NodeJS.ProcessEnv): ValidationError | null {
-  // Prevent TS from narrowing to the current literal config value.
-  const gateway = (() => config.ai.gateway as string)();
+  const gateway: string = config.ai.gateway;
   const missing = gatewayEnvRequirements
     .map((requirement) => getMissingRequirement(requirement, env))
     .filter((value) => value !== null);
@@ -410,7 +409,7 @@ function validateBaseUrl(env: NodeJS.ProcessEnv): ValidationError | null {
 }
 
 function checkGatewaySnapshot(): string | null {
-  if ((config.ai.gateway as string) === generatedForGateway) {
+  if (config.ai.gateway === generatedForGateway) {
     return null;
   }
   return `models.generated.ts was built for "${generatedForGateway}" but config uses "${config.ai.gateway}". Run \`bun fetch:models\` to update the fallback snapshot.`;

--- a/apps/docs/features/reasoning.mdx
+++ b/apps/docs/features/reasoning.mdx
@@ -45,7 +45,7 @@ Each provider activates reasoning differently. ChatJS handles this automatically
 
 ### Adjusting reasoning budgets
 
-Modify the token budgets in `lib/ai/providers.ts` inside the `getModelProviderOptions` function:
+The defaults live in `packages/gateways/src/provider-options.ts` in the ChatJS repository. In a generated app, customize the returned options in `lib/ai/providers.ts`, after calling the shared `getModelProviderOptions` helper. Override the nested provider budget you want to change:
 
 ```ts
 // Anthropic thinking budget

--- a/apps/docs/gateways/custom.mdx
+++ b/apps/docs/gateways/custom.mdx
@@ -1,307 +1,57 @@
 ---
 title: "Custom Gateway"
-description: "Add a new AI gateway to the multi-gateway system"
+description: "Compose a ChatJS app with a third-party gateway registry item"
 ---
 
-Add support for any AI provider by implementing the `GatewayProvider` interface and registering it. If your provider follows the OpenAI API format, consider using the built-in [OpenAI Compatible](/gateways/openai-compatible) gateway instead.
+Install a custom gateway when creating your app. If your endpoint implements the OpenAI API, you can also use the built-in [OpenAI Compatible](/gateways/openai-compatible) gateway.
 
-## Steps
-
-### 1. Install the provider SDK
-
-If your provider has an AI SDK adapter, install it:
-
-```bash
-bun add @ai-sdk/openai-compatible
+```sh
+chat-js create my-chat --gateway https://example.com/r/my-gateway.json
+chat-js create my-chat --gateway ./my-gateway.json
 ```
 
-For providers with a dedicated SDK (like `@ai-sdk/openai` or `@openrouter/ai-sdk-provider`), install that instead.
+Remote registry items and their dependencies require HTTPS. HTTP is supported for loopback development servers only.
 
-### 2. Add environment variables
+## Author a registry item
 
-Register the required env vars in `lib/env-schema.ts`:
+Start from a built-in item in the [gateway registry](https://github.com/FranciscoMoretti/chat-js/tree/main/packages/registry/gateways). The [authoring contract](https://github.com/FranciscoMoretti/chat-js/blob/main/packages/registry/gateways/README.md) describes the complete metadata and adapter interface.
 
-```ts title="lib/env-schema.ts"
-export const serverEnvSchema = {
-  // ... existing vars
+Your root item must use `type: "registry:item"`. Declare its SDK in `dependencies`, and include an adapter exporting `Gateway` at `~/lib/ai/gateway.ts`. Supporting files belong under `~/lib/ai/gateway/` and can come from `registryDependencies`.
 
-  // My Gateway (required when config.ai.gateway is "my-gateway")
-  MY_GATEWAY_BASE_URL: z.string().url().optional(),
-  MY_GATEWAY_API_KEY: z.string().optional(),
-};
-```
+Set `meta.chatjs` with:
 
-Register the build-time requirement in `lib/config-requirements.ts` as well. The `Record<GatewayType, EnvRequirement>` type reports a missing entry after you add the gateway to the registry:
+- `kind: "gateway"`, `contractVersion: 1`, and a unique literal `id`.
+- `capabilities` describing image and video support.
+- Complete `defaults` for models, workflows, documents, and tools. Use model IDs served by your endpoint.
+- `envRequirements`, an array of required groups. Each group's `options` contains alternative sets of variables.
+- `optionalEnv` for additional variables the adapter reads.
 
-```ts title="lib/config-requirements.ts"
-export const gatewayEnvRequirements: Record<GatewayType, EnvRequirement> = {
-  // ... existing gateways
-  "my-gateway": {
-    options: [["MY_GATEWAY_BASE_URL", "MY_GATEWAY_API_KEY"]],
-    description: "MY_GATEWAY_BASE_URL, MY_GATEWAY_API_KEY",
-  },
-};
-```
+For example, an endpoint that requires a base URL and accepts an optional API key can declare:
 
-### 3. Create the gateway class
-
-Create `lib/ai/gateways/my-gateway.ts`. Every gateway implements the `GatewayProvider` interface:
-
-```ts
-type GatewayProvider<
-  TGateway,
-  TModelId,
-  TImageModelId,
-  TVideoModelId
-> = {
-  readonly type: TGateway;
-  createLanguageModel(modelId: TModelId): LanguageModel;
-  createImageModel(modelId: TImageModelId): ImageModel | null;
-  createVideoModel(modelId: TVideoModelId): Experimental_VideoModelV3 | null;
-  fetchModels(): Promise<AiGatewayModel[]>;
-};
-```
-
-Full example:
-
-```ts title="lib/ai/gateways/my-gateway.ts"
-import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
-import type { Experimental_VideoModelV3 } from "@ai-sdk/provider";
-import type { ImageModel, LanguageModel } from "ai";
-import { createModuleLogger } from "@/lib/logger";
-import type { AiGatewayModel } from "../ai-gateway-models-schemas";
-import { models as fallbackModels } from "../models.generated";
-import type { GatewayProvider } from "./gateway-provider";
-
-const log = createModuleLogger("ai/gateways/my-gateway");
-
-type MyProviderModelResponse = {
-  id: string;
-  object: string;
-  created: number;
-  owned_by: string;
-};
-
-function toAiGatewayModel(model: MyProviderModelResponse): AiGatewayModel {
-  return {
-    id: model.id,
-    object: "model",
-    created: model.created ?? 0,
-    owned_by: model.owned_by ?? "unknown",
-    name: model.id,
-    description: "",
-    context_window: 0,
-    max_tokens: 0,
-    type: "language",
-    pricing: {},
-  };
-}
-
-export class MyGateway implements GatewayProvider<
-  "my-gateway",
-  string,
-  string,
-  string
-> {
-  readonly type = "my-gateway" as const;
-
-  private getProvider() {
-    const apiKey = this.getApiKey();
-    const baseURL = this.getBaseURL();
-    if (!baseURL) {
-      throw new Error("MY_GATEWAY_BASE_URL is not configured");
-    }
-    return createOpenAICompatible({
-      name: "my-gateway",
-      baseURL,
-      apiKey,
-    });
-  }
-
-  createLanguageModel(modelId: string): LanguageModel {
-    const provider = this.getProvider();
-    return provider(modelId);
-  }
-
-  createImageModel(modelId: string): ImageModel | null {
-    // Return null if your provider does not support image generation.
-    const provider = this.getProvider();
-    return provider.imageModel(modelId);
-  }
-
-  createVideoModel(_modelId: string): Experimental_VideoModelV3 | null {
-    return null;
-  }
-
-  private getApiKey(): string | undefined {
-    return process.env.MY_GATEWAY_API_KEY;
-  }
-
-  private getBaseURL(): string | undefined {
-    return process.env.MY_GATEWAY_BASE_URL;
-  }
-
-  async fetchModels(): Promise<AiGatewayModel[]> {
-    const apiKey = this.getApiKey();
-    const baseURL = this.getBaseURL();
-
-    if (!baseURL) {
-      log.warn("No MY_GATEWAY_BASE_URL found, using fallback models");
-      return fallbackModels as unknown as AiGatewayModel[];
-    }
-
-    const url = `${baseURL}/models`;
-    log.debug({ url }, "Fetching models from my provider");
-
-    try {
-      const headers: Record<string, string> = {
-        "Content-Type": "application/json",
-      };
-      if (apiKey) {
-        headers.Authorization = `Bearer ${apiKey}`;
-      }
-
-      const response = await fetch(url, {
-        headers,
-        next: { revalidate: 3600 },
-      });
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch models: ${response.statusText}`);
-      }
-
-      const body = await response.json();
-      const models = (body.data ?? []) as MyProviderModelResponse[];
-      const result = models.map(toAiGatewayModel);
-
-      log.info({ modelCount: result.length }, "Fetched models");
-      return result;
-    } catch (error) {
-      log.error({ err: error, url }, "Error fetching models, using fallback");
-      return fallbackModels as unknown as AiGatewayModel[];
-    }
-  }
+```json
+{
+  "envRequirements": [{ "options": [["MY_GATEWAY_BASE_URL"]] }],
+  "optionalEnv": ["MY_GATEWAY_API_KEY"]
 }
 ```
 
-<Callout type="tip">
-  If your provider uses a dedicated SDK (not OpenAI-compatible), replace
-  `createOpenAICompatible` with the provider-specific factory. See the [OpenAI
-  gateway](https://github.com/franciscomoretti/chat-js/blob/main/apps/chat/lib/ai/gateways/openai-gateway.ts)
-  for an example that uses `createOpenAI`.
-</Callout>
+This is a metadata fragment, not a complete registry item. Read declared credentials through the adapter's injected environment, such as `this.env.MY_GATEWAY_API_KEY` when extending `GatewayRuntime` from `@chat-js/gateways/runtime`.
 
-### 4. Register in the gateway registry
+## Generated app
 
-Import your class and add it to the registry:
+The CLI installs the selected adapter and dependencies, then writes `lib/ai/gateway-model-defaults.ts` with the gateway ID, defaults, capabilities, and environment declarations. `lib/env.ts` forwards those declared variables to the adapter, and `scripts/check-env.ts` checks the requirements. You do not add gateway entries to a central application registry or environment schema.
 
-```ts title="lib/ai/gateways/registry.ts"
-import { MyGateway } from "./my-gateway";
+The generated `chat.config.ts` selects your gateway. Add credentials to `.env.local`, then verify the app:
 
-export const gatewayRegistry = {
-  vercel: () => new VercelGateway(),
-  openrouter: () => new OpenRouterGateway(),
-  openai: () => new OpenAIGateway(),
-  "openai-compatible": () => new OpenAICompatibleGateway(),
-  litellm: () => new LiteLLMGateway(),
-  "my-gateway": () => new MyGateway(), // add here
-} as const satisfies Record<string, () => GatewayProviderBase>;
-```
-
-### 5. Add gateway defaults
-
-Add a `myGatewayDefaults` block to `lib/ai/gateway-model-defaults.ts` and register it in `GATEWAY_MODEL_DEFAULTS`:
-
-```ts title="lib/ai/gateway-model-defaults.ts"
-export const GATEWAY_MODEL_DEFAULTS: {
-  [G in GatewayType]: ModelDefaultsFor<G>;
-} = {
-  vercel: vercelDefaults,
-  openrouter: openrouterDefaults,
-  openai: openaiDefaults,
-  "openai-compatible": openaiCompatibleDefaults,
-  litellm: litellmDefaults,
-  "my-gateway": myGatewayDefaults,
-};
-```
-
-Use the closest existing defaults block as a starting point. Update every model-backed workflow and tool default to IDs that your gateway accepts. The mapped `ModelDefaultsFor<"my-gateway">` type checks that the block is complete.
-
-### 6. Add the schema variant
-
-In `lib/config-schema.ts`, add your gateway to two places:
-
-**The schema map** (compile-time enforced):
-
-```ts title="lib/config-schema.ts"
-const gatewaySchemaMap: {
-  [G in GatewayType]: ReturnType<typeof createAiSchema<G>>;
-} = {
-  vercel: createAiSchema("vercel"),
-  openrouter: createAiSchema("openrouter"),
-  openai: createAiSchema("openai"),
-  "openai-compatible": createAiSchema("openai-compatible"),
-  litellm: createAiSchema("litellm"),
-  "my-gateway": createAiSchema("my-gateway"), // add here
-};
-```
-
-**The discriminated union** (runtime validation):
-
-```ts title="lib/config-schema.ts"
-export const aiConfigSchema = z.discriminatedUnion("gateway", [
-  gatewaySchemaMap.vercel,
-  gatewaySchemaMap.openrouter,
-  gatewaySchemaMap.openai,
-  gatewaySchemaMap["openai-compatible"],
-  gatewaySchemaMap.litellm,
-  gatewaySchemaMap["my-gateway"], // add here
-]);
-```
-
-<Callout type="note">
-  The `gatewaySchemaMap` record is typed as `[G in GatewayType]`, so TypeScript
-  shows an error if you add a gateway to the registry but forget to add it here.
-</Callout>
-
-### 7. Configure your app
-
-Set the gateway in `chat.config.ts`. Values omitted here come from the defaults you registered in the previous step:
-
-```ts title="chat.config.ts"
-const config: ConfigInput = {
-  ai: {
-    gateway: "my-gateway",
-  },
-};
-```
-
-Add the env vars to `.env.local`:
-
-```bash title=".env.local"
-MY_GATEWAY_BASE_URL=https://api.my-provider.com/v1
-MY_GATEWAY_API_KEY=sk-...
-```
-
-### 8. Verify
-
-```bash
+```sh
 bun test:types
 bun fetch:models
+bun dev
 ```
 
-## Checklist
-
-1. Install the provider SDK (`bun add ...`)
-2. Add env vars to `lib/env-schema.ts` and their requirement to `lib/config-requirements.ts`
-3. Create the gateway class in `lib/ai/gateways/`
-4. Add it to `gatewayRegistry` in `registry.ts`
-5. Add complete gateway defaults in `gateway-model-defaults.ts`
-6. Add the schema variant to `gatewaySchemaMap` and `aiConfigSchema` in `config-schema.ts`
-7. Set `ai.gateway` in `chat.config.ts`
-8. Run `bun test:types` and `bun fetch:models`
+Send a real chat message to verify provider authentication and streaming. Type checks validate the adapter interface and configuration, but cannot verify remote credentials or model availability.
 
 ## Related
 
-- [Gateways Overview](/gateways/overview) for the gateway system architecture
-- [Multi-Model Support](/core/multi-model) for model configuration
+- [Gateways Overview](/gateways/overview)
+- [Multi-Model Support](/core/multi-model)

--- a/apps/docs/gateways/openai-compatible.mdx
+++ b/apps/docs/gateways/openai-compatible.mdx
@@ -11,7 +11,7 @@ This gateway works with:
 
 - [Ollama](https://ollama.com) — local models on your machine
 - [LM Studio](https://lmstudio.ai) — local model management with a GUI
-- [vLLM](https://docs.vllm.ai) — high-throughput self-hosted inference
+- [vLLM](https://github.com/vllm-project/vllm) — high-throughput self-hosted inference
 - [Azure OpenAI](https://learn.microsoft.com/azure/ai-foundry/openai/overview) — OpenAI models on Azure
 - Any other endpoint that implements `/v1/chat/completions` and `/v1/models`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -31,7 +31,7 @@ The CLI installs only that item's adapter files and declared dependencies.
 `@chat-js/gateways` supplies shared contracts and utilities, with no gateway
 implementations. Third-party items declare their own ID, defaults, capabilities,
 and credentials; the CLI has no fixed gateway enum. See
-[gateway authoring](../registry/gateways/README.md) for the version 1 contract.
+[gateway authoring](https://github.com/FranciscoMoretti/chat-js/blob/main/packages/registry/gateways/README.md) for the version 1 contract.
 
 Run `bun --filter @chat-js/cli test:gateways` from the repository root to verify
 independent installs of all built-ins and an external registry gateway.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,7 +46,7 @@
 		"template:sync": "bun ../../scripts/sync-template.ts",
 		"prepublishOnly": "bun run build && node ./dist/index.js --help >/dev/null",
 		"test:scaffold": "bash scripts/test-scaffold.sh",
-		"test:gateways": "bun run template:sync && bun test --timeout 180000 test/gateway-selection.test.ts"
+		"test:gateways": "bun run template:sync && bun test --timeout 180000 ./test/gateway-selection.test.ts"
 	},
 	"type": "module",
 	"devDependencies": {

--- a/packages/cli/scripts/test-scaffold.sh
+++ b/packages/cli/scripts/test-scaffold.sh
@@ -68,7 +68,13 @@ NODE
     yarn) yarn install ;;
     *) echo "Unsupported package manager: $package_manager" >&2; exit 1 ;;
   esac
-  node --input-type=module -e 'for (const path of ["defaults", "models", "gateway-provider", "provider-options", "runtime", "provider-types", "definition"]) await import("@chat-js/gateways/" + path);'
+  node --input-type=module -e '
+import { createRequire } from "node:module";
+const require = createRequire(process.cwd() + "/package.json");
+const manifest = require("@chat-js/gateways/package.json");
+for (const key of Object.keys(manifest.exports)) {
+  if (key !== "./package.json") await import("@chat-js/gateways" + key.slice(1));
+}'
   popd >/dev/null
 
   if [ "$electron_flag" = "true" ]; then

--- a/packages/cli/scripts/test-scaffold.sh
+++ b/packages/cli/scripts/test-scaffold.sh
@@ -68,6 +68,7 @@ NODE
     yarn) yarn install ;;
     *) echo "Unsupported package manager: $package_manager" >&2; exit 1 ;;
   esac
+  node --input-type=module -e 'for (const path of ["defaults", "models", "gateway-provider", "provider-options", "runtime", "provider-types", "definition"]) await import("@chat-js/gateways/" + path);'
   popd >/dev/null
 
   if [ "$electron_flag" = "true" ]; then

--- a/packages/cli/src/commands/create.test.ts
+++ b/packages/cli/src/commands/create.test.ts
@@ -113,3 +113,45 @@ describe("create command", () => {
     expect(provider).toContain('from "files-sdk/vercel-blob"');
   });
 });
+
+it("leaves non-ChatJS Git templates unconfigured through the full create command", async () => {
+	const { writeFile } = await import("node:fs/promises");
+	const source = makeTempDir("plain-source");
+	const destination = makeTempDir("plain-clone");
+	await mkdir(source, { recursive: true });
+	const manifest = JSON.stringify({ name: "plain-app", dependencies: {} });
+	await writeFile(join(source, "package.json"), manifest);
+	for (const args of [
+		["init"],
+		["add", "."],
+		[
+			"-c",
+			"user.name=ChatJS Test",
+			"-c",
+			"user.email=test@chatjs.dev",
+			"commit",
+			"-m",
+			"initial",
+		],
+	]) {
+		expect(Bun.spawnSync(["git", ...args], { cwd: source }).exitCode).toBe(0);
+	}
+	await create.parseAsync(
+		[
+			destination,
+			"--from-git",
+			source,
+			"--gateway",
+			"vercel",
+			"--yes",
+			"--no-install",
+		],
+		{ from: "user" },
+	);
+	expect(await Bun.file(join(destination, "chat.config.ts")).exists()).toBe(
+		false,
+	);
+	expect(await readFile(join(destination, "package.json"), "utf8")).toBe(
+		manifest,
+	);
+});

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { basename, join, relative, resolve } from "node:path";
 import { intro, outro } from "@clack/prompts";
@@ -234,6 +235,13 @@ export const create = new Command()
 						storage,
 						gateway: gatewaySelection,
 					});
+					if (!existsSync(join(targetDir, "lib/ai/gateway.ts"))) {
+						scaffoldSpinner.succeed("Repository cloned.");
+						logger.warn(
+							"This repository has no ChatJS gateway slot. Skipping ChatJS configuration and installation.",
+						);
+						return;
+					}
 				} else {
 					await scaffoldFromTemplate(targetDir, {
 						packageManager,

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -175,10 +175,14 @@ export const create = new Command()
 				options.gateway ? options.registry : undefined,
 			);
 			const gateway = gatewaySelection.definition.id;
-			const coreFeatures = await promptCoreFeatures(options.yes);
+			const coreFeatures = await promptCoreFeatures(
+				options.yes,
+				gatewaySelection.definition,
+			);
 			const documentTypes = await promptDocumentTypes(
 				options.yes,
 				coreFeatures.documents,
+				gatewaySelection.definition,
 			);
 
 			let registryItems: Awaited<ReturnType<typeof fetchRegistryIndex>> = [];

--- a/packages/cli/src/helpers/config-requirements.ts
+++ b/packages/cli/src/helpers/config-requirements.ts
@@ -1,9 +1,5 @@
 import { builtInGateways } from "../registry/gateways";
-import type {
-	AuthProvider,
-	BuiltInToolKey,
-	CoreFeatureKey,
-} from "../types";
+import type { AuthProvider, BuiltInToolKey, CoreFeatureKey } from "../types";
 
 type EnvVarName = string;
 
@@ -12,12 +8,18 @@ export interface EnvRequirement {
 	options: EnvVarName[][];
 }
 
-export const gatewayEnvRequirements: Record<string, EnvRequirement> = Object.fromEntries(
-  builtInGateways.map(item => [item.meta.chatjs.id, {
-    ...item.meta.chatjs.envRequirements[0],
-    description: item.meta.chatjs.envRequirements[0].options.map(option => option.join(" + ")).join(" or "),
-  }])
-);
+export const gatewayEnvRequirements: Record<string, EnvRequirement[]> =
+	Object.fromEntries(
+		builtInGateways.map((item) => [
+			item.meta.chatjs.id,
+			item.meta.chatjs.envRequirements.map((requirement) => ({
+				...requirement,
+				description:
+					requirement.description ??
+					requirement.options.map((option) => option.join(" + ")).join(" or "),
+			})),
+		]),
+	);
 
 export const coreFeatureEnvRequirements: Partial<
 	Record<CoreFeatureKey, EnvRequirement>

--- a/packages/cli/src/helpers/ensure-target.ts
+++ b/packages/cli/src/helpers/ensure-target.ts
@@ -1,10 +1,14 @@
-import { readdir, stat } from "node:fs/promises";
+import { readdir, lstat } from "node:fs/promises";
 import { highlighter } from "../utils/highlighter";
 import { logger } from "../utils/logger";
 
 export async function ensureTargetEmpty(targetDir: string): Promise<void> {
-  const targetStats = await stat(targetDir).catch(() => null);
+  const targetStats = await lstat(targetDir).catch((error) => {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  });
   if (!targetStats) return;
+  if (targetStats.isSymbolicLink()) throw new Error("Target directory must not be a symlink.");
 
   if (!targetStats.isDirectory()) {
     logger.error(

--- a/packages/cli/src/helpers/env-checklist.ts
+++ b/packages/cli/src/helpers/env-checklist.ts
@@ -79,7 +79,8 @@ export function collectEnvChecklist(input: {
 	});
 
 	// --- AI Gateway ---
-	const gwReq = input.gatewayRequirements ?? [gatewayEnvRequirements[input.gateway]];
+	const gwReq =
+		input.gatewayRequirements ?? gatewayEnvRequirements[input.gateway] ?? [];
 	const gwEntries = gwReq.flatMap(requirementToEntries);
 
 	entries.push(...gwEntries);

--- a/packages/cli/src/helpers/gateway-provider.test.ts
+++ b/packages/cli/src/helpers/gateway-provider.test.ts
@@ -173,3 +173,20 @@ it("rejects symlinked fixed outputs and missing snapshots before modifying the a
 	await expect(configureGatewayProvider(directory, "openai")).rejects.toThrow();
 	expect(await readFile(gateway, "utf8")).toBe(original);
 });
+
+it("rejects a symlinked app root without modifying its target", async () => {
+	const { symlink } = await import("node:fs/promises");
+	const parent = await mkdtemp(join(tmpdir(), "chatjs-root-link-"));
+	directories.push(parent);
+	const app = join(parent, "app");
+	await scaffoldFromTemplate(app);
+	const { ensureTargetEmpty } = await import("./ensure-target");
+	const alias = join(parent, "alias");
+	await symlink(app, alias);
+	await expect(ensureTargetEmpty(alias)).rejects.toThrow("symlink");
+	const original = await readFile(join(app, "lib/ai/gateway.ts"), "utf8");
+	await expect(configureGatewayProvider(alias, "openai")).rejects.toThrow(
+		"symlink",
+	);
+	expect(await readFile(join(app, "lib/ai/gateway.ts"), "utf8")).toBe(original);
+});

--- a/packages/cli/src/helpers/gateway-provider.test.ts
+++ b/packages/cli/src/helpers/gateway-provider.test.ts
@@ -141,3 +141,35 @@ it("rejects incompatible contracts, cycles and unsafe or conflicting files befor
 		);
 	}
 });
+
+it("rejects symlinked fixed outputs and missing snapshots before modifying the adapter", async () => {
+	const { symlink } = await import("node:fs/promises");
+	const directory = await mkdtemp(join(tmpdir(), "chatjs-preflight-"));
+	directories.push(directory);
+	await scaffoldFromTemplate(directory);
+	const gateway = join(directory, "lib/ai/gateway.ts");
+	const original = await readFile(gateway, "utf8");
+	for (const target of [
+		"package.json",
+		".env.example",
+		"lib/ai/models.generated.ts",
+		"lib/ai/gateway-model-defaults.ts",
+	]) {
+		const path = join(directory, target);
+		const content = await readFile(path, "utf8");
+		const outside = join(directory, "sentinel");
+		await writeFile(outside, content);
+		await rm(path);
+		await symlink(outside, path);
+		await expect(configureGatewayProvider(directory, "openai")).rejects.toThrow(
+			"symlink",
+		);
+		expect(await readFile(gateway, "utf8")).toBe(original);
+		expect(await readFile(outside, "utf8")).toBe(content);
+		await rm(path);
+		await writeFile(path, content);
+	}
+	await rm(join(directory, "lib/ai/models.generated.ts"));
+	await expect(configureGatewayProvider(directory, "openai")).rejects.toThrow();
+	expect(await readFile(gateway, "utf8")).toBe(original);
+});

--- a/packages/cli/src/helpers/gateway-provider.ts
+++ b/packages/cli/src/helpers/gateway-provider.ts
@@ -43,17 +43,6 @@ export async function configureGatewayProvider(
 			}
 			if (files.has(target))
 				throw new Error(`Conflicting gateway registry file: ${target}`);
-			// Reject symlinks before any writes, including an existing parent directory.
-			let path = destination;
-			for (const part of target.split("/")) {
-				path = join(path, part);
-				const entry = await lstat(path).catch((error) => {
-					if (error.code === "ENOENT") return null;
-					throw error;
-				});
-				if (entry?.isSymbolicLink())
-					throw new Error(`Gateway target contains a symlink: ${target}`);
-			}
 			files.set(target, file.content);
 		}
 	}
@@ -79,6 +68,39 @@ export async function configureGatewayProvider(
 			}
 		}
 	}
+	// Check every output, not only paths supplied by the registry, before mutation.
+	for (const target of new Set([
+		...files.keys(),
+		"package.json",
+		".env.example",
+		"lib/ai/gateway-model-defaults.ts",
+		"lib/ai/models.generated.ts",
+	])) {
+		let path = destination;
+		for (const part of target.split("/")) {
+			path = join(path, part);
+			const entry = await lstat(path).catch((error) => {
+				if (error.code === "ENOENT") return null;
+				throw error;
+			});
+			if (entry?.isSymbolicLink())
+				throw new Error(`Gateway target contains a symlink: ${target}`);
+			if (
+				entry &&
+				(path === join(destination, target)
+					? !entry.isFile()
+					: !entry.isDirectory())
+			)
+				throw new Error(`Invalid gateway target: ${target}`);
+		}
+	}
+	const snapshotPath = join(destination, "lib/ai/models.generated.ts");
+	const snapshot = await readFile(snapshotPath, "utf8");
+	const example = join(destination, ".env.example");
+	let env = await readFile(example, "utf8").catch((error) => {
+		if (error.code === "ENOENT") return "";
+		throw error;
+	});
 	const gatewayPath = join(destination, "lib/ai/gateway.ts");
 	const current = await readFile(gatewayPath, "utf8");
 	const manifestPath = join(destination, "package.json");
@@ -129,8 +151,6 @@ export const gatewayEnvRequirements = ${JSON.stringify(definition.envRequirement
 export const gatewayEnvVariables = ${JSON.stringify([...new Set([...definition.envRequirements.flatMap((r) => r.options.flat()), ...definition.optionalEnv])])};
 `,
 	);
-	const snapshotPath = join(destination, "lib/ai/models.generated.ts");
-	const snapshot = await readFile(snapshotPath, "utf8");
 	if (
 		!snapshot.includes(`generatedForGateway = ${JSON.stringify(definition.id)}`)
 	) {
@@ -144,8 +164,6 @@ export const models: readonly AiGatewayModel[] = [];
 `,
 		);
 	}
-	const example = join(destination, ".env.example");
-	let env = await readFile(example, "utf8").catch(() => "");
 	for (const name of new Set(
 		definition.envRequirements.flatMap((r) => r.options.flat()),
 	)) {

--- a/packages/cli/src/helpers/gateway-provider.ts
+++ b/packages/cli/src/helpers/gateway-provider.ts
@@ -25,6 +25,9 @@ export async function configureGatewayProvider(
 	destination: string,
 	input: string | GatewaySelection,
 ): Promise<void> {
+	const root = await lstat(destination);
+	if (root.isSymbolicLink() || !root.isDirectory())
+		throw new Error("Gateway destination must be a directory, not a symlink.");
 	const selection =
 		typeof input === "string" ? await resolveGateway(input) : input;
 	const files = new Map<string, string>();

--- a/packages/cli/src/helpers/prompts.test.ts
+++ b/packages/cli/src/helpers/prompts.test.ts
@@ -1,0 +1,54 @@
+import { expect, it } from "bun:test";
+import { gatewayDefinitionSchema } from "@chat-js/gateways/definition";
+import { externalGatewayFixture } from "../../test/external-gateway";
+import {
+	promptAssistantTools,
+	promptCoreFeatures,
+	promptDocumentTypes,
+} from "./prompts";
+import { collectEnvChecklist } from "./env-checklist";
+
+it("uses external defaults and every environment group with --yes", async () => {
+	const definition = externalGatewayFixture().root.meta.chatjs;
+	definition.defaults.tools.documents.types = {
+		text: false,
+		code: true,
+		sheet: false,
+	};
+	definition.defaults.tools.mcp.enabled = true;
+	definition.defaults.tools.webSearch.enabled = true;
+	definition.envRequirements = [
+		{ options: [["FIRST"]] },
+		{ options: [["SECOND"], ["ALTERNATE"]] },
+	];
+	const coreFeatures = await promptCoreFeatures(true, definition);
+	const documentTypes = await promptDocumentTypes(true, true, definition);
+	const { builtInTools } = await promptAssistantTools([], true, definition);
+	expect(coreFeatures.mcp).toBe(true);
+	expect(documentTypes).toEqual({ text: false, code: true, sheet: false });
+	expect(builtInTools.webSearch).toBe(true);
+	const input = {
+		gateway: "acme",
+		coreFeatures,
+		builtInTools,
+		auth: { google: false, github: false, vercel: false },
+	};
+	const entries = collectEnvChecklist({
+		...input,
+		gatewayRequirements: definition.envRequirements,
+	});
+	expect(entries.map((entry) => entry.vars)).toEqual(
+		expect.arrayContaining(["FIRST", "SECOND", "ALTERNATE"]),
+	);
+	expect(() => collectEnvChecklist(input)).not.toThrow();
+	expect(() =>
+		collectEnvChecklist({ ...input, gatewayRequirements: [] }),
+	).not.toThrow();
+});
+
+it("rejects a default for media the gateway cannot support", () => {
+	const definition = externalGatewayFixture().root.meta.chatjs;
+	definition.capabilities.image = false;
+	definition.defaults.tools.image = { enabled: false, default: "unsupported" };
+	expect(gatewayDefinitionSchema.safeParse(definition).success).toBe(false);
+});

--- a/packages/cli/src/helpers/prompts.test.ts
+++ b/packages/cli/src/helpers/prompts.test.ts
@@ -52,3 +52,12 @@ it("rejects a default for media the gateway cannot support", () => {
 	definition.defaults.tools.image = { enabled: false, default: "unsupported" };
 	expect(gatewayDefinitionSchema.safeParse(definition).success).toBe(false);
 });
+
+it("enables web search when external defaults enable deep research", async () => {
+	const definition = externalGatewayFixture().root.meta.chatjs;
+	definition.defaults.tools.webSearch.enabled = false;
+	definition.defaults.tools.deepResearch.enabled = true;
+	const { builtInTools } = await promptAssistantTools([], true, definition);
+	expect(builtInTools.deepResearch).toBe(true);
+	expect(builtInTools.webSearch).toBe(true);
+});

--- a/packages/cli/src/helpers/prompts.ts
+++ b/packages/cli/src/helpers/prompts.ts
@@ -327,7 +327,8 @@ export async function promptAssistantTools(
 }> {
 	const defaultTools = gateway.defaults.tools;
 	const BUILT_IN_TOOL_DEFAULTS: Record<BuiltInToolKey, boolean> = {
-		webSearch: defaultTools.webSearch.enabled,
+		webSearch:
+			defaultTools.webSearch.enabled || defaultTools.deepResearch.enabled,
 		urlRetrieval: defaultTools.urlRetrieval.enabled,
 		deepResearch: defaultTools.deepResearch.enabled,
 		codeExecution: defaultTools.codeExecution.enabled,

--- a/packages/cli/src/helpers/prompts.ts
+++ b/packages/cli/src/helpers/prompts.ts
@@ -12,7 +12,6 @@ import {
 	AUTHENTICATION_DEFAULTS,
 	FEATURES_DEFAULTS,
 } from "../../../../apps/chat/lib/config-schema";
-import { builtInGateways } from "../registry/gateways";
 import type { GatewayDefinition } from "@chat-js/gateways/definition";
 import {
 	authEnvRequirements,
@@ -40,31 +39,6 @@ import {
 	resolveStorageProvider,
 	type StorageSelection,
 } from "./storage-provider";
-
-const defaultTools = builtInGateways[0].meta.chatjs.defaults.tools;
-
-const CORE_FEATURE_DEFAULTS: Record<CoreFeatureKey, boolean> = {
-	attachments: FEATURES_DEFAULTS.attachments,
-	parallelResponses: FEATURES_DEFAULTS.parallelResponses,
-	documents: defaultTools.documents.enabled,
-	mcp: defaultTools.mcp.enabled,
-	followupSuggestions: defaultTools.followupSuggestions.enabled,
-};
-
-const DOCUMENT_TYPE_DEFAULTS: Record<DocumentTypeKey, boolean> = {
-	text: defaultTools.documents.types.text,
-	code: defaultTools.documents.types.code,
-	sheet: defaultTools.documents.types.sheet,
-};
-
-const BUILT_IN_TOOL_DEFAULTS: Record<BuiltInToolKey, boolean> = {
-	webSearch: defaultTools.webSearch.enabled,
-	urlRetrieval: defaultTools.urlRetrieval.enabled,
-	deepResearch: defaultTools.deepResearch.enabled,
-	codeExecution: defaultTools.codeExecution.enabled,
-	imageGeneration: defaultTools.image.enabled,
-	videoGeneration: defaultTools.video.enabled,
-};
 
 const AUTH_DEFAULTS: Record<AuthProvider, boolean> = AUTHENTICATION_DEFAULTS;
 
@@ -114,15 +88,15 @@ function isSupportedBuiltInTool(
 
 	if (key === "imageGeneration") {
 		return (
-			typeof (gatewayToolDefaults.image as { default?: unknown }).default ===
-			"string"
+			gateway.capabilities.image &&
+			typeof gatewayToolDefaults.image.default === "string"
 		);
 	}
 
 	if (key === "videoGeneration") {
 		return (
-			typeof (gatewayToolDefaults.video as { default?: unknown }).default ===
-			"string"
+			gateway.capabilities.video &&
+			typeof gatewayToolDefaults.video.default === "string"
 		);
 	}
 
@@ -190,7 +164,9 @@ export async function promptGateway(skipPrompt: boolean): Promise<Gateway> {
 			...GATEWAYS.map((gw) => ({
 				value: gw,
 				label: gw,
-				hint: gatewayEnvRequirements[gw].description,
+				hint: gatewayEnvRequirements[gw]
+					.map((requirement) => requirement.description)
+					.join("; "),
 			})),
 			{
 				value: "__external__",
@@ -271,7 +247,17 @@ export async function promptStorage(
 
 export async function promptCoreFeatures(
 	skipPrompt: boolean,
+	gateway: GatewayDefinition,
 ): Promise<Record<CoreFeatureKey, boolean>> {
+	const defaultTools = gateway.defaults.tools;
+	const CORE_FEATURE_DEFAULTS: Record<CoreFeatureKey, boolean> = {
+		attachments: FEATURES_DEFAULTS.attachments,
+		parallelResponses: FEATURES_DEFAULTS.parallelResponses,
+		documents: defaultTools.documents.enabled,
+		mcp: defaultTools.mcp.enabled,
+		followupSuggestions: defaultTools.followupSuggestions.enabled,
+	};
+
 	if (skipPrompt) return { ...CORE_FEATURE_DEFAULTS };
 
 	const selected = await multiselect({
@@ -299,7 +285,15 @@ export async function promptCoreFeatures(
 export async function promptDocumentTypes(
 	skipPrompt: boolean,
 	documentsEnabled: boolean,
+	gateway: GatewayDefinition,
 ): Promise<Record<DocumentTypeKey, boolean>> {
+	const defaultTools = gateway.defaults.tools;
+	const DOCUMENT_TYPE_DEFAULTS: Record<DocumentTypeKey, boolean> = {
+		text: defaultTools.documents.types.text,
+		code: defaultTools.documents.types.code,
+		sheet: defaultTools.documents.types.sheet,
+	};
+
 	if (!documentsEnabled) {
 		return toSelectionRecord(DOCUMENT_TYPE_KEYS, []);
 	}
@@ -331,6 +325,16 @@ export async function promptAssistantTools(
 	builtInTools: Record<BuiltInToolKey, boolean>;
 	installableTools: string[];
 }> {
+	const defaultTools = gateway.defaults.tools;
+	const BUILT_IN_TOOL_DEFAULTS: Record<BuiltInToolKey, boolean> = {
+		webSearch: defaultTools.webSearch.enabled,
+		urlRetrieval: defaultTools.urlRetrieval.enabled,
+		deepResearch: defaultTools.deepResearch.enabled,
+		codeExecution: defaultTools.codeExecution.enabled,
+		imageGeneration: defaultTools.image.enabled,
+		videoGeneration: defaultTools.video.enabled,
+	};
+
 	const installableItems = registryItems.filter((item) => !item.hidden);
 	const supportedBuiltInTools = BUILT_IN_TOOL_KEYS.filter((key) =>
 		isSupportedBuiltInTool(gateway, key),

--- a/packages/cli/src/helpers/run-command.test.ts
+++ b/packages/cli/src/helpers/run-command.test.ts
@@ -1,0 +1,20 @@
+import { expect, it } from "bun:test";
+import { run } from "../../test/run-command";
+
+it("reports command timeouts even when descendants keep the pipes open", async () => {
+	await expect(
+		run(
+			process.cwd(),
+			[
+				process.execPath,
+				"-e",
+				`
+const { spawn } = require("node:child_process");
+spawn(process.execPath, ["-e", "setTimeout(() => {}, 30000)"], { stdio: ["ignore", 1, 2] });
+setTimeout(() => {}, 30000);
+`,
+			],
+			250,
+		),
+	).rejects.toThrow("timed out after 250ms");
+});

--- a/packages/cli/src/helpers/scaffold.test.ts
+++ b/packages/cli/src/helpers/scaffold.test.ts
@@ -369,6 +369,7 @@ describe("scaffoldFromGit", () => {
 		}
 
 		await scaffoldFromGit(source, destination, {
+			gateway: "vercel",
 			storage: { provider: "vercel-blob", options: {} },
 		});
 

--- a/packages/cli/src/helpers/scaffold.ts
+++ b/packages/cli/src/helpers/scaffold.ts
@@ -466,7 +466,7 @@ export async function scaffoldFromGit(
     process.cwd()
   );
   await rm(join(destination, ".git"), { recursive: true, force: true });
-  if (options?.gateway) {
+  if (options?.gateway && existsSync(join(destination, "lib/ai/gateway.ts"))) {
     await configureGatewayProvider(destination, options.gateway);
   }
   if (!existsSync(join(destination, "lib", "storage-provider.ts"))) {

--- a/packages/cli/src/registry/fetch.ts
+++ b/packages/cli/src/registry/fetch.ts
@@ -48,11 +48,12 @@ function isLocalSource(source: string): boolean {
 	return !/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(source) || path.isAbsolute(source);
 }
 
-export async function fetchJson(source: string): Promise<unknown> {
+export async function fetchJson(
+	source: string,
+	options?: { secureTransport: boolean },
+): Promise<unknown> {
 	const isLocalPath = isLocalSource(source);
-	const filePath = isLocalPath
-		? path.resolve(process.cwd(), source)
-		: source;
+	const filePath = isLocalPath ? path.resolve(process.cwd(), source) : source;
 
 	if (isLocalPath) {
 		const content = await fs.readFile(filePath, "utf8").catch(() => {
@@ -61,11 +62,34 @@ export async function fetchJson(source: string): Promise<unknown> {
 		return JSON.parse(content);
 	}
 
-	const res = await fetch(filePath).catch(() => {
-		throw new Error(
-			`Could not reach registry. Check your internet connection.`,
-		);
-	});
+	let url = filePath;
+	let res: Response;
+	for (let redirects = 0; ; redirects++) {
+		if (options?.secureTransport) {
+			const parsed = new URL(url);
+			if (
+				parsed.protocol !== "https:" &&
+				!(
+					parsed.protocol === "http:" &&
+					["localhost", "127.0.0.1", "[::1]"].includes(parsed.hostname)
+				)
+			)
+				throw new Error(
+					"Remote gateway registries must use HTTPS (HTTP is allowed only on loopback).",
+				);
+		}
+		res = await fetch(url, { redirect: "manual" }).catch(() => {
+			throw new Error(
+				`Could not reach registry. Check your internet connection.`,
+			);
+		});
+
+		if (![301, 302, 303, 307, 308].includes(res.status)) break;
+		const location = res.headers.get("location");
+		if (!location || redirects >= 10)
+			throw new Error("Invalid or excessive registry redirects.");
+		url = new URL(location, url).href;
+	}
 
 	if (res.status === 404) {
 		throw new Error(`Registry resource not found: ${filePath}`);

--- a/packages/cli/src/registry/fetch.ts
+++ b/packages/cli/src/registry/fetch.ts
@@ -70,6 +70,7 @@ export async function fetchJson(
 			if (
 				parsed.protocol !== "https:" &&
 				!(
+					redirects === 0 &&
 					parsed.protocol === "http:" &&
 					["localhost", "127.0.0.1", "[::1]"].includes(parsed.hostname)
 				)

--- a/packages/cli/src/registry/gateways.test.ts
+++ b/packages/cli/src/registry/gateways.test.ts
@@ -1,0 +1,43 @@
+import { expect, it } from "bun:test";
+import { builtInGateways, resolveGateway } from "./gateways";
+
+it("requires secure remote transport for roots, dependencies and redirects", async () => {
+	await expect(
+		resolveGateway("http://example.com/gateway.json"),
+	).rejects.toThrow("HTTPS");
+	const item = builtInGateways[0];
+	const server = Bun.serve({
+		port: 0,
+		hostname: "127.0.0.1",
+		fetch(request) {
+			const path = new URL(request.url).pathname;
+			if (path === "/redirect.json")
+				return Response.redirect("http://example.com/item.json");
+			if (path === "/dependencies.json")
+				return Response.json({
+					...item,
+					registryDependencies: ["http://example.com/adapter.json"],
+				});
+			if (path === "/invalid.json")
+				return Response.json({ ...item, type: "registry:lib" });
+			return Response.json(item);
+		},
+	});
+	try {
+		const base = `HTTP://127.0.0.1:${server.port}`;
+		expect((await resolveGateway(`${base}/item.json`)).definition.id).toBe(
+			"vercel",
+		);
+		await expect(resolveGateway(`${base}/redirect.json`)).rejects.toThrow(
+			"HTTPS",
+		);
+		await expect(resolveGateway(`${base}/dependencies.json`)).rejects.toThrow(
+			"HTTPS",
+		);
+		await expect(resolveGateway(`${base}/invalid.json`)).rejects.toThrow(
+			"Selected registry item",
+		);
+	} finally {
+		server.stop(true);
+	}
+});

--- a/packages/cli/src/registry/gateways.test.ts
+++ b/packages/cli/src/registry/gateways.test.ts
@@ -11,6 +11,8 @@ it("requires secure remote transport for roots, dependencies and redirects", asy
 		hostname: "127.0.0.1",
 		fetch(request) {
 			const path = new URL(request.url).pathname;
+			if (path === "/loopback-redirect.json")
+				return Response.redirect(new URL("/item.json", request.url));
 			if (path === "/redirect.json")
 				return Response.redirect("http://example.com/item.json");
 			if (path === "/dependencies.json")
@@ -28,6 +30,9 @@ it("requires secure remote transport for roots, dependencies and redirects", asy
 		expect((await resolveGateway(`${base}/item.json`)).definition.id).toBe(
 			"vercel",
 		);
+		await expect(
+			resolveGateway(`${base}/loopback-redirect.json`),
+		).rejects.toThrow("HTTPS");
 		await expect(resolveGateway(`${base}/redirect.json`)).rejects.toThrow(
 			"HTTPS",
 		);
@@ -35,7 +40,7 @@ it("requires secure remote transport for roots, dependencies and redirects", asy
 			"HTTPS",
 		);
 		await expect(resolveGateway(`${base}/invalid.json`)).rejects.toThrow(
-			"Selected registry item",
+			"type registry:item",
 		);
 	} finally {
 		server.stop(true);

--- a/packages/cli/src/registry/gateways.ts
+++ b/packages/cli/src/registry/gateways.ts
@@ -39,15 +39,15 @@ export async function resolveGateway(
 	const visited = new Map<string, GatewayRegistryItem>();
 	const visiting = new Set<string>();
 	function address(name: string, parent?: string): string {
-		if (/^https?:\/\//.test(name) || isAbsolute(name)) return name;
+		if (/^https?:\/\//i.test(name) || isAbsolute(name)) return name;
 		if (name.startsWith(".") || name.endsWith(".json")) {
-			return parent && /^https?:\/\//.test(parent)
+			return parent && /^https?:\/\//i.test(parent)
 				? new URL(name, parent).href
 				: resolve(parent ? dirname(parent) : process.cwd(), name);
 		}
 		if (registry) return registry.replace("{name}", encodeURIComponent(name));
 		if (parent && !parent.startsWith("builtin:")) {
-			return /^https?:\/\//.test(parent)
+			return /^https?:\/\//i.test(parent)
 				? new URL(`${name}.json`, parent).href
 				: resolve(dirname(parent), `${name}.json`);
 		}
@@ -65,7 +65,7 @@ export async function resolveGateway(
 						item.name === location.slice(8) ||
 						item.meta.chatjs.id === location.slice(8),
 				)
-			: await fetchJson(location);
+			: await fetchJson(location, { secureTransport: true });
 		if (!raw)
 			throw new Error(
 				`Unknown gateway "${location.slice(8)}". Use a built-in name, registry URL, or local JSON path.`,
@@ -81,7 +81,7 @@ export async function resolveGateway(
 	const location = address(source);
 	const selected = await visit(location);
 	const definition = selected.meta?.chatjs;
-	if (!definition)
+	if (selected.type !== "registry:item" || !definition)
 		throw new Error(
 			"Selected registry item must declare meta.chatjs with a version 1 gateway contract.",
 		);

--- a/packages/cli/src/registry/gateways.ts
+++ b/packages/cli/src/registry/gateways.ts
@@ -81,7 +81,9 @@ export async function resolveGateway(
 	const location = address(source);
 	const selected = await visit(location);
 	const definition = selected.meta?.chatjs;
-	if (selected.type !== "registry:item" || !definition)
+	if (selected.type !== "registry:item")
+		throw new Error("Selected gateway root must have type registry:item.");
+	if (!definition)
 		throw new Error(
 			"Selected registry item must declare meta.chatjs with a version 1 gateway contract.",
 		);

--- a/packages/cli/test/external-gateway.ts
+++ b/packages/cli/test/external-gateway.ts
@@ -28,6 +28,7 @@ export function externalGatewayFixture() {
 				chatjs: {
 					...base.meta.chatjs,
 					id: "acme",
+					optionalEnv: [],
 					envRequirements: [{ options: [["ACME_BASE_URL", "ACME_API_KEY"]] }],
 				},
 			},

--- a/packages/cli/test/gateway-selection.test.ts
+++ b/packages/cli/test/gateway-selection.test.ts
@@ -1,3 +1,4 @@
+import { run } from "./run-command";
 import { afterAll, beforeAll, expect, it } from "bun:test";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -16,21 +17,6 @@ const cliDirectory = join(import.meta.dir, "..");
 const cliEntry = join(cliDirectory, "dist", "index.js");
 const archive = join(root, `chat-js-gateways-${gatewayPackage.version}.tgz`);
 
-async function run(cwd: string, command: string[]) {
-	const child = Bun.spawn(command, { cwd, stdout: "pipe", stderr: "pipe" });
-	const timeout = setTimeout(() => child.kill(), 180_000);
-	const [exitCode, stdout, stderr] = await Promise.all([
-		child.exited,
-		new Response(child.stdout).text(),
-		new Response(child.stderr).text(),
-	]).finally(() => clearTimeout(timeout));
-	if (exitCode !== 0) {
-		throw new Error(
-			`${command.join(" ")} failed in ${cwd}:\n${stdout}\n${stderr}`,
-		);
-	}
-}
-
 beforeAll(async () => {
 	await run(packageDirectory, ["bun", "run", "build"]);
 	await run(packageDirectory, ["bun", "pm", "pack", "--destination", root]);
@@ -43,7 +29,10 @@ afterAll(async () => {
 		await Promise.race([
 			rm(root, { recursive: true, force: true }),
 			new Promise<never>((_, reject) => {
-				timeout = setTimeout(() => reject(new Error("Gateway test cleanup timed out")), 180_000);
+				timeout = setTimeout(
+					() => reject(new Error("Gateway test cleanup timed out")),
+					180_000,
+				);
 			}),
 		]);
 	} finally {

--- a/packages/cli/test/gateway-selection.test.ts
+++ b/packages/cli/test/gateway-selection.test.ts
@@ -18,11 +18,12 @@ const archive = join(root, `chat-js-gateways-${gatewayPackage.version}.tgz`);
 
 async function run(cwd: string, command: string[]) {
 	const child = Bun.spawn(command, { cwd, stdout: "pipe", stderr: "pipe" });
+	const timeout = setTimeout(() => child.kill(), 180_000);
 	const [exitCode, stdout, stderr] = await Promise.all([
 		child.exited,
 		new Response(child.stdout).text(),
 		new Response(child.stderr).text(),
-	]);
+	]).finally(() => clearTimeout(timeout));
 	if (exitCode !== 0) {
 		throw new Error(
 			`${command.join(" ")} failed in ${cwd}:\n${stdout}\n${stderr}`,
@@ -37,7 +38,17 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-	await rm(root, { recursive: true, force: true });
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		await Promise.race([
+			rm(root, { recursive: true, force: true }),
+			new Promise<never>((_, reject) => {
+				timeout = setTimeout(() => reject(new Error("Gateway test cleanup timed out")), 180_000);
+			}),
+		]);
+	} finally {
+		clearTimeout(timeout);
+	}
 });
 
 const external = externalGatewayFixture();

--- a/packages/cli/test/run-command.ts
+++ b/packages/cli/test/run-command.ts
@@ -1,0 +1,61 @@
+import { spawn } from "node:child_process";
+
+/** Bound the entire operation, including pipes inherited by descendants. */
+export function run(
+	cwd: string,
+	command: string[],
+	timeoutMs = 180_000,
+): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const grouped = process.platform !== "win32";
+		const child = spawn(command[0], command.slice(1), {
+			cwd,
+			detached: grouped,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let stdout = "";
+		let stderr = "";
+		let timedOut = false;
+		const signal = (value: NodeJS.Signals) => {
+			try {
+				if (grouped && child.pid) process.kill(-child.pid, value);
+				else child.kill(value);
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "ESRCH") reject(error);
+			}
+		};
+		child.stdout.on("data", (chunk) => {
+			stdout += chunk;
+		});
+		child.stderr.on("data", (chunk) => {
+			stderr += chunk;
+		});
+		const timer = setTimeout(() => {
+			timedOut = true;
+			signal("SIGTERM");
+			setTimeout(() => signal("SIGKILL"), 1000).unref();
+			child.stdout.destroy();
+			child.stderr.destroy();
+			reject(
+				new Error(
+					`${command.join(" ")} timed out after ${timeoutMs}ms in ${cwd}`,
+				),
+			);
+		}, timeoutMs);
+		child.on("error", (error) => {
+			clearTimeout(timer);
+			reject(error);
+		});
+		child.on("close", (code) => {
+			clearTimeout(timer);
+			if (timedOut) return;
+			if (code === 0) resolve();
+			else
+				reject(
+					new Error(
+						`${command.join(" ")} failed in ${cwd}:\n${stdout}\n${stderr}`,
+					),
+				);
+		});
+	});
+}

--- a/packages/gateways/src/definition.ts
+++ b/packages/gateways/src/definition.ts
@@ -66,7 +66,8 @@ export const gatewayDefinitionSchema = z
   .superRefine((definition, ctx) => {
     for (const kind of ["image", "video"] as const) {
       if (
-        definition.defaults.tools[kind].enabled &&
+        (definition.defaults.tools[kind].enabled ||
+          definition.defaults.tools[kind].default !== undefined) &&
         !definition.capabilities[kind]
       ) {
         ctx.addIssue({

--- a/packages/registry/build-gateways.ts
+++ b/packages/registry/build-gateways.ts
@@ -1,8 +1,11 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readdir, rm, writeFile } from "node:fs/promises";
 import { builtInGateways } from "./gateways/catalog";
 
 const directory = new URL("./items/", import.meta.url);
 await mkdir(directory, { recursive: true });
+for (const name of await readdir(directory)) {
+  if (name.endsWith("-gateway.json")) await rm(new URL(name, directory));
+}
 for (const item of builtInGateways) {
   await writeFile(
     new URL(`${item.name}.json`, directory),

--- a/packages/registry/gateways/README.md
+++ b/packages/registry/gateways/README.md
@@ -59,3 +59,8 @@ config. Test model creation and discovery through `GatewayProvider` with injecte
 fixtures. The integration suite in `packages/cli/test/gateway-selection.test.ts`
 uses an HTTP registry with an unknown `acme` gateway and a separate adapter item.
 No paid provider credentials are required for these tests.
+
+Installation rejects symlinked destinations and output paths during preflight.
+These checks protect against symlinks already present in a cloned app. They are
+not an atomic filesystem sandbox against processes concurrently modifying the
+same destination with the user's permissions.

--- a/packages/registry/gateways/catalog.ts
+++ b/packages/registry/gateways/catalog.ts
@@ -19,7 +19,7 @@ const environment = {
   vercel: [["AI_GATEWAY_API_KEY"], ["VERCEL_OIDC_TOKEN"]],
   openai: [["OPENAI_API_KEY"]],
   "openai-compatible": [
-    ["OPENAI_COMPATIBLE_BASE_URL", "OPENAI_COMPATIBLE_API_KEY"],
+    ["OPENAI_COMPATIBLE_BASE_URL"],
   ],
   openrouter: [["OPENROUTER_API_KEY"]],
   litellm: [["LITELLM_BASE_URL"]],
@@ -55,7 +55,7 @@ export const builtInGateways = Object.entries(gatewayMetadata).map(
             video: metadata.supportsVideo,
           },
           envRequirements: [{ options: environment[name] }],
-          optionalEnv: id === "litellm" ? ["LITELLM_API_KEY"] : [],
+          optionalEnv: id === "litellm" ? ["LITELLM_API_KEY"] : id === "openai-compatible" ? ["OPENAI_COMPATIBLE_API_KEY"] : [],
           defaults: GATEWAY_MODEL_DEFAULTS[name],
         }),
       },

--- a/packages/registry/gateways/defaults.ts
+++ b/packages/registry/gateways/defaults.ts
@@ -159,46 +159,7 @@ const openaiDefaults = {
 } satisfies GatewayModelDefaults<Gateways["openai"]>;
 
 const openaiCompatibleDefaults = {
-  providerOrder: ["openai"],
-  disabledModels: [],
-  curatedDefaults: [
-    "gpt-5-nano",
-    "gpt-5-mini",
-    "gpt-5.2",
-    "gpt-5.2-chat-latest",
-  ],
-  anonymousModels: ["gpt-5-nano"],
-  workflows: {
-    chat: "gpt-5-mini",
-    title: "gpt-5-nano",
-    pdf: "gpt-5-mini",
-    chatImageCompatible: "gpt-4o-mini",
-  },
-  tools: {
-    webSearch: { enabled: false },
-    urlRetrieval: { enabled: false },
-    codeExecution: { enabled: false },
-    mcp: { enabled: false },
-    documents: {
-      enabled: true,
-      types: { text: true, code: true, sheet: true },
-    },
-    followupSuggestions: { enabled: false, default: "gpt-5-nano" },
-    text: { polish: "gpt-5-mini" },
-    sheet: { format: "gpt-5-mini", analyze: "gpt-5-mini" },
-    code: { edits: "gpt-5-mini" },
-    image: { enabled: false, default: "gpt-image-1" },
-    video: { enabled: false },
-    deepResearch: {
-      enabled: false,
-      defaultModel: "gpt-5-nano",
-      finalReportModel: "gpt-5-mini",
-      allowClarification: true,
-      maxResearcherIterations: 1,
-      maxConcurrentResearchUnits: 2,
-      maxSearchQueries: 2,
-    },
-  },
+  ...openaiDefaults,
 } satisfies GatewayModelDefaults<Gateways["openai-compatible"]>;
 
 const litellmDefaults = {

--- a/turbo.json
+++ b/turbo.json
@@ -143,6 +143,7 @@
     },
     "@chat-js/cli#test:unit": {
       "dependsOn": ["build"],
+      "outputs": ["templates/**"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/apps/chat/**",


### PR DESCRIPTION
External gateway installation could overwrite symlinked app files, accept insecure remote source code, and replace an item's defaults with Vercel defaults. This follow-up to #332 validates installation inputs before writes and preserves the selected gateway's configuration.

Changes:

- Require HTTPS for remote gateway roots, dependencies, and redirects, with loopback HTTP for local registries. Accept uppercase HTTP(S) schemes and require `registry:item` at the root.
- Check all output paths for symlinks and invalid file types, and read required inputs before replacing adapter files. Preserve arbitrary `--from-git` repositories without a ChatJS gateway slot.
- Use the selected item's feature, document, and tool defaults in both prompt paths. Preserve all environment requirement groups and handle empty requirements and unknown external IDs. Forward optional OpenAI-compatible keys without requiring them.
- Derive the configured gateway type from the installed metadata literal. Reject media defaults for unsupported capabilities.
- Restore generated templates on CLI test cache hits, remove stale gateway registry payloads, verify package exports in every package-manager scaffold case, and bound integration setup/cleanup.
- Replace the obsolete custom-gateway guide, correct reasoning customization and published README links, remove redundant gateway assertions, and share identical OpenAI/OpenAI-compatible defaults.

Validation: `bun lint`, `bun test:types`, docs link validation, 66 CLI tests, 145 app tests, 14 gateway contract tests, and six independent generated-app installs/type checks. The external install also generated a response through its installed adapter. Verified registry regeneration removes obsolete gateway payloads while preserving tool items.

Review disposition:

- The transport, symlink, preflight, cloned-layout, defaults, environment, capability, typing, caching-output, generated-artifact, documentation, package-export, and test-harness comments are addressed above. Duplicate comments are covered by the same fixes, including the out-of-diff prompt-default finding.
- Bun lifecycle parsing and cold declaration generation were fixed in #332 before merge. This PR keeps the compatible timeout invocation and build-before-typecheck order, and adds explicit operation bounds.
- An explicit forwarding constructor is unnecessary: subclasses inherit `GatewayRuntime`'s constructor. The injected-runtime contract tests pass.
- The one-hour model fetch cache was present before #332 (for example, `vercel-gateway.ts` at base `2db364c`) and the model catalog also has a one-hour application cache. Preserve this behavior.
- GPT-5's low reasoning setting was also present in the pre-#332 provider helper. Preserve the established behavior rather than changing model policy during this registry correction. The documentation now explains where to customize the returned options.

No package publication is included.

## Summary by Sourcery

Harden gateway registry installation and preserve the selected gateway’s configuration across generated applications.

Bug Fixes:
- Harden external gateway installation against insecure remote sources, symlinked or invalid output paths, incomplete inputs, and unsupported capability defaults.
- Preserve each selected gateway’s feature, tool, document, model, and environment configuration, including optional OpenAI-compatible credentials and non-ChatJS Git templates.
- Prevent stale generated registry artifacts and restore expected generated templates during cached CLI test runs.

Enhancements:
- Derive gateway typing from the configured gateway literal and improve validation for external IDs, registry item types, redirects, and generated manifests.
- Bound subprocess integration operations and improve cleanup, package export verification, and independent generated-app installation checks.

Documentation:
- Replace the obsolete custom gateway guide with documentation for installing and authoring registry items, and correct reasoning customization and published README links.

Tests:
- Expand CLI, gateway contract, scaffold, registry transport, symlink safety, prompt defaults, timeout, and generated-app validation coverage.

Chores:
- Align OpenAI-compatible defaults with OpenAI defaults while retaining optional provider-specific environment variables.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens external gateway installation to validate remote sources and output paths before any writes, and preserves the selected gateway's defaults instead of replacing them with built-in values.

**Installation hardening**
- Remote registry roots, dependencies, and redirects require HTTPS; HTTP is only allowed on loopback.
- Symlinked destinations and output paths are rejected before installation so a failed install leaves the app unchanged.
- `--from-git` repositories without a ChatJS gateway slot are left unconfigured instead of failing.

**Configuration, docs, and tests**
- Feature, document, and tool defaults come from the selected item in both prompt paths, and all environment requirement groups are preserved.
- Empty requirements and unknown external IDs no longer throw; OpenAI-compatible gateways work without a required API key.
- The obsolete custom-gateway guide is replaced with install and authoring docs, with corrected links.
- Registry regeneration removes stale gateway payloads, and CLI test commands are bounded with timeouts.

<sup>Written for commit f07a09e860e41e7dc5a60e91fe5bed6be94f86e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CLI support for installing and configuring custom gateways from local or remote registries.
  - Gateway setup prompts now provide gateway-specific defaults and environment requirements.
  - OpenAI-compatible gateways can now operate without an API key when supported.

- **Bug Fixes**
  - Improved environment requirement handling and capability validation.
  - Added safeguards against unsafe registry connections, invalid redirects, and symlinked generated files.
  - Gateway configuration now avoids modifying projects without the required integration.

- **Documentation**
  - Updated custom gateway and reasoning-budget guidance with the latest setup workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Follow-up review pass (`bde19aca`): reject symlinked app roots before copying and in gateway installation; normalize deep-research/web-search defaults; disallow HTTP redirect targets; report root-item type errors separately; leave unsupported Git templates unconfigured through the complete CLI command; derive export smoke tests from the installed manifest; and bound subprocess execution including inherited pipes, explicit timeout errors, and process-group termination on CI/macOS. All six installs also passed with Bun 1.3.1.

The concurrent path-swap finding is documented as a limit rather than claimed solved: preflight rejects pre-existing symlinks, but does not provide an atomic filesystem sandbox against another process modifying the destination with the user's permissions. Such a process can also replace the generated application after installation. The CLI does not execute cloned repository code during gateway preflight.