### PR TITLE
Fix Markdown flushing across text-part boundaries

### DIFF
--- a/apps/chat/lib/ai/markdown-joiner-transform.test.ts
+++ b/apps/chat/lib/ai/markdown-joiner-transform.test.ts
@@ -1,0 +1,35 @@
+import type { TextStreamPart, ToolSet } from "ai";
+import { expect, it } from "vitest";
+import { markdownJoinerTransform } from "./markdown-joiner-transform";
+
+it("flushes buffered markdown before its text part ends, retaining the part ID", async () => {
+  const chunks: TextStreamPart<ToolSet>[] = [
+    { type: "text-start", id: "first" },
+    { type: "text-delta", id: "first", text: "Result [" },
+    { type: "text-end", id: "first" },
+    { type: "text-start", id: "second" },
+    { type: "text-delta", id: "second", text: "next" },
+    { type: "text-end", id: "second" },
+  ];
+  const source = new ReadableStream<TextStreamPart<ToolSet>>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+  const output: TextStreamPart<ToolSet>[] = [];
+  for await (const chunk of source.pipeThrough(markdownJoinerTransform()())) {
+    output.push(chunk);
+  }
+  expect(output).toEqual([
+    chunks[0],
+    { type: "text-delta", id: "first", text: "Result " },
+    { type: "text-delta", id: "first", text: "[" },
+    chunks[2],
+    chunks[3],
+    chunks[4],
+    chunks[5],
+  ]);
+});

--- a/apps/chat/lib/ai/markdown-joiner-transform.ts
+++ b/apps/chat/lib/ai/markdown-joiner-transform.ts
@@ -83,30 +83,32 @@ class MarkdownJoiner {
 export const markdownJoinerTransform =
   <TOOLS extends ToolSet>() =>
   () => {
-    const joiner = new MarkdownJoiner();
+    const parts = new Map<string, MarkdownJoiner>();
 
     return new TransformStream<TextStreamPart<TOOLS>, TextStreamPart<TOOLS>>({
       transform(chunk, controller) {
         if (chunk.type === "text-delta") {
+          const joiner = parts.get(chunk.id) ?? new MarkdownJoiner();
+          parts.set(chunk.id, joiner);
           const processedText = joiner.processText(chunk.text);
           if (processedText) {
+            controller.enqueue({ ...chunk, text: processedText });
+          }
+          return;
+        }
+
+        if (chunk.type === "text-end") {
+          const remaining = parts.get(chunk.id)?.flush();
+          if (remaining) {
             controller.enqueue({
-              ...chunk,
-              text: processedText,
+              type: "text-delta",
+              id: chunk.id,
+              text: remaining,
             });
           }
-        } else {
-          controller.enqueue(chunk);
+          parts.delete(chunk.id);
         }
-      },
-      flush(controller) {
-        const remaining = joiner.flush();
-        if (remaining) {
-          controller.enqueue({
-            type: "text-delta",
-            text: remaining,
-          } as TextStreamPart<TOOLS>);
-        }
+        controller.enqueue(chunk);
       },
     });
   };


### PR DESCRIPTION
Fixes #339.

An incomplete Markdown fragment could be emitted after its text part ended, without an ID, causing chat responses to fail with `AI_UIMessageStreamError`. Keep a buffer per text-part ID and flush it before forwarding `text-end` so fragments cannot leak into another part.

Validation: the regression test reproduces the previous missing-ID/cross-part behavior and passes with the fix. The changed files pass Biome. A real Vercel gateway response with a word-count tool call completed and persisted after reload with this fix applied.

This PR is based directly on `main` and is independent of the registry/CLI cleanup stack.

## Summary by Sourcery

Preserve text-part boundaries and IDs when joining streamed Markdown fragments.

Bug Fixes:
- Ensure buffered Markdown fragments are flushed with their text-part ID before each text part ends, preventing cross-part leakage and invalid UI message streams.

Enhancements:
- Maintain independent Markdown buffering for concurrent or sequential text parts.

Tests:
- Add a regression test covering buffered Markdown flushing across text-part boundaries and ID preservation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #339. An incomplete Markdown fragment could be emitted after its text part ended and without an ID, triggering `AI_UIMessageStreamError`. The transform now keeps a buffer per text-part ID and flushes it before forwarding `text-end`.

**Bug Fixes**
- Uses a `Map` of `MarkdownJoiner` instances keyed by text-part ID instead of one shared instance.
- Removes the buffer when its part ends so fragments cannot bleed into later parts.

**Tests**
- Adds a regression test asserting buffered fragments flush with the correct ID before `text-end`.

<sup>Written for commit 71e8881cef600dcc1757f4870170df5863803b99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streamed Markdown handling when multiple text parts arrive interleaved.
  - Ensured each text part is processed independently, with buffered content flushed at the appropriate end of each part.
  - Preserved text-part identifiers and chunk ordering in streamed output.

- **Tests**
  - Added regression coverage for interleaved Markdown streams, buffering behavior, and output ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->