### PR TITLE
Document the standard registry workflow and migration

### DIFF
--- a/apps/docs/cli/add.mdx
+++ b/apps/docs/cli/add.mdx
@@ -1,60 +1,39 @@
 ---
 title: add
-description: Add a tool to an existing ChatJS project
+description: Install registry tools and generate their ChatJS registrations
 ---
 
 ```bash
-npx @chat-js/cli@latest add [tools...] [options]
+npx @chat-js/cli@latest add <tools...> [options]
 ```
 
-## Arguments
+Accepts built-in names, standard `@namespace/item` addresses, complete item URLs,
+and local registry JSON paths. Run inside a ChatJS app with `chat.config.ts`.
 
-| Argument   | Description                         |
-| ---------- | ----------------------------------- |
-| `tools…`   | One or more tool names to install.  |
-
-## Options
-
-| Flag                    | Default | Description                                                    |
-| ----------------------- | ------- | -------------------------------------------------------------- |
-| `-y, --yes`             | `false` | Skip confirmation prompt.                                      |
-| `-o, --overwrite`       | `false` | Overwrite existing installed files without prompting.          |
-| `-c, --cwd <cwd>`       | `cwd`   | Working directory (where `chat.config.ts` lives).              |
-| `-r, --registry <url>`  | —       | Registry URL or local path template. Overrides `CHATJS_REGISTRY_URL`. |
-
-## Examples
+| Flag | Default | Description |
+| --- | --- | --- |
+| `-y, --yes` | `false` | Skip ChatJS confirmation |
+| `-o, --overwrite` | `false` | Replace existing source files |
+| `-c, --cwd <cwd>` | Current directory | Destination app |
 
 ```bash
-# Install a single tool
-npx @chat-js/cli@latest add word-count
-
-# Install multiple tools, skip confirmation
-npx @chat-js/cli@latest add word-count pdf-summary --yes
-
-# Use a local registry (monorepo development)
-npx @chat-js/cli@latest add word-count \
-  --registry ./packages/registry/items/{name}.json \
-  --cwd apps/chat
+npx @chat-js/cli@latest add word-count get-weather --yes
+npx @chat-js/cli@latest add @acme/my-tool
+npx @chat-js/cli@latest add ./my-tool.json --cwd apps/chat
 ```
 
-## What it does
+Configure namespaces in `components.json`. The former `--registry` flag is
+removed. shadcn installs source and packages using the project's detected package
+manager, then ChatJS syncs local tool descriptors into typed registrations.
 
-For each tool name, the command:
+After direct shadcn installation, regenerate registrations explicitly:
 
-1. Fetches `{name}.json` from the registry
-2. Recursively resolves any `registryDependencies`
-3. Writes the tool's files into your project (under the path configured in `chat.config.ts`)
-4. Installs any npm dependencies the resolved items declare
-5. Warns if the installed items declare missing environment variables
-6. Injects imports and registrations into the CLI-managed registry files at `tools/chatjs/tools.ts` and `tools/chatjs/ui.ts` by default
+```bash
+npx @chat-js/cli@latest sync --cwd apps/chat
+```
 
-## Environment variables
+If wiring fails after source installation, the command exits unsuccessfully with
+recovery instructions. Repair the reported descriptor or index and rerun `sync`.
 
-| Variable               | Description                                        |
-| ---------------------- | -------------------------------------------------- |
-| `CHATJS_REGISTRY_URL`  | Default registry URL template. The `{name}` placeholder is replaced with the tool name. Useful for pointing to a local registry without passing `--registry` every time. |
-
-## Related
-
-- [Adding Tools](/cookbook/add-tools) — step-by-step walkthrough
-- [Tools](/cookbook/tools) — how to build and publish a tool
+- [Tool Registry](../core/tool-registry) explains customizations and migration.
+- [Tools](../cookbook/tools) explains authoring.

--- a/apps/docs/cli/create.mdx
+++ b/apps/docs/cli/create.mdx
@@ -21,8 +21,7 @@ npx @chat-js/cli@latest [directory] [options]
 | Flag               | Default | Description                                                                          |
 | ------------------ | ------- | ------------------------------------------------------------------------------------ |
 | `-y, --yes`                         | `false` | Skip all prompts and use defaults (Vercel gateway, GitHub auth, no extra features). |
-| `--no-install`                      | Not applicable | Skip automatic dependency installation.                                      |
-| `--package-manager <bun\|npm\|pnpm\|yarn>` | Not applicable | Override which package manager the CLI uses for install + next steps.        |
+| `--gateway <name-or-address>` | Vercel | Select a built-in or external registry gateway. |
 | `--from-git <url>`                  | Not applicable | Clone from a git repository instead of the built-in template.                |
 | `--storage-provider <provider>`     | Not applicable | Select a Files SDK provider such as `vercel-blob`, `s3`, `r2`, or `gcs`.      |
 | `--storage-config <json>`           | Not applicable | Pass non-secret JSON options to the selected adapter. Credentials use env vars. |
@@ -37,9 +36,8 @@ When run without `--yes`, the CLI walks you through:
 4. **File storage:** provider and non-secret adapter options when selected features store files
 5. **Auth providers:** authentication method (e.g. GitHub OAuth)
 6. **Electron desktop app:** optionally adds an `electron/` subfolder to package the app as a native desktop app (see [Desktop](/platforms/desktop))
-7. **Install dependencies:** whether to run the package manager automatically
 
-The CLI keeps `pnpm`, `yarn`, and `bun` when launched from those tools. If you launch through `npx`/npm, it defaults the generated app to npm unless you pass `--package-manager`.
+New apps use the invoking package manager, with Bun as the fallback. The CLI records its version in `package.json`, and shadcn installs dependencies immediately. The former `--no-install`, `--package-manager`, and `--registry` flags are removed.
 
 ## What gets generated
 
@@ -80,16 +78,10 @@ npx @chat-js/cli@latest create my-chat-app
 npx @chat-js/cli@latest create my-chat-app --yes
 ```
 
-**Create without installing dependencies**
+**Select a gateway**
 
 ```bash
-npx @chat-js/cli@latest create my-chat-app --no-install
-```
-
-**Use npm for install + printed next steps**
-
-```bash
-npx @chat-js/cli@latest create my-chat-app --package-manager npm
+npx @chat-js/cli@latest create my-chat-app --gateway openrouter
 ```
 
 **Clone from a custom git repository**
@@ -120,3 +112,5 @@ cp .env.example .env.local
 bun run db:push
 bun run dev
 ```
