### PR TITLE
Make the reference app own its selected gateway

### DIFF
--- a/.changeset/gateway-fetch-callable.md
+++ b/.changeset/gateway-fetch-callable.md
@@ -1,0 +1,6 @@
+---
+"@chat-js/gateways": patch
+---
+
+Accept a fetch-compatible callable without requiring host-specific static fetch
+properties, so injected fetch implementations work across Node and Bun typings.

--- a/apps/chat/lib/ai/app-model-id.ts
+++ b/apps/chat/lib/ai/app-model-id.ts
@@ -1,6 +1,5 @@
 import type chatConfig from "@/chat.config";
 import type {
-  DefaultGateway,
   GatewayImageModelIdMap,
   GatewayModelIdMap,
   GatewayType,
@@ -11,7 +10,7 @@ export type ActiveGatewayType = typeof chatConfig extends {
   ai: { gateway: infer G extends GatewayType };
 }
   ? G
-  : DefaultGateway;
+  : GatewayType;
 
 /** Runtime model ID — narrowed to the active gateway */
 export type ModelId = GatewayModelIdMap[ActiveGatewayType];

--- a/apps/chat/lib/ai/gateway-model-defaults.ts
+++ b/apps/chat/lib/ai/gateway-model-defaults.ts
@@ -1,10 +1,85 @@
-import { GATEWAY_MODEL_DEFAULTS } from "../../../../packages/registry/gateways/defaults";
+import type { GatewayModelDefaults } from "@chat-js/gateways/defaults";
+import type { Gateway } from "./gateway";
 
-export const gatewayModelDefaults = GATEWAY_MODEL_DEFAULTS.vercel;
-export const gatewayType = "vercel";
+export const gatewayType = "vercel" satisfies InstanceType<
+  typeof Gateway
+>["type"];
+export const gatewayModelDefaults = {
+  anonymousModels: ["google/gemini-2.5-flash-lite", "openai/gpt-5-nano"],
+  curatedDefaults: [
+    "openai/gpt-5-nano",
+    "openai/gpt-5-mini",
+    "openai/gpt-5.2",
+    "google/gemini-2.5-flash-lite",
+    "google/gemini-3-flash",
+    "google/gemini-3.1-pro-preview",
+    "anthropic/claude-sonnet-4.5",
+    "anthropic/claude-opus-4.5",
+  ],
+  disabledModels: [],
+  providerOrder: ["openai", "google", "anthropic"],
+  workflows: {
+    chat: "openai/gpt-5-mini",
+    title: "openai/gpt-5-nano",
+    pdf: "openai/gpt-5-mini",
+    chatImageCompatible: "openai/gpt-4o-mini",
+  },
+  tools: {
+    webSearch: {
+      enabled: false,
+    },
+    urlRetrieval: {
+      enabled: false,
+    },
+    codeExecution: {
+      enabled: false,
+    },
+    mcp: {
+      enabled: false,
+    },
+    documents: {
+      enabled: true,
+      types: {
+        text: true,
+        code: true,
+        sheet: true,
+      },
+    },
+    followupSuggestions: {
+      enabled: false,
+      default: "google/gemini-2.5-flash-lite",
+    },
+    text: {
+      polish: "openai/gpt-5-mini",
+    },
+    sheet: {
+      format: "openai/gpt-5-mini",
+      analyze: "openai/gpt-5-mini",
+    },
+    code: {
+      edits: "openai/gpt-5-mini",
+    },
+    image: {
+      enabled: false,
+      default: "google/gemini-3-pro-image",
+    },
+    video: {
+      enabled: false,
+      default: "xai/grok-imagine-video",
+    },
+    deepResearch: {
+      enabled: false,
+      defaultModel: "google/gemini-2.5-flash-lite",
+      finalReportModel: "google/gemini-3-flash",
+      allowClarification: true,
+      maxResearcherIterations: 1,
+      maxConcurrentResearchUnits: 2,
+      maxSearchQueries: 2,
+    },
+  },
+} satisfies GatewayModelDefaults<InstanceType<typeof Gateway>>;
 export const gatewayCapabilities = { image: true, video: true };
 export const gatewayEnvRequirements = [
   { options: [["AI_GATEWAY_API_KEY"], ["VERCEL_OIDC_TOKEN"]] },
 ];
-
 export const gatewayEnvVariables = ["AI_GATEWAY_API_KEY", "VERCEL_OIDC_TOKEN"];

--- a/apps/chat/lib/ai/gateway.ts
+++ b/apps/chat/lib/ai/gateway.ts
@@ -32,7 +32,7 @@ export class VercelGateway
       VercelVideoModelId
     >
 {
-  readonly type = "vercel" as const;
+  readonly type = "vercel";
 
   createLanguageModel(modelId: VercelLanguageModelId): LanguageModelV4 {
     return this.getProvider()(modelId);

--- a/apps/chat/lib/ai/gateway.ts
+++ b/apps/chat/lib/ai/gateway.ts
@@ -1,4 +1,131 @@
-// ChatJS gateway dependency: @ai-sdk/gateway
-import { VercelGateway } from "../../../../packages/registry/gateways/vercel";
+import { createGateway, type gateway } from "@ai-sdk/gateway";
+import type {
+  Experimental_VideoModelV4,
+  LanguageModelV4,
+} from "@ai-sdk/provider";
+import type { GatewayProvider } from "@chat-js/gateways/gateway-provider";
+import {
+  type AiGatewayModel,
+  aiGatewayModelDiscriminatorSchema,
+  aiGatewayModelSchema,
+  aiGatewayModelsEnvelopeSchema,
+  isAiGatewayModelType,
+} from "@chat-js/gateways/models";
+import type { StrictLiterals } from "@chat-js/gateways/provider-types";
+import { GatewayRuntime } from "@chat-js/gateways/runtime";
+import type { ImageModel } from "ai";
 
-export const Gateway = VercelGateway;
+type VercelImageModelId = Parameters<(typeof gateway)["imageModel"]>[0];
+type VercelVideoModelId = Parameters<(typeof gateway)["videoModel"]>[0];
+type VercelLanguageModelId = StrictLiterals<
+  Parameters<(typeof gateway)["languageModel"]>[0]
+>;
+
+export class VercelGateway
+  extends GatewayRuntime
+  implements
+    GatewayProvider<
+      "vercel",
+      VercelLanguageModelId,
+      VercelImageModelId,
+      VercelVideoModelId
+    >
+{
+  readonly type = "vercel" as const;
+
+  createLanguageModel(modelId: VercelLanguageModelId): LanguageModelV4 {
+    return this.getProvider()(modelId);
+  }
+
+  createImageModel(modelId: VercelImageModelId): ImageModel {
+    return this.getProvider().imageModel(modelId);
+  }
+
+  createVideoModel(modelId: VercelVideoModelId): Experimental_VideoModelV4 {
+    return this.getProvider().videoModel(modelId);
+  }
+
+  private provider?: ReturnType<typeof createGateway>;
+
+  private getProvider() {
+    this.provider ??= createGateway({ apiKey: this.env.AI_GATEWAY_API_KEY });
+    return this.provider;
+  }
+
+  private getApiKey(): string | undefined {
+    return this.env.AI_GATEWAY_API_KEY || this.env.VERCEL_OIDC_TOKEN;
+  }
+
+  private getModelsUrl(): string {
+    return "https://ai-gateway.vercel.sh/v1/models";
+  }
+
+  async fetchModels(): Promise<AiGatewayModel[]> {
+    const apiKey = this.getApiKey();
+
+    if (!apiKey) {
+      this.log.warn("No AI gateway API key found, using fallback models");
+      return [...this.getFallbackModels(this.type)];
+    }
+
+    const url = this.getModelsUrl();
+    this.log.debug({ url }, "Fetching models from Vercel AI Gateway");
+
+    try {
+      const response = await this.fetch(url, {
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        this.log.error(
+          { status: response.status, statusText: response.statusText, url },
+          "Vercel AI Gateway returned non-OK response"
+        );
+        throw new Error(`Failed to fetch models: ${response.statusText}`);
+      }
+
+      const bodyRaw = await response.json();
+      const body = aiGatewayModelsEnvelopeSchema.parse(bodyRaw);
+      const unsupportedTypes = new Set<string>();
+      const models: AiGatewayModel[] = [];
+
+      for (const candidate of body.data) {
+        const { type } = aiGatewayModelDiscriminatorSchema.parse(candidate);
+        if (!isAiGatewayModelType(type)) {
+          unsupportedTypes.add(type);
+          continue;
+        }
+        const model = aiGatewayModelSchema.parse(candidate);
+        models.push({ ...model, type });
+      }
+
+      if (unsupportedTypes.size > 0) {
+        this.log.warn(
+          {
+            unsupportedTypes: [...unsupportedTypes],
+            skippedModelCount: body.data.length - models.length,
+            modelCount: body.data.length,
+          },
+          "Skipping models with unsupported types from Vercel AI Gateway"
+        );
+      }
+
+      this.log.info(
+        { modelCount: models.length },
+        "Successfully fetched models from Vercel AI Gateway"
+      );
+      return models;
+    } catch (error) {
+      this.log.error(
+        { err: error, url },
+        "Error fetching models from Vercel AI Gateway, falling back to generated models"
+      );
+      return [...this.getFallbackModels(this.type)];
+    }
+  }
+}
+
+export { VercelGateway as Gateway };

--- a/apps/chat/lib/ai/gateway.ts
+++ b/apps/chat/lib/ai/gateway.ts
@@ -1,3 +1,4 @@
+// ChatJS gateway dependency: @ai-sdk/gateway
 import { createGateway, type gateway } from "@ai-sdk/gateway";
 import type {
   Experimental_VideoModelV4,

--- a/apps/chat/lib/ai/gateways/registry.ts
+++ b/apps/chat/lib/ai/gateways/registry.ts
@@ -1,13 +1,11 @@
 import type { GatewayProvider as GatewayProviderBase } from "@chat-js/gateways/gateway-provider";
 import type { Gateway } from "../gateway";
-import { gatewayType } from "../gateway-model-defaults";
+import type { gatewayType } from "../gateway-model-defaults";
 import type { generatedForGateway, models } from "../models.generated";
 
 export type InstalledGateway = InstanceType<typeof Gateway>;
 export type GatewayType = typeof gatewayType;
 export type GatewayProvider = GatewayProviderBase<GatewayType>;
-export const DEFAULT_GATEWAY = gatewayType;
-export type DefaultGateway = GatewayType;
 
 export type GatewayModelIdMap = {
   [K in GatewayType]: Parameters<InstalledGateway["createLanguageModel"]>[0];

--- a/apps/chat/lib/config-schema.ts
+++ b/apps/chat/lib/config-schema.ts
@@ -11,8 +11,8 @@ export type { GatewayType } from "@/lib/ai/gateways/registry";
 import {
   gatewayCapabilities,
   gatewayModelDefaults,
+  gatewayType,
 } from "./ai/gateway-model-defaults";
-import { DEFAULT_GATEWAY } from "./ai/gateways/registry";
 import type { ToolName } from "./ai/types";
 
 // Helper to create typed model ID schemas
@@ -157,7 +157,7 @@ function createAiSchema<G extends GatewayType>(g: G) {
   });
 }
 
-const installedGatewaySchema = createAiSchema(DEFAULT_GATEWAY);
+const installedGatewaySchema = createAiSchema(gatewayType);
 
 export const aiConfigSchema = installedGatewaySchema
   .superRefine((ai, ctx) => {
@@ -172,7 +172,7 @@ export const aiConfigSchema = installedGatewaySchema
     }
   })
   .default({
-    gateway: DEFAULT_GATEWAY,
+    gateway: gatewayType,
     ...gatewayModelDefaults,
   });
 
@@ -563,7 +563,7 @@ function mergeToolsConfig<T extends Record<string, unknown>>(
 
 // Apply defaults to partial config
 export function applyDefaults(input: ConfigInput): Config {
-  const gateway = input.ai?.gateway ?? DEFAULT_GATEWAY;
+  const gateway = input.ai?.gateway ?? gatewayType;
   const gatewayDefaults = gatewayModelDefaults;
   const aiInput = input.ai as Record<string, unknown> | undefined;
 

--- a/apps/chat/lib/utils.ts
+++ b/apps/chat/lib/utils.ts
@@ -16,7 +16,7 @@ interface ApplicationError extends Error {
 	status: number;
 }
 
-export const fetchWithErrorHandlers: typeof fetch = async (input, init) => {
+export const fetchWithErrorHandlers = async (...[input, init]: Parameters<typeof fetch>): Promise<Response> => {
 	try {
 		const response = await fetch(input, init);
 

--- a/packages/gateways/src/runtime.ts
+++ b/packages/gateways/src/runtime.ts
@@ -9,7 +9,9 @@ interface GatewayLogger {
 
 export interface GatewayOptions {
   env?: Record<string, string | undefined>;
-  fetch?: typeof globalThis.fetch;
+  fetch?: (
+    ...args: Parameters<typeof globalThis.fetch>
+  ) => ReturnType<typeof globalThis.fetch>;
   getFallbackModels?: (gateway: string) => readonly AiGatewayModel[];
   logger?: GatewayLogger;
 }


### PR DESCRIPTION
Make `apps/chat` consume its selected Vercel gateway and defaults through ordinary local files instead of importing implementation code from the registry-authoring workspace. Preserve selected model-ID types and capabilities while removing redundant default-gateway aliases.

Also make injected fetch types depend on the callable signature, rather than host-specific static properties such as Bun's `fetch.preconnect`.

This is the foundation of the two-PR registry cleanup stack. Registry generation, CLI installation, and tool registration migration are in the next PR. The independent streaming fix is #340 and is not included here.

Validation: workspace lint, type checks, and unit tests on this branch in a separate worktree.

## Summary by Sourcery

Decouple the chat reference app from registry-owned gateway implementation and defaults while making injected fetch handling portable across runtimes.

New Features:
- Make the chat reference app own its Vercel gateway implementation and model defaults locally.
- Preserve gateway-specific model ID typing and capability configuration for the selected gateway.

Bug Fixes:
- Allow injected fetch implementations to work across Node and Bun typings without requiring host-specific fetch properties.

Enhancements:
- Remove redundant default-gateway aliases and use the locally selected gateway consistently for configuration defaults and validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Vercel AI Gateway model discovery now supports language, image, and video models.
  - Available models are fetched from the gateway when credentials are configured, with generated fallback models when unavailable.
  - Custom fetch implementations are now supported across Node and Bun environments.

- **Bug Fixes**
  - Improved gateway configuration handling when the active gateway cannot be inferred.
  - Gateway defaults and model settings are now validated more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->