### PR TITLE
Delegate tool installation to shadcn

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,96 +1,47 @@
-import fs from "node:fs/promises";
-import path from "node:path";
-import { confirm, intro, isCancel, log, outro } from "@clack/prompts";
+import { access } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { confirm, isCancel } from "@clack/prompts";
 import { Command } from "commander";
-import { loadProjectConfig, resolveToolsPath } from "../utils/get-config";
+import { toolDefinitionSchema } from "../../../registry/metadata";
+import { installItems, itemAddress, readItem } from "../registry/shadcn";
+import { syncTools } from "../utils/sync-tools";
 import { handleError } from "../utils/handle-error";
-import { installRegistryTools } from "../utils/install-registry-tools";
-import { spinner } from "../utils/spinner";
 
-export const add = new Command()
-	.name("add")
-	.description("add a tool to an existing ChatJS project")
-	.argument("[tools...]", "tool names to add (e.g. word-count)")
-	.option("-y, --yes", "skip confirmation prompt", false)
-	.option(
-		"-o, --overwrite",
-		"overwrite existing files without prompting",
-		false,
+export const add = new Command("add")
+	.description(
+		"install registry tools and regenerate their ChatJS registrations",
 	)
-	.option(
-		"-c, --cwd <cwd>",
-		"the working directory (defaults to current directory)",
-		process.cwd(),
-	)
-	.option(
-		"-r, --registry <url>",
-		"registry URL or local path template (e.g. ./packages/registry/items/{name}.json)",
-	)
-	.action(async (tools: string[], opts) => {
+	.argument("<tools...>", "tool names or standard shadcn registry addresses")
+	.option("-y, --yes", "skip confirmation", false)
+	.option("-o, --overwrite", "overwrite existing installed source files", false)
+	.option("-c, --cwd <cwd>", "project directory", process.cwd())
+	.action(async (tools: string[], options) => {
 		try {
-			const cwd = path.resolve(opts.cwd);
-
-			if (tools.length === 0) {
-				log.error(
-					"Please specify one or more tool names, e.g. chatjs add word-count",
+			const cwd = resolve(options.cwd);
+			await access(join(cwd, "chat.config.ts"));
+			const addresses = tools.map((tool) => itemAddress(tool, "tool"));
+			const expected = [];
+			for (const address of addresses)
+				expected.push(
+					toolDefinitionSchema.parse(
+						(await readItem(address, cwd)).meta?.chatjs,
+					),
 				);
-				process.exit(1);
-			}
-
-			try {
-				await fs.stat(path.join(cwd, "chat.config.ts"));
-			} catch {
-				log.error(
-					"No chat.config.ts found. Run `chat-js create` first or specify --cwd.",
-				);
-				process.exit(1);
-			}
-
-			intro("chatjs add");
-
-			const configSpinner = spinner("Loading project config...");
-			configSpinner.start();
-			let config: { paths: { tools: string } };
-			try {
-				config = await loadProjectConfig(cwd);
-				configSpinner.succeed("Project config loaded");
-			} catch (err) {
-				configSpinner.fail("Failed to load project config");
-				throw err;
-			}
-
-			const toolsDir = resolveToolsPath(config.paths.tools, cwd);
-
-			if (!opts.yes) {
+			if (!options.yes) {
 				const answer = await confirm({
-					message: `Install ${tools.join(", ")} into ${path.relative(process.cwd(), toolsDir)}/?`,
+					message: `Install ${tools.join(", ")}?`,
 				});
-				if (isCancel(answer) || !answer) {
-					outro("Cancelled.");
-					process.exit(0);
-				}
+				if (isCancel(answer) || !answer) return;
 			}
-
-			await installRegistryTools({
-				tools,
-				cwd,
-				toolsDir,
-				toolsAlias: config.paths.tools,
-				overwrite: opts.overwrite as boolean,
-				registryUrl: opts.registry,
-				confirmOverwrite: async (existingFiles) => {
-					const answer = await confirm({
-						message: `${existingFiles
-							.map((file) => path.relative(cwd, file))
-							.join(", ")} already exist. Overwrite?`,
-					});
-					return !(isCancel(answer) || !answer);
-				},
-			});
-
-			outro(
-				`Done! ${tools.length === 1 ? `"${tools[0]}"` : `${tools.length} tools`} installed successfully.`,
-			);
+			await syncTools(cwd, { checkOnly: true });
+			await installItems(addresses, cwd, options.overwrite);
+			try {
+				await syncTools(cwd, { expected });
+			} catch (error) {
+				throw new Error(
+					`Source installation completed, but registration failed. Fix the problem and run chat-js sync. ${error instanceof Error ? error.message : error}`,
+				);
+			}
 		} catch (error) {
 			handleError(error);
 		}

--- a/packages/cli/src/registry/shadcn.ts
+++ b/packages/cli/src/registry/shadcn.ts
@@ -1,0 +1,51 @@
+import { withRegistryTransport } from "./transport";
+import {
+	addRegistryItems,
+	getRegistriesConfig,
+	getRegistry,
+	getRegistryItems,
+} from "shadcn/registry";
+import { registryItemSchema } from "shadcn/schema";
+
+export const registryUrl =
+	"https://unpkg.com/@chat-js/registry@1/dist/r/{name}.json";
+export async function registryConfig(cwd: string) {
+	const config = await getRegistriesConfig(cwd);
+	return {
+		registries: {
+			"@chatjs": process.env.CHATJS_REGISTRY_URL ?? registryUrl,
+			...config.registries,
+		},
+	};
+}
+export function itemAddress(source: string, kind: "gateway" | "tool") {
+	if (/^[a-z][a-z0-9-]*$/.test(source))
+		return `@chatjs/${source}${kind === "gateway" && !source.endsWith("-gateway") ? "-gateway" : ""}`;
+	return source;
+}
+export async function readItem(source: string, cwd: string) {
+	const [item] = await withRegistryTransport(async () =>
+		getRegistryItems([source], { config: await registryConfig(cwd) }),
+	);
+	return registryItemSchema.parse(item);
+}
+export async function listTools(cwd: string) {
+	const catalog = await withRegistryTransport(async () =>
+		getRegistry("@chatjs", { config: await registryConfig(cwd) }),
+	);
+	return catalog.items.filter((item) => item.meta?.chatjs?.kind === "tool");
+}
+export async function installItems(
+	sources: string[],
+	cwd: string,
+	overwrite = false,
+) {
+	await withRegistryTransport(async () =>
+		addRegistryItems(sources, {
+			cwd,
+			config: await registryConfig(cwd),
+			overwrite,
+			silent: true,
+		}),
+	);
+}

--- a/packages/cli/src/registry/transport.test.ts
+++ b/packages/cli/src/registry/transport.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { installItems } from "./shadcn";
+import { withRegistryTransport } from "./transport";
+
+test("shadcn transitive registry requests retain transport policy and restore host fetch", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "chatjs-transport-"));
+	const original = globalThis.fetch;
+	const server = Bun.serve({
+		port: 0,
+		hostname: "127.0.0.1",
+		fetch: () =>
+			Response.json({
+				name: "unsafe-dependency",
+				type: "registry:item",
+				registryDependencies: ["http://example.com/insecure.json"],
+				files: [],
+			}),
+	});
+	try {
+		await expect(
+			installItems([`http://127.0.0.1:${server.port}/root.json`], cwd),
+		).rejects.toThrow("HTTPS");
+		expect(globalThis.fetch).toBe(original);
+		expect(await withRegistryTransport(async () => "next operation")).toBe(
+			"next operation",
+		);
+		expect(globalThis.fetch).toBe(original);
+	} finally {
+		server.stop(true);
+		await rm(cwd, { recursive: true, force: true });
+	}
+});

--- a/packages/cli/src/registry/transport.ts
+++ b/packages/cli/src/registry/transport.ts
@@ -1,0 +1,51 @@
+/** A process-local network policy around shadcn's native fetch calls.
+ * shadcn still owns requests, authentication, redirects, caching and resolution.
+ * Serialize operations so this temporary host policy cannot leak between calls.
+ */
+let pending: Promise<void> = Promise.resolve();
+function requireSecure(url: string, redirect = false) {
+	const parsed = new URL(url);
+	if (parsed.protocol === "https:") return;
+	if (
+		!redirect &&
+		parsed.protocol === "http:" &&
+		["localhost", "127.0.0.1", "[::1]"].includes(parsed.hostname)
+	)
+		return;
+	throw new Error(
+		"Registry requests must use HTTPS (HTTP is allowed only on loopback, without redirects).",
+	);
+}
+export function withRegistryTransport<T>(
+	operation: () => Promise<T>,
+): Promise<T> {
+	const run = async () => {
+		const original = globalThis.fetch;
+		globalThis.fetch = new Proxy(original, {
+			apply(target, receiver, args: Parameters<typeof fetch>) {
+				const input = args[0];
+				const url = input instanceof Request ? input.url : String(input);
+				requireSecure(url);
+				return Reflect.apply(target, receiver, args).then(
+					(response: Response) => {
+						const location = response.headers.get("location");
+						if (response.status >= 300 && response.status < 400 && location)
+							requireSecure(new URL(location, url).href, true);
+						return response;
+					},
+				);
+			},
+		});
+		try {
+			return await operation();
+		} finally {
+			globalThis.fetch = original;
+		}
+	};
+	const result = pending.then(run);
+	pending = result.then(
+		() => {},
+		() => {},
+	);
+	return result;
+}


### PR DESCRIPTION
Make `chat-js add` resolve and install registry items through shadcn 4.21.0, then validate installed descriptors and regenerate ChatJS registrations. Standard registry namespaces live in components.json. A process-local transport policy enforces HTTPS while shadcn owns resolution, fetching, and file installation.

Validation: workspace lint, type checks, and unit tests passed on this layer, including transport policy tests. The integrated packed-CLI checks belong to #346.

Stack: #342 → #344 → #345 → #346 → #347. The old installer remains used by create until the next layer removes it.

## Summary by Sourcery

Delegate `chat-js add` registry resolution and installation to shadcn, then validate and synchronize the resulting ChatJS registrations.

New Features:
- Route `chat-js add` registry resolution and source installation through shadcn while supporting standard ChatJS tool addresses and custom registry items.
- Validate installed registry metadata and regenerate ChatJS tool registrations after installation.

Bug Fixes:
- Enforce secure registry transport for shadcn requests, including transitive dependencies and redirects, while restoring the host fetch implementation after each operation.

Enhancements:
- Use project registry configuration and ChatJS namespace defaults for registry access, with support for overriding the ChatJS registry URL.

Tests:
- Add coverage for registry transport enforcement, operation serialization, and fetch restoration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The `add` command now installs tools from the standard shadcn registry.
  - Tools can be specified by name or registry address, with gateway tools resolved automatically.
  - Added support for configured and custom registry sources.
  - Added confirmation prompts, `--yes` support, and optional overwriting of existing items.
  - Installed tools automatically regenerate ChatJS registrations.

- **Bug Fixes**
  - Registry requests now enforce secure connections and safely handle redirects.
  - Improved recovery when registration fails, including guidance to run `chat-js sync`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->