+
+Run `npx @chat-js/cli@latest sync` after a direct shadcn tool installation. For a recognized `--from-git` ChatJS clone, create replaces its selected gateway slot and writes a new configuration. Unsupported clones skip ChatJS installation.

--- a/apps/docs/cookbook/add-tools.mdx
+++ b/apps/docs/cookbook/add-tools.mdx
@@ -1,168 +1,49 @@
 ---
 title: Adding Tools
-description: How the ChatJS registry installs a tool into your project
+description: Install and register a tool in an existing ChatJS app
 ---
 
-This recipe explains what `chatjs add` does to your project and how the registry install flow works under the hood.
-
-For the user-facing overview of the registry itself, start with [Tool Registry](../core/tool-registry).
-
-## Problem
-
-You want to distribute a tool as source code that another ChatJS app can install, type-check, and render without manual wiring.
-
-That means installation needs to do more than download a single file. It has to:
-
-- copy the tool implementation into the app
-- copy its renderer and any shared helper files
-- install npm dependencies
-- register the tool so the model can call it
-- register the UI so tool parts render correctly
-
-## Solution
-
-`chatjs add` installs a registry item into the app's installable tools namespace at `tools/chatjs` by default.
+Start in a ChatJS app containing `chat.config.ts` and `components.json`.
 
 ```bash
-npx @chat-js/cli@latest add word-count
+npx @chat-js/cli@latest add word-count --yes
 ```
 
-The command resolves the requested item, installs any registry dependencies, writes all declared files, then updates the CLI-managed registry files.
-
-## Install Flow
-
-The current flow is:
-
-1. Load `chat.config.ts` and resolve `paths.tools`
-2. Fetch the requested registry item JSON
-3. Recursively resolve `registryDependencies`
-4. Write every declared file into the tools directory
-5. Rewrite `@toolkit/*` imports into local project imports under `tools/chatjs/_shared`
-6. Install the combined npm dependencies and dev dependencies
-7. Inject tool registrations into `tools/chatjs/tools.ts` and UI registrations into `tools/chatjs/ui.ts`
+The CLI validates the item's ChatJS metadata and existing registration outputs.
+shadcn installs the item, supporting registry files, and npm dependencies using
+your project's package manager. ChatJS then reads local descriptors and generates
+typed imports in `tools/chatjs/tools.ts` and `tools/chatjs/ui.ts`.
 
 ```mermaid
-flowchart TD
-  A["chatjs add word-count"] --> B["load chat.config.ts"]
-  B --> C["resolve registry items"]
-  C --> D["write files into tools/chatjs"]
-  D --> E["install npm dependencies"]
-  E --> F["update tools/chatjs/tools.ts + ui.ts"]
-  F --> G["installedTools and toolRendererRegistry pick up new entries"]
+flowchart LR
+  A[Select item] --> B[shadcn installation]
+  B --> C[Installed source and descriptor]
+  C --> D[ChatJS sync]
+  D --> E[Typed server and client registrations]
 ```
 
-## Registry Item Shape
+The app derives installed tool types through `lib/ai/installed-tools.ts` and
+selects their renderers through `lib/ai/tool-renderer-registry.ts`.
 
-Each installable item is a JSON manifest. It declares files to copy plus dependency metadata.
+## Customize and update
 
-```json title="packages/registry/items/get-weather.json"
-{
-  "name": "get-weather",
-  "description": "Get the current weather at a location",
-  "dependencies": ["ai", "date-fns", "zod"],
-  "registryDependencies": ["toolkit-renderer"],
-  "files": [
-    {
-      "path": "tool.ts",
-      "type": "tool",
-      "target": "get-weather/tool.ts",
-      "content": "..."
-    },
-    {
-      "path": "renderer.tsx",
-      "type": "renderer",
-      "target": "get-weather/renderer.tsx",
-      "content": "..."
-    }
-  ]
-}
+Edit installed `tool.ts` and `renderer.tsx` normally. Put additional registrations
+in `custom-tools.ts` and `custom-ui.ts`. Leave generated indexes to `sync`.
+
+Repeat `add` to update an item. Existing files use normal shadcn overwrite
+behavior. Use `--overwrite` only when you want to replace installed source.
+
+After a direct shadcn install, or a reported registration failure, run:
+
+```bash
+npx @chat-js/cli@latest sync
 ```
 
-`registryDependencies` let one registry item pull in another. In this branch, `get-weather` depends on `toolkit-renderer`, which installs shared files like `_shared/lib/cx.ts` and `_shared/hooks/use-tool-is-compact.ts`.
-
-## What Changes In Your Project
-
-After installation, your project will usually gain:
-
-```text
-tools/
-  chatjs/
-    tools.ts
-    ui.ts
-    word-count/
-      tool.ts
-      renderer.tsx
-    _shared/
-      hooks/
-      lib/
-```
-
-The CLI also updates the managed registry files:
-
-```ts title="tools/chatjs/tools.ts"
-// [chatjs-registry:tool-imports]
-import { wordCount } from "@/tools/chatjs/word-count/tool";
-// [/chatjs-registry:tool-imports]
-
-export const tools = {
-  // [chatjs-registry:tools]
-  wordCount,
-  // [/chatjs-registry:tools]
-} as const;
-```
-
-```ts title="tools/chatjs/ui.ts"
-// [chatjs-registry:ui-imports]
-import { WordCountRenderer } from "@/tools/chatjs/word-count/renderer";
-// [/chatjs-registry:ui-imports]
-
-export const ui = {
-  // [chatjs-registry:ui]
-  "tool-wordCount": WordCountRenderer,
-  // [/chatjs-registry:ui]
-};
-```
-
-You do not edit this file by hand. The CLI owns the marker blocks and injects entries idempotently.
-
-## How The Installed Tool Becomes Available
-
-Once `tools/chatjs/tools.ts` and `tools/chatjs/ui.ts` are updated, the rest of the app picks up the new tool through two static wrappers:
-
-- `lib/ai/installed-tools.ts` derives `InstalledTools` from the `tools` export
-- `lib/ai/tool-renderer-registry.ts` exposes the `ui` map as the renderer registry
-
-```mermaid
-flowchart TD
-  A["tools/chatjs/tools.ts"] --> B["lib/ai/installed-tools.ts"]
-  C["tools/chatjs/ui.ts"] --> D["lib/ai/tool-renderer-registry.ts"]
-  B --> E["lib/ai/types.ts"]
-  D --> F["components/part/tool-part.tsx"]
-  E --> F
-```
-
-This keeps installable tools separate from built-in platform tools while still making them first-class typed tools in the app.
-
-## Key Files
-
-| File | Role |
-| --- | --- |
-| `packages/cli/src/commands/add.ts` | Main install flow for `chatjs add` |
-| `packages/cli/src/registry/resolve.ts` | Recursively resolves registry dependencies |
-| `packages/cli/src/utils/write-files.ts` | Writes files and rewrites `@toolkit/*` imports |
-| `packages/cli/src/utils/inject-tool.ts` | Updates the CLI-managed registry files |
-| `apps/chat/lib/ai/installed-tools.ts` | Derives typed installed tools |
-| `apps/chat/lib/ai/tool-renderer-registry.ts` | Registers installed renderers |
-
-## Notes
-
-- The registry index is created automatically if it does not exist yet.
-- Re-installing a tool is safe because registration is idempotent.
-- Existing files are preserved unless you confirm an overwrite or pass `--overwrite`.
-- The registry can distribute more than `tool.ts` and `renderer.tsx`. It can also ship shared libs, components, and hooks.
+Sync validates descriptors, duplicate keys, and generated-index integrity before
+writing registrations. A missing or mismatched requested descriptor is an error.
 
 ## Related
 
-- [Tool Registry](../core/tool-registry) for the conceptual overview
-- [Tools](./tools) for building and publishing registry tools
-- [CLI add](../cli/add) for the command reference
+- [Tool Registry](../core/tool-registry) for ownership and migration
+- [Tools](./tools) for building a registry item
+- [CLI add](../cli/add) for command options

--- a/apps/docs/cookbook/add-tools.mdx
+++ b/apps/docs/cookbook/add-tools.mdx
@@ -39,8 +39,10 @@ After a direct shadcn install, or a reported registration failure, run:
 npx @chat-js/cli@latest sync
 ```
 
-Sync validates descriptors, duplicate keys, and generated-index integrity before
-writing registrations. A missing or mismatched requested descriptor is an error.
+Sync validates descriptors, duplicate installed descriptor keys, and generated-index
+integrity before writing registrations. Generated indexes detect collisions with
+custom registrations when loaded. A missing or mismatched requested descriptor is
+an error.
 
 ## Related
 

--- a/apps/docs/cookbook/tools.mdx
+++ b/apps/docs/cookbook/tools.mdx
@@ -1,241 +1,94 @@
 ---
 title: Tools
-description: How to build and distribute installable AI tools with custom UI components
+description: Author tested source files and publish them as shadcn registry items
 ---
 
-> Build a self-contained tool that the `chatjs add` CLI command can install into any ChatJS project.
+Author tools as real TypeScript files that you can import, type-check, and test.
+In this repository, canonical implementations live in `packages/registry/src`.
+The app consumes installed copies through normal local imports.
 
-For the product-level overview of the registry and when to use it, start with [Tool Registry](../core/tool-registry).
+## Server and renderer
 
-## Overview
+Use the AI SDK's `tool()` helper for the server implementation:
 
-The registry system lets you package a backend AI tool and its frontend renderer as a distributable unit. Once installed, the tool is available to the AI model and its output is rendered with your custom component -- with full TypeScript type safety end to end.
-
-This recipe covers how the system works and what files make up an installable tool.
-
-## How it works
-
-Installing a tool does three things:
-
-1. Copies the tool implementation and renderer into the project
-2. Injects the tool into `tools/chatjs/tools.ts` and `tools/chatjs/ui.ts`, the two files the CLI manages
-3. The static wrappers (`installed-tools.ts`, `tool-renderer-registry.ts`) automatically pick up the new entries while built-in tools stay under `tools/platform`
-
-```mermaid
-flowchart TD
-  A["tools/chatjs/tools.ts\n(CLI-managed server registry)"] --> B["lib/ai/installed-tools.ts\n(static wrapper)"]
-  C["tools/chatjs/ui.ts\n(CLI-managed client registry)"] --> D["lib/ai/tool-renderer-registry.ts\n(static wrapper)"]
-  B --> E["lib/ai/types.ts\nChatTools & InstalledTools"]
-  D --> F["components/part/tool-part.tsx\ntoolRendererRegistry lookup"]
-  E --> F
-```
-
-## File structure
-
-Each tool lives in its own folder. The CLI copies two files and injects entries for all three into the registry index.
-
-| File | What it contains |
-|------|-----------------|
-| `tools/chatjs/{name}/tool.ts` | Backend tool: schema + `execute` function |
-| `tools/chatjs/{name}/renderer.tsx` | Frontend renderer component |
-| `tools/chatjs/tools.ts` | Server registry file -- CLI injects tool imports and entries here |
-| `tools/chatjs/ui.ts` | Client registry file -- CLI injects renderer imports and entries here |
-
-## Tool environment variables
-
-If a tool needs environment variables, declare them in `tool.ts` with `toolEnvVars`.
-
-```ts title="tools/chatjs/retrieve-url/tool.ts"
-import type { ToolEnvVars } from "@chat-js/registry";
-import { tool } from "ai";
-
-export const toolEnvVars: ToolEnvVars = [
-  {
-    options: [["FIRECRAWL_API_KEY"]],
-  },
-];
-
-export const retrieveUrl = tool({
-  // ...
-});
-```
-
-This is the source of truth for installable tool env requirements.
-
-- The registry build extracts `toolEnvVars` into the published manifest as `envRequirements`.
-- `chatjs add` uses that metadata to warn about missing env vars during installation.
-- `check-env` validates installed tools by reading `toolEnvVars` from each installed `tool.ts`.
-
-`description` is optional. If omitted, ChatJS formats a readable fallback from `options`, for example `OPENAI_COMPATIBLE_BASE_URL + OPENAI_COMPATIBLE_API_KEY` or `TAVILY_API_KEY or FIRECRAWL_API_KEY`.
-
-## Code
-
-### 1. Backend tool
-
-Registry tools use `tool()` from the AI SDK directly. They are plain tools that take input and return output.
-
-```ts title="tools/chatjs/word-count/tool.ts"
+```ts
 import { tool } from "ai";
 import { z } from "zod";
 
 export const wordCount = tool({
-  description: "Count the words, characters, and sentences in a given text",
-  inputSchema: z.object({
-    text: z.string().describe("The text to analyze"),
+  description: "Count words in text",
+  inputSchema: z.object({ text: z.string() }),
+  execute: ({ text }) => ({
+    words: text.trim() ? text.trim().split(/\s+/).length : 0,
   }),
-  execute: async ({ text }: { text: string }) => {
-    const words = text.trim() === "" ? 0 : text.trim().split(/\s+/).length;
-    const characters = text.length;
-    const charactersNoSpaces = text.replace(/\s/g, "").length;
-    const sentences = text
-      .split(/[.!?]+/)
-      .filter((s) => s.trim().length > 0).length;
-
-    return { words, characters, charactersNoSpaces, sentences };
-  },
-});
-
-export type WordCountOutput = {
-  words: number;
-  characters: number;
-  charactersNoSpaces: number;
-  sentences: number;
-};
-```
-
-### 2. Frontend renderer
-
-The renderer imports `WordCountOutput` from the tool file and defines a local `WordCountPart` type. This avoids the circular import that would arise from importing through `@/lib/ai/types` (which depends on the tools registry).
-
-```tsx title="tools/chatjs/word-count/renderer.tsx"
-"use client";
-
-import type { WordCountOutput } from "./tool";
-
-// Typed locally to avoid circular imports (tools/ ← lib/ai/types ← installed-tools ← tools/)
-type WordCountPart =
-  | { state: "input-available" | "input-streaming"; output?: never }
-  | { state: "output-available"; output: WordCountOutput };
-
-export function WordCountRenderer({ tool }: { tool: unknown }) {
-  const part = tool as WordCountPart;
-
-  if (part.state === "input-available") {
-    return (
-      <div className="text-muted-foreground rounded-lg border p-3 text-sm">
-        Counting words...
-      </div>
-    );
-  }
-
-  if (part.state !== "output-available") {
-    return null;
-  }
-
-  const { words, characters, charactersNoSpaces, sentences } = part.output;
-
-  return (
-    <div className="grid grid-cols-2 gap-2 rounded-lg border p-3 text-sm sm:grid-cols-4">
-      <Stat label="Words" value={words} />
-      <Stat label="Characters" value={characters} />
-      <Stat label="No spaces" value={charactersNoSpaces} />
-      <Stat label="Sentences" value={sentences} />
-    </div>
-  );
-}
-
-function Stat({ label, value }: { label: string; value: number }) {
-  return (
-    <div className="flex flex-col items-center gap-1">
-      <span className="font-semibold text-lg">{value}</span>
-      <span className="text-muted-foreground text-xs">{label}</span>
-    </div>
-  );
-}
-```
-
-### 3. Registry files (CLI-managed)
-
-The CLI appends imports and entries to the managed server and client registry files. You do not edit these files manually.
-
-```ts title="tools/chatjs/tools.ts"
-// [chatjs-registry:tool-imports]
-import { wordCount } from "@/tools/chatjs/word-count/tool";
-// [/chatjs-registry:tool-imports]
-
-export const tools = {
-  // [chatjs-registry:tools]
-  wordCount,
-  // [/chatjs-registry:tools]
-} as const;
-```
-
-```ts title="tools/chatjs/ui.ts"
-// [chatjs-registry:ui-imports]
-import { WordCountRenderer } from "@/tools/chatjs/word-count/renderer";
-// [/chatjs-registry:ui-imports]
-
-export const ui = {
-  // [chatjs-registry:ui]
-  "tool-wordCount": WordCountRenderer,
-  // [/chatjs-registry:ui]
-};
-```
-
-## Type flow
-
-`installed-tools.ts` derives `InstalledTools` from the `tools` export via a mapped `InferUITool` type. `types.ts` intersects this with the built-in `ChatTools`, so installed tools become first-class typed members of the union.
-
-```
-tools (as const) → InstalledTools → ChatTools & InstalledTools → ToolUIPart<ChatTools>
-```
-
-Renderers receive `{ tool: unknown }` and cast to a locally defined type. The local type is built from the exported `WordCountOutput` type in `tool.ts`, keeping the renderer isolated from the `@/lib/ai/types` import chain (which would cause a circular dependency via `installed-tools → tools/chatjs/index`). The `output` field is fully typed with no `unknown` beyond the initial cast.
-
-## Path configuration
-
-The CLI reads `paths.tools` from `chat.config.ts` to know where to copy files and which import alias to write into the registry index. The default matches the out-of-the-box project layout.
-
-```ts title="chat.config.ts"
-export default defineConfig({
-  // ...
-  paths: {
-    tools: "@/tools/chatjs",
-  },
 });
 ```
 
-## Platform vs installable tools
+The renderer exports a named React component. Use the source tool's inferred
+input/output types and the shared `ToolPartFromTool` helper, keeping runtime imports of
+server code out of the client bundle. See the existing word-count source for
+loading, result, and error states.
 
-ChatJS now separates tool code into two buckets:
+## Item metadata
 
-| Location | Purpose |
-|----------|---------|
-| `tools/platform` | Built-in product tools and internal helpers |
-| `tools/chatjs` | CLI-managed installable tools from the registry |
+Declare standard shadcn files and dependencies in `packages/registry/registry.ts`.
+ChatJS metadata describes only registration and environment requirements:
 
-Only `tools/chatjs/tools.ts` and `tools/chatjs/ui.ts` are managed by `chatjs add`.
+```json
+{
+  "contractVersion": 1,
+  "kind": "tool",
+  "id": "word-count",
+  "toolExport": "wordCount",
+  "rendererExport": "WordCountRenderer",
+  "envRequirements": []
+}
+```
 
-## Architecture note
+The same metadata is emitted as `meta.chatjs` in the registry item and as an
+installed `tools/chatjs/word-count/chatjs.json` descriptor. Each item targets
+`tool.ts`, `renderer.tsx`, and `chatjs.json` under `~/tools/chatjs/<id>/`.
+Shared helpers use standard `registryDependencies`. npm packages use
+`dependencies` or `devDependencies`.
 
-Treat `tools/platform` and `tools/chatjs` as different ownership layers:
+For credentials, declare environment alternatives in the typed item metadata:
 
-- Put a tool in `tools/platform` when it is part of the product runtime, depends tightly on app infrastructure, or needs richer internal contracts.
-- Put a tool in `tools/chatjs` when it is a self-contained installable unit that can be copied into another ChatJS project by `chatjs add`.
+```ts
+const envRequirements = [{ options: [["FIRECRAWL_API_KEY"]] }];
+```
 
-This boundary is intentional:
+Every outer requirement must be satisfied. Within one requirement, `options`
+contains alternatives, and each alternative lists variables needed together.
+The build serializes this data into the descriptor. The installed app's
+`check-env` command reads it without evaluating remote source. The old
+`toolEnvVars` source parser and registry authoring-type npm exports are removed.
 
-1. Installable tools are the extension surface.
-2. Platform tools are the built-in product surface.
-3. `tools/chatjs/tools.ts` and `tools/chatjs/ui.ts` are the CLI-managed registry files.
-4. `paths.tools` configures the installable tools namespace, not the platform tool namespace.
+## Build and verify
 
-Do not migrate a platform tool into `tools/chatjs` unless it remains useful as a portable package with a small public contract.
+```bash
+bun run --cwd packages/registry test:types
+bun run --cwd packages/registry test:unit
+bun run --cwd packages/registry build
+```
 
-## Registry manifest
+The small build script emits `registry.json`, then pinned `shadcn@4.21.0 build`
+reads the actual sources and generates `dist/r/*.json`. Do not hand-maintain JSON
+source strings. Publish those generated files from your registry endpoint.
 
-When you publish a tool to a registry, the manifest is a self-contained JSON payload with the source files, dependency list, and any extracted environment requirements the CLI will install and validate.
+Install the built item into an independent ChatJS app and type-check it. Source
+tests validate execution logic, while installation tests catch missing files,
+dependencies, incorrect targets, and renderer registration problems.
+
+```bash
+npx @chat-js/cli@latest add https://example.com/r/word-count.json
+```
+
+Third-party registries use the same standard item format and descriptor contract.
+There is no runtime plugin loader or general compatibility solver. The installed
+app's TypeScript checks validate composition against its actual local contracts.
 
 ## Related
 
-- [Tool Part](/cookbook/tool-part) -- how built-in tools connect a backend definition to a frontend component
+- [Tool Registry](../core/tool-registry) for ownership and namespaces
+- [Adding Tools](./add-tools) for installation and sync
+- [Tool Part](./tool-part) for rendering tool results

--- a/apps/docs/core/tool-registry.mdx
+++ b/apps/docs/core/tool-registry.mdx
@@ -25,8 +25,9 @@ Existing source follows shadcn's overwrite prompts. Pass `--overwrite` to replac
 | `tools/chatjs/tools.ts`, `ui.ts` | Generated registrations |
 | `tools/chatjs/custom-tools.ts`, `custom-ui.ts` | Your custom registrations |
 
-Keep manual registrations in the custom modules. Sync rejects duplicate keys and
-edited generated indexes. It also refuses to remove a previously registered tool
+Keep manual registrations in the custom modules. Sync rejects duplicate installed
+descriptor keys and edited generated indexes. Generated indexes detect collisions
+with custom registrations when loaded. Sync also refuses to remove a previously registered tool
 just because its descriptor disappeared. Restore the descriptor before syncing.
 Known legacy built-in indexes migrate automatically. Customized legacy indexes
 need an explicit move into the custom modules before removing the old indexes.

--- a/apps/docs/core/tool-registry.mdx
+++ b/apps/docs/core/tool-registry.mdx
@@ -1,122 +1,78 @@
 ---
-title: "Tool Registry"
-description: "Install and distribute ChatJS tools through the registry"
+title: Tool Registry
+description: Install and distribute typed ChatJS tools with shadcn registries
 ---
 
-The ChatJS tool registry is the distribution layer for installable tools. It lets you ship a tool's server logic, UI renderer, and supporting files as a portable package that another ChatJS app can install with `chatjs add`.
-
-This is the extension surface for ChatJS. Built-in product tools stay in `tools/platform`. Installable tools live in `tools/chatjs` and are managed by the CLI.
-
-## What You Install
-
-When you run `chatjs add`, the CLI:
-
-1. Fetches a registry item by name
-2. Resolves any registry dependencies that item depends on
-3. Writes the tool files into the installable tools directory from `chat.config.ts`
-4. Installs any npm dependencies declared by the registry item
-5. Warns if installed items declare missing environment variables
-6. Updates the CLI-managed registry files so the tool is available to the model and renderer
+The ChatJS registry distributes editable source code using shadcn. A tool includes
+server logic, a client renderer, dependencies, and a declarative registration
+descriptor. Installed tools become part of your app's typed tool system.
 
 ```bash
 npx @chat-js/cli@latest add word-count
 ```
 
-## Why This Exists
+shadcn resolves the item and its dependencies, installs packages, and writes the
+source files. ChatJS then regenerates separate server and client registrations.
+Existing source follows shadcn's overwrite prompts. Pass `--overwrite` to replace it.
 
-The registry gives ChatJS a standardized way to distribute software between projects.
+## Installed files
 
-- You can publish self-contained tools instead of copying app-specific code by hand.
-- Installed tools become part of the app's typed tool system automatically.
-- Each tool can ship both execution logic and a custom UI renderer.
-- Shared helpers can be distributed as registry dependencies and installed alongside the main tool.
+| File | Ownership |
+| --- | --- |
+| `tools/chatjs/<id>/tool.ts` | Editable server implementation |
+| `tools/chatjs/<id>/renderer.tsx` | Editable client renderer |
+| `tools/chatjs/<id>/chatjs.json` | Installed registration and environment descriptor |
+| `tools/chatjs/tools.ts`, `ui.ts` | Generated registrations |
+| `tools/chatjs/custom-tools.ts`, `custom-ui.ts` | Your custom registrations |
 
-If you have used `shadcn/ui`, the model is similar. The registry distributes source files into your project instead of mounting opaque runtime plugins.
+Keep manual registrations in the custom modules. Sync rejects duplicate keys and
+edited generated indexes. It also refuses to remove a previously registered tool
+just because its descriptor disappeared. Restore the descriptor before syncing.
+Known legacy built-in indexes migrate automatically. Customized legacy indexes
+need an explicit move into the custom modules before removing the old indexes.
 
-## Installed Tool Layout
+Registry items specify explicit file targets. This integration uses `tools/chatjs`.
+The former `paths.tools` configuration and marker-based injection are removed.
+Built-in product tools remain in `tools/platform`.
 
-By default, installed tools are written into `tools/chatjs`:
+## External registries
 
-```text
-tools/
-  chatjs/
-    tools.ts
-    ui.ts
-    word-count/
-      tool.ts
-      renderer.tsx
-    _shared/
-      hooks/
-      lib/
+Configure standard namespaces in `components.json`:
+
+```json
+{
+  "registries": {
+    "@chatjs": "https://unpkg.com/@chat-js/registry@1/dist/r/{name}.json",
+    "@acme": "https://example.com/r/{name}.json"
+  }
+}
 ```
-
-`tools/chatjs/tools.ts` and `tools/chatjs/ui.ts` are the CLI-managed registry files. You should not edit them manually.
-
-## Registry Boundaries
-
-ChatJS separates tools into two layers:
-
-| Location | Ownership | Purpose |
-| --- | --- | --- |
-| `tools/platform` | ChatJS platform | Built-in product tools and tightly coupled internal tooling |
-| `tools/chatjs` | Registry + app | Installable tools distributed through `chatjs add` |
-
-Use `tools/platform` when a tool depends on internal app contracts or product infrastructure.
-
-Use `tools/chatjs` when a tool should be portable across ChatJS projects as a distributable package.
-
-## Project Configuration
-
-The registry installs files into the path configured by `paths.tools` in `chat.config.ts`:
-
-```ts title="chat.config.ts"
-export default defineConfig({
-  paths: {
-    tools: "@/tools/chatjs",
-  },
-});
-```
-
-The CLI uses this path both to decide where files should be written and which import alias should be used inside the generated registry index.
-
-## Tool Environment Variables
-
-Installable tools can declare their own environment requirements directly in `tool.ts`.
-
-```ts title="tools/chatjs/retrieve-url/tool.ts"
-import type { ToolEnvVars } from "@chat-js/registry";
-
-export const toolEnvVars: ToolEnvVars = [
-  {
-    options: [["FIRECRAWL_API_KEY"]],
-  },
-];
-```
-
-The registry build extracts `toolEnvVars` into the generated registry manifest as `envRequirements`. `chatjs add` uses that metadata for install-time warnings, and `check-env` validates installed tools from their `tool.ts` source at app startup and build time.
-
-## Using a Different Registry
-
-You can point the CLI at a local or custom registry:
 
 ```bash
-npx @chat-js/cli@latest add word-count \
-  --registry ./packages/registry/items/{name}.json \
-  --cwd apps/chat
+npx @chat-js/cli@latest add @acme/my-tool
 ```
 
-You can also set a default registry URL template with `CHATJS_REGISTRY_URL`.
+You can also pass a complete registry item URL or local JSON path. Registry
+requests require HTTPS, with HTTP allowed for local loopback development.
+`--registry` has been replaced by standard namespace configuration.
 
-## Manual Update And Troubleshooting
+## Direct shadcn installation
 
-- Re-running `chatjs add` is safe. The CLI avoids duplicate registry entries.
-- Pass `--overwrite` if you want to replace existing installed files.
-- If `chat.config.ts` is missing, `chatjs add` will stop before making changes.
-- If an item declares shared registry dependencies, those are installed automatically before the main item is registered.
-- If the registry index does not exist yet, the CLI creates it for you.
+```bash
+npx shadcn@4.21.0 add @chatjs/word-count
+npx @chat-js/cli@latest sync
+```
+
+shadcn installs source. `sync` reads installed descriptors and generates ChatJS
+registrations without evaluating third-party source. `chat-js add` performs both
+steps. If registration fails after installation, fix the reported issue and run
+`sync` again. Package installation is not transactional.
+
+Tool environment requirements live in `chatjs.json`, generated from typed item
+metadata. `check-env` reads those descriptors without importing server tools.
 
 ## Related
 
-- [CLI add](../cli/add) for the command reference
-- [Adding Tools](../cookbook/add-tools) for how installation works under the hood
-- [Tools](../cookbook/tools) for authoring and publishing registry tools
+- [CLI add](../cli/add) for command options
+- [Adding Tools](../cookbook/add-tools) for the installation steps
+- [Tools](../cookbook/tools) for source authoring

--- a/apps/docs/platforms/desktop.mdx
+++ b/apps/docs/platforms/desktop.mdx
@@ -104,7 +104,7 @@ bun install
 bun run dev
 ```
 
-Use the same package manager you selected during `create`. If you passed `--package-manager npm` (or another manager), replace `bun` above with that manager.
+Use the package manager recorded in your generated `package.json`. For an npm-created app, replace `bun` above with `npm`.
 
 In development, the Electron wrapper points at `http://localhost:3000` by default.
 

--- a/apps/docs/quickstart.mdx
+++ b/apps/docs/quickstart.mdx
@@ -19,7 +19,7 @@ npx @chat-js/cli@latest create my-app
 cd my-app
 ```
 
-The CLI walks you through selecting your AI gateway, features, and auth providers, then generates a configured project with `chat.config.ts` ready to go. It also asks whether to include a [Desktop app](/platforms/desktop). It preserves `bun`, `pnpm`, and `yarn` when launched from those tools, and defaults `npx`/npm launches to npm unless you pass `--package-manager`.
+The CLI walks you through selecting your AI gateway, features, and auth providers, then generates a configured project with `chat.config.ts` ready to go. It also asks whether to include a [Desktop app](/platforms/desktop). It preserves `bun`, `pnpm`, and `yarn` when launched from those tools, and defaults `npx`/npm launches to npm.
 
 ## Understanding `chat.config.ts`
 
@@ -31,7 +31,7 @@ The `chat.config.ts` file controls all feature toggles, branding, and app settin
 
 | Setting             | Default           | Notes                                                         |
 | ------------------- | ----------------- | ------------------------------------------------------------- |
-| **Gateway**         | Vercel AI Gateway | Set `gateway: "openrouter"` for OpenRouter                    |
+| **Gateway**         | Vercel AI Gateway | Use `create --gateway openrouter` for OpenRouter                    |
 | **Authentication**  | GitHub only       | Google and Vercel OAuth disabled                              |
 | **Features**        | All disabled      | No sandbox, web search, MCP, image generation, or attachments |
 | **Anonymous users** | 10 credits        | Limited access, no tools                                      |

--- a/apps/docs/reference/cli.mdx
+++ b/apps/docs/reference/cli.mdx
@@ -61,10 +61,10 @@ Use `npx @chat-js/cli@latest --version` or `chat-js --version` after a global in
 ### `add`
 
 ```bash
-npx @chat-js/cli@latest add [tools...]
+npx @chat-js/cli@latest add <tools...> [options]
 ```
 
-Install one or more registry tools into an existing ChatJS project. Items specify explicit targets under `tools/chatjs`; namespace configuration lives in `components.json`.
+Install one or more registry tools into an existing ChatJS project. Items specify explicit targets under `tools/chatjs`. Namespace configuration lives in `components.json`.
 
 | Flag                   | Default           | Description                                      |
 | ---------------------- | ----------------- | ------------------------------------------------ |

--- a/apps/docs/reference/cli.mdx
+++ b/apps/docs/reference/cli.mdx
@@ -44,15 +44,13 @@ npx @chat-js/cli@latest [directory] [options]
 | Flag                                      | Default  | Description                                                                  |
 | ----------------------------------------- | -------- | ---------------------------------------------------------------------------- |
 | `-y, --yes`                               | `false`  | Skip prompts and use the scaffold defaults.                                  |
-| `--no-install`                            | —        | Skip automatic dependency installation.                                      |
 | `--electron` / `--no-electron`            | Prompted | Include or exclude the Electron desktop app.                                 |
-| `-r, --registry <url>`                    | Default registry | Use a registry URL or local path template.                            |
-| `--package-manager <bun\|npm\|pnpm\|yarn>` | Inferred | Override the package manager used for installation and next steps.       |
+| `--gateway <name-or-address>` | Vercel | Select a built-in or external registry gateway. |
 | `--from-git <url>`                        | Built-in scaffold | Clone from a Git repository instead of the built-in scaffold.         |
 | `--storage-provider <provider>`           | Prompted when needed | Select a Files SDK provider such as `vercel-blob`, `s3`, `r2`, or `gcs`. |
 | `--storage-config <json>`                 | —        | Supply non-secret Files SDK adapter options as JSON.                         |
 
-The CLI first checks for a package-manager lockfile, then checks the invoking tool. Running through `npx` or npm selects npm. If neither signal exists, npm is the default. Pass `--package-manager` to override the result.
+New apps use the invoking package manager, with Bun as the fallback. The CLI records its version in `package.json`, and shadcn installs dependencies immediately. The former `--no-install`, `--package-manager`, and `--registry` flags are removed.
 
 After scaffolding, the CLI prints the exact environment variables required for your chosen configuration.
 
@@ -66,14 +64,13 @@ Use `npx @chat-js/cli@latest --version` or `chat-js --version` after a global in
 npx @chat-js/cli@latest add [tools...]
 ```
 
-Install one or more registry tools into an existing ChatJS project. The command reads the tool destination from `chat.config.ts`.
+Install one or more registry tools into an existing ChatJS project. Items specify explicit targets under `tools/chatjs`; namespace configuration lives in `components.json`.
 
 | Flag                   | Default           | Description                                      |
 | ---------------------- | ----------------- | ------------------------------------------------ |
 | `-y, --yes`            | `false`           | Skip the installation confirmation.              |
 | `-o, --overwrite`      | `false`           | Overwrite existing tool files without prompting. |
 | `-c, --cwd <cwd>`      | Current directory | Run against another ChatJS project.               |
-| `-r, --registry <url>` | Default registry  | Use a registry URL or local path template.        |
 
 ```bash
 npx @chat-js/cli@latest add word-count
@@ -134,16 +131,10 @@ npx @chat-js/cli@latest create my-chat-app --yes
 
 Defaults include Vercel AI Gateway, GitHub OAuth, parallel responses, document tools, no Electron app, and npm when invoked through `npx`.
 
-**Create without installing dependencies**
+**Select a gateway**
 
 ```bash
-npx @chat-js/cli@latest create my-chat-app --no-install
-```
-
-**Use npm for install + printed next steps**
-
-```bash
-npx @chat-js/cli@latest create my-chat-app --package-manager npm
+npx @chat-js/cli@latest create my-chat-app --gateway openrouter
 ```
 
 **Clone from a custom git repository**
@@ -155,10 +146,12 @@ npx @chat-js/cli@latest create my-chat-app --from-git https://github.com/your-or
 **Full flow after scaffolding**
 
 ```bash
-npx @chat-js/cli@latest create my-chat-app --package-manager npm
+npx @chat-js/cli@latest create my-chat-app
 cd my-chat-app
 cp .env.example .env.local
 # Fill in the env vars printed by the CLI
 npm run db:push
 npm run dev
 ```
+
+Run `npx @chat-js/cli@latest sync` after a direct shadcn tool installation. For a recognized `--from-git` ChatJS clone, create replaces its selected gateway slot and writes a new configuration. Unsupported clones skip ChatJS installation.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -35,3 +35,35 @@ and credentials; the CLI has no fixed gateway enum. See
 
 Run `bun --filter @chat-js/cli test:gateways` from the repository root to verify
 independent installs of all built-ins and an external registry gateway.
+
+## Installation and migration
+
+The CLI uses unmodified shadcn 4.21.0 for registry resolution and installation.
+New apps use the invoking package manager, with Bun as the fallback. Existing
+apps use their standard package metadata and lockfiles. Dependencies install
+immediately. `--no-install`, `--package-manager`, and `--registry` are removed.
+Configure registry namespaces in `components.json` instead:
+
+```json
+{ "registries": { "@acme": "https://example.com/r/{name}.json" } }
+```
+
+```sh
+chat-js add @acme/my-tool --yes
+chat-js add word-count --overwrite
+chat-js sync
+```
+
+Tools install under `tools/chatjs`; `paths.tools` is no longer configuration.
+Generated server/client indexes merge user-owned `custom-tools.ts` and
+`custom-ui.ts`. Known legacy built-in indexes are migrated automatically. For
+customized legacy indexes, move registrations into the custom modules and remove
+the old indexes before syncing. Tool source remains yours to edit. Missing
+descriptors and manually edited generated indexes cause an actionable error.
+
+Direct shadcn tool installation requires `chat-js sync` afterward. A gateway is
+selected during creation; this release does not replace gateways in existing apps.
+For `create --from-git`, a recognized ChatJS clone receives the selected gateway
+in its existing slot and a new configuration. Unsupported clones are left without
+ChatJS installation. Registry/package installation is not transactional; repair a
+partial tool installation and rerun `chat-js sync`.

--- a/packages/registry/README.md
+++ b/packages/registry/README.md
@@ -1,13 +1,38 @@
 # @chat-js/registry
 
-Published ChatJS registry artifacts and authoring types.
+Code-first authoring and generated shadcn registry distribution for ChatJS.
 
-The package is distributed through npm. The CLI consumes the published
-`items/*.json` manifests from the package contents via the default npm-backed
-registry URL, so there is no separate registry deploy step.
+Edit the real TypeScript sources in `gateways/` and `src/`. `registry.ts` declares
+standard item files, targets, dependencies, and validated `meta.chatjs` metadata.
+Test implementations by importing those sources directly.
 
-This package contains:
+```sh
+bun run test:types
+bun run test:unit
+bun run build
+```
 
-- `index.json` with the registry index
-- `items/*.json` with generated registry tool manifests
-- `ToolEnvVars` for typing static `toolEnvVars` exports in `tool.ts`
+`build.ts` serializes the catalog and tool descriptors, then runs published
+`shadcn@4.21.0 build`. shadcn reads the source files and emits `dist/r/*.json`.
+Both the intermediate `registry.json` and output are generated, never edited.
+The output directory is cleared first, so deleted items cannot survive a build.
+
+The npm package publishes `dist/r/`. Version 1 uses the standard registry format:
+`https://unpkg.com/@chat-js/registry@1/dist/r/{name}.json`. Historical version 0
+npm artifacts retain their legacy `items/` format for already-published CLIs.
+Publish registry v1 and the shared gateway contracts before promoting the CLI
+release that consumes them. The static Vercel deployment serves the same output.
+
+## Tools
+
+Each tool item installs `tool.ts`, `renderer.tsx`, and `chatjs.json` under
+`~/tools/chatjs/<id>/`. The descriptor contains contractVersion 1, kind `tool`,
+id, named tool/renderer exports, and environment requirements. The build derives
+it from the same typed metadata used in the catalog.
+
+`chat-js add` delegates installation to shadcn, then generates typed server and
+client indexes. Direct `shadcn add` installs are supported by running `chat-js sync`
+afterward. Custom registrations belong in `custom-tools.ts` and `custom-ui.ts`.
+Third-party items use the same shape and standard namespaces in `components.json`.
+
+See [gateway authoring](./gateways/README.md) for adapter-specific metadata.

--- a/packages/registry/gateways/README.md
+++ b/packages/registry/gateways/README.md
@@ -12,21 +12,22 @@ chat-js create my-chat --gateway ./acme-gateway.json
 ```
 
 Without `--gateway`, the interactive CLI offers the bundled gateway items.
-`--yes` selects Vercel. A named item can also be resolved with
-`--gateway acme --registry 'https://example.com/r/{name}.json'`.
+`--yes` selects Vercel. Use standard namespaces in `components.json` for external
+registries, or pass a complete item URL/local JSON path.
 
-Run `bun --filter @chat-js/registry build` to generate the built-in
-`items/*-gateway.json` payloads and the standard `gateways.json` registry index.
-The CLI bundles those same item definitions for offline built-in scaffolding.
+Run `bun --filter @chat-js/registry build` to generate `dist/r/*.json` from the
+real adapter source files. The CLI reads those standard artifacts through shadcn.
+There is no offline adapter bundle or custom registry resolver.
 
 ## Author an item
 
 Use a built item as a starting point. Declare:
 
-- `type: "registry:item"`, a name, and `files` with source `content`.
+- `type: "registry:item"`, a name, and `files` with source paths and explicit targets.
+  shadcn build embeds the source content in the published JSON.
 - `dependencies` / `devDependencies`: npm names with optional versions.
-- `registryDependencies`: URLs or local paths to supporting registry items.
-  Relative addresses resolve against the declaring item's location.
+- `registryDependencies`: standard shadcn addresses to supporting registry items.
+  Use namespace addresses or absolute URLs for portable dependencies.
 - A file targeting `~/lib/ai/gateway.ts`, exporting a `Gateway` constructor.
   Supporting files live under `~/lib/ai/gateway/`.
 - `meta.chatjs`: `kind: "gateway"`, `contractVersion: 1`, a unique literal `id`,
@@ -45,9 +46,10 @@ app checks them against the actual adapter, not a list of known gateway names.
 
 An item can instead install a tiny entry file importing `Gateway` from an author's
 npm package and list that package in `dependencies`. No ChatJS CLI change is
-needed for a new gateway ID. Registry dependencies may contain supporting files,
-but cannot select another gateway. Conflicting files, dependency versions,
-unsupported contract versions and paths outside the gateway slot are rejected.
+needed for a new gateway ID. Registry dependencies may contain supporting files. ChatJS checks the root
+item's contract and gateway slot, while shadcn owns dependency resolution and
+existing-file behavior. Type-check the installed app to verify the adapter and
+configuration agree. There is no general compatibility solver.
 
 The registry supplies files and dependencies; it does not execute installation
 hooks. Standard package-manager behavior still applies when dependencies install.
@@ -60,7 +62,8 @@ fixtures. The integration suite in `packages/cli/test/gateway-selection.test.ts`
 uses an HTTP registry with an unknown `acme` gateway and a separate adapter item.
 No paid provider credentials are required for these tests.
 
-Installation rejects symlinked destinations and output paths during preflight.
+ChatJS integration rejects symlinked configuration output paths during preflight.
+Source installation uses shadcn's own destination checks.
 These checks protect against symlinks already present in a cloned app. They are
 not an atomic filesystem sandbox against processes concurrently modifying the
 same destination with the user's permissions.


### PR DESCRIPTION
Update CLI, tool authoring, registry, and package documentation for code-first registry sources, shadcn installation, and chat-js sync. Explain standard namespaces and the removal of --registry, --no-install, --package-manager, and paths.tools.

Validation: workspace lint and documentation link checks passed.

Documentation-only final layer: #342 → #344 → #345 → #346 → #347.

## Summary by Sourcery

Document the standard shadcn-based registry workflow and migration path for ChatJS tools, gateways, and namespaces.

New Features:
- Document standard shadcn registry namespaces, direct item addresses, and the `add`/`sync` workflow for installing and registering ChatJS tools.
- Document code-first tool authoring, typed ChatJS descriptors, generated registry artifacts, and external registry publication.

Enhancements:
- Update CLI and registry documentation for fixed tool namespaces, generated server/client registrations, editable installed source, and migration from legacy registry indexes.
- Clarify gateway selection, package-manager detection, `--from-git` behavior, and removal of the `--no-install`, `--package-manager`, `--registry`, and `paths.tools` interfaces.

Deployment:
- Document publishing generated standard registry artifacts through npm and static registry deployments.

Documentation:
- Revise CLI, quickstart, cookbook, platform, reference, package, and registry documentation to reflect the standard registry workflow and migration guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated CLI guides and references for gateway selection, Git-based scaffolding, automatic package-manager detection, Files SDK storage, and immediate shadcn dependency installation.
  - Documented the new shadcn-based workflow for adding tools, generating typed registrations with `sync`, configuring registries, and recovering from installation failures.
  - Added guidance for code-first tool and gateway authoring, metadata, validation, builds, publishing, and versioned registry formats.
  - Removed documentation for legacy flags, registry overrides, and former registry layouts and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->