### PR TITLE
Organize registry documentation by category

### DIFF
--- a/apps/docs/blume.config.ts
+++ b/apps/docs/blume.config.ts
@@ -10,6 +10,7 @@ const contentSections = [
   "gateways",
   "platforms",
   "reference",
+  "tools",
 ] as const;
 
 export default defineConfig({
@@ -69,6 +70,11 @@ export default defineConfig({
       { href: "/cli", label: "CLI", icon: "terminal" },
     ],
   },
+  redirects: [
+    { from: "/core/tool-registry", to: "/tools/overview" },
+    { from: "/cookbook/add-tools", to: "/tools/install" },
+    { from: "/cookbook/tools", to: "/tools/authoring" },
+  ],
   navigation: {
     featured: [
       {
@@ -95,9 +101,34 @@ export default defineConfig({
             "/core/configuration",
             "/core/file-storage",
             "/core/authentication",
-            "/core/tool-registry",
             "/core/multi-model",
             "/core/syntax-highlighting",
+          ],
+        },
+        {
+          label: "Registry",
+          items: [
+            "/core/registry",
+            {
+              label: "Gateways",
+              items: [
+                "/gateways/overview",
+                "/gateways/vercel",
+                "/gateways/openrouter",
+                "/gateways/openai",
+                "/gateways/openai-compatible",
+                "/gateways/litellm",
+                "/gateways/custom",
+              ],
+            },
+            {
+              label: "Tools",
+              items: [
+                "/tools/overview",
+                "/tools/install",
+                "/tools/authoring",
+              ],
+            },
           ],
         },
         {
@@ -158,18 +189,6 @@ export default defineConfig({
             "/reference/routing",
             "/reference/testing",
             "/reference/evaluations",
-            {
-              label: "Gateways",
-              items: [
-                "/gateways/overview",
-                "/gateways/vercel",
-                "/gateways/openrouter",
-                "/gateways/openai",
-                "/gateways/openai-compatible",
-                "/gateways/litellm",
-                "/gateways/custom",
-              ],
-            },
           ],
         },
         {
@@ -180,8 +199,6 @@ export default defineConfig({
             "/cookbook/resumable-streams",
             "/cookbook/stop-resumable-streams",
             "/cookbook/tool-part",
-            "/cookbook/tools",
-            "/cookbook/add-tools",
             "/cookbook/next-chat-transition",
             "/cookbook/credit-tracking",
             "/cookbook/neon-branching",

--- a/apps/docs/blume.config.ts
+++ b/apps/docs/blume.config.ts
@@ -10,6 +10,7 @@ const contentSections = [
   "gateways",
   "platforms",
   "reference",
+  "registry",
   "tools",
 ] as const;
 
@@ -71,6 +72,7 @@ export default defineConfig({
     ],
   },
   redirects: [
+    { from: "/core/registry", to: "/registry" },
     { from: "/core/tool-registry", to: "/tools/overview" },
     { from: "/cookbook/add-tools", to: "/tools/install" },
     { from: "/cookbook/tools", to: "/tools/authoring" },
@@ -106,29 +108,35 @@ export default defineConfig({
           ],
         },
         {
+          label: "Gateways",
+          items: [
+            "/gateways/overview",
+            "/gateways/vercel",
+            "/gateways/openrouter",
+            "/gateways/openai",
+            "/gateways/openai-compatible",
+            "/gateways/litellm",
+            "/gateways/custom",
+          ],
+        },
+        {
+          label: "Tools",
+          items: [
+            "/tools/overview",
+            "/tools/install",
+            "/tools/word-count",
+            "/tools/get-weather",
+            "/tools/retrieve-url",
+            "/tools/authoring",
+          ],
+        },
+        {
           label: "Registry",
           items: [
-            "/core/registry",
-            {
-              label: "Gateways",
-              items: [
-                "/gateways/overview",
-                "/gateways/vercel",
-                "/gateways/openrouter",
-                "/gateways/openai",
-                "/gateways/openai-compatible",
-                "/gateways/litellm",
-                "/gateways/custom",
-              ],
-            },
-            {
-              label: "Tools",
-              items: [
-                "/tools/overview",
-                "/tools/install",
-                "/tools/authoring",
-              ],
-            },
+            "/registry",
+            "/registry/namespaces",
+            "/registry/authoring",
+            "/registry/testing",
           ],
         },
         {

--- a/apps/docs/cli/add.mdx
+++ b/apps/docs/cli/add.mdx
@@ -35,5 +35,5 @@ npx @chat-js/cli@latest sync --cwd apps/chat
 If wiring fails after source installation, the command exits unsuccessfully with
 recovery instructions. Repair the reported descriptor or index and rerun `sync`.
 
-- [Tool Registry](../core/tool-registry) explains customizations and migration.
-- [Tools](../cookbook/tools) explains authoring.
+- [Tool Registry](../tools/overview) explains customizations and migration.
+- [Tools](../tools/authoring) explains authoring.

--- a/apps/docs/core/registry.mdx
+++ b/apps/docs/core/registry.mdx
@@ -1,0 +1,71 @@
+---
+title: Registry Overview
+description: Choose gateway and tool extensions, and understand their source and installation contracts
+---
+
+Use the ChatJS registry to install editable source and the dependencies required
+by your selected extensions. shadcn distributes and installs items. The ChatJS
+CLI configures the app and generates tool registrations from installed descriptors.
+
+## Categories
+
+Choose a category based on what you want to change in your app.
+
+| Category | App behavior | Start here |
+| --- | --- | --- |
+| Gateways | Select the AI backend when creating an app | [Choose a gateway](../gateways/overview) |
+| Tools | Add server tools and their result renderers to an existing app | [Install tools](../tools/install) |
+
+For gateways, use `chat-js create --gateway` to install and configure the selected
+adapter. For tools, use `chat-js add` to install items and regenerate registrations.
+These categories have different activation contracts even though both use shadcn.
+
+Layouts and caches are not registry categories yet. Existing layout recipes and
+cache configuration do not imply a registry installation contract.
+
+## Namespaces and item names
+
+Configure registry source aliases such as `@chatjs` or `@acme` in `components.json`.
+An address such as `@chatjs/word-count` identifies an item from that source.
+The item's `meta.chatjs.kind` identifies its category independently of its name.
+
+Source folders, public item names, and installed paths are separate. The built-in
+Vercel item is named `vercel-gateway`, is authored under `src/gateways/vercel/`,
+and installs into `lib/ai/gateway.ts`. Changing a registry alias does not change an
+item's explicit file targets.
+
+## Source and ownership
+
+| Location in the repository | Responsibility |
+| --- | --- |
+| `packages/registry/src/gateways/<id>/gateway.ts` | Canonical gateway implementations |
+| `packages/registry/src/tools/<id>/` | Canonical tools and renderers |
+| `packages/registry/registry.ts` | Item files, dependencies, targets, and metadata |
+| `packages/registry/dist/r/` | Generated registry JSON for distribution |
+| `packages/gateways/` | Shared gateway contracts and runtime utilities |
+| `packages/cli/` | App creation, installation, and registration generation |
+| `apps/chat/` | Working reference app and app template source |
+
+Author and test TypeScript source. The registry build serializes metadata and
+runs shadcn to embed that source in distributable JSON. Do not edit generated JSON.
+
+Your app owns the installed source. Its selected gateway occupies
+`lib/ai/gateway.ts`. Built-in registry tools coexist under `tools/chatjs/<id>/`.
+Keep manual tool registrations in `custom-tools.ts` and `custom-ui.ts`, leaving
+`tools.ts` and `ui.ts` to the generator. Product tools under `tools/platform/`
+remain part of the app.
+
+## Author and verify an extension
+
+Follow the category's contract:
+
+- [Custom gateways](../gateways/custom) describes adapter exports, capabilities,
+  credentials, and model defaults.
+- [Authoring tools](../tools/authoring) describes server and renderer exports,
+  descriptors, and environment requirements.
+- [Tool registration](../tools/overview) explains generated files, customizations,
+  and direct shadcn installation.
+
+Test source behavior, then install the built item into an independent app and
+run its type checks. This verifies file targets, dependencies, and local contracts.
+A real provider request is still needed to verify credentials and remote behavior.

--- a/apps/docs/e2e/docs-visual.browser.test.ts
+++ b/apps/docs/e2e/docs-visual.browser.test.ts
@@ -3,6 +3,8 @@ import { expect, test } from "vitest";
 
 const pages = [
 	{ name: "home", path: "/docs" },
+	{ name: "registry", path: "/docs/core/registry" },
+	{ name: "tools", path: "/docs/tools/authoring" },
 	{ name: "quickstart", path: "/docs/quickstart" },
 	{ name: "changelog", path: "/docs/changelog" },
 	{ name: "cookbook", path: "/docs/cookbook" },

--- a/apps/docs/e2e/docs-visual.browser.test.ts
+++ b/apps/docs/e2e/docs-visual.browser.test.ts
@@ -3,8 +3,14 @@ import { expect, test } from "vitest";
 
 const pages = [
 	{ name: "home", path: "/docs" },
-	{ name: "registry", path: "/docs/core/registry" },
+	{ name: "registry", path: "/docs/registry" },
 	{ name: "tools", path: "/docs/tools/authoring" },
+	{ name: "namespaces", path: "/docs/registry/namespaces" },
+	{ name: "publishing", path: "/docs/registry/authoring" },
+	{ name: "registry-testing", path: "/docs/registry/testing" },
+	{ name: "word-count", path: "/docs/tools/word-count" },
+	{ name: "get-weather", path: "/docs/tools/get-weather" },
+	{ name: "retrieve-url", path: "/docs/tools/retrieve-url" },
 	{ name: "quickstart", path: "/docs/quickstart" },
 	{ name: "changelog", path: "/docs/changelog" },
 	{ name: "cookbook", path: "/docs/cookbook" },

--- a/apps/docs/registry/authoring.mdx
+++ b/apps/docs/registry/authoring.mdx
@@ -1,0 +1,36 @@
+---
+title: Authoring and Publishing
+description: Publish tested TypeScript source through generated shadcn registry JSON
+---
+
+Start with a working implementation of a supported category contract:
+
+- [Custom gateways](../gateways/custom) defines gateway exports, capabilities,
+  credentials, and model defaults.
+- [Authoring tools](../tools/authoring) defines server and renderer exports,
+  registration descriptors, and environment requirements.
+
+## Keep source in code
+
+In this repository, gateway source lives under
+`packages/registry/src/gateways/<id>/` and tool source under
+`packages/registry/src/tools/<id>/`. Declare files, dependencies, installation
+targets, and metadata in `packages/registry/registry.ts`.
+
+Use standard shadcn `dependencies` for npm packages and `registryDependencies`
+for shared registry items. ChatJS metadata describes the category contract.
+The public item name does not have to contain the category name.
+
+## Generate and publish JSON
+
+Run `bun run --cwd packages/registry build`. The build serializes the typed
+registry definition and descriptors, then runs shadcn to embed source files in
+`packages/registry/dist/r/*.json`. Treat these files as generated artifacts.
+
+Publish the generated item files at your registry endpoint. Configure an alias
+using a URL template ending in `{name}.json`, as described in
+[Namespaces](./namespaces). Consumers install those files through shadcn or the
+ChatJS CLI, and own the resulting source in their app.
+
+Before publishing, follow [Building and Testing](./testing) to check both the
+source and its installation into an independent app.

--- a/apps/docs/registry/index.mdx
+++ b/apps/docs/registry/index.mdx
@@ -20,20 +20,6 @@ For gateways, use `chat-js create --gateway` to install and configure the select
 adapter. For tools, use `chat-js add` to install items and regenerate registrations.
 These categories have different activation contracts even though both use shadcn.
 
-Layouts and caches are not registry categories yet. Existing layout recipes and
-cache configuration do not imply a registry installation contract.
-
-## Namespaces and item names
-
-Configure registry source aliases such as `@chatjs` or `@acme` in `components.json`.
-An address such as `@chatjs/word-count` identifies an item from that source.
-The item's `meta.chatjs.kind` identifies its category independently of its name.
-
-Source folders, public item names, and installed paths are separate. The built-in
-Vercel item is named `vercel-gateway`, is authored under `src/gateways/vercel/`,
-and installs into `lib/ai/gateway.ts`. Changing a registry alias does not change an
-item's explicit file targets.
-
 ## Source and ownership
 
 | Location in the repository | Responsibility |
@@ -55,17 +41,8 @@ Keep manual tool registrations in `custom-tools.ts` and `custom-ui.ts`, leaving
 `tools.ts` and `ui.ts` to the generator. Product tools under `tools/platform/`
 remain part of the app.
 
-## Author and verify an extension
+## Registry guides
 
-Follow the category's contract:
-
-- [Custom gateways](../gateways/custom) describes adapter exports, capabilities,
-  credentials, and model defaults.
-- [Authoring tools](../tools/authoring) describes server and renderer exports,
-  descriptors, and environment requirements.
-- [Tool registration](../tools/overview) explains generated files, customizations,
-  and direct shadcn installation.
-
-Test source behavior, then install the built item into an independent app and
-run its type checks. This verifies file targets, dependencies, and local contracts.
-A real provider request is still needed to verify credentials and remote behavior.
+- [Namespaces](./namespaces) explains item addresses and installation targets.
+- [Authoring and publishing](./authoring) explains the source-to-JSON workflow.
+- [Building and testing](./testing) explains how to verify distributed items.

--- a/apps/docs/registry/namespaces.mdx
+++ b/apps/docs/registry/namespaces.mdx
@@ -1,0 +1,34 @@
+---
+title: Namespaces
+description: Identify registry sources independently of item categories and installed paths
+---
+
+Configure registry source aliases such as `@chatjs` or `@acme` in `components.json`.
+An address such as `@chatjs/word-count` identifies an item from that source.
+The item's `meta.chatjs.kind` identifies its category independently of its name.
+
+Source folders, public item names, and installed paths are separate. The built-in
+Vercel item is named `vercel-gateway`, is authored under `src/gateways/vercel/`,
+and installs into `lib/ai/gateway.ts`. Changing a registry alias does not change an
+item's explicit file targets.
+
+For example, configure an external source alongside the built-in registry:
+
+```json
+{
+  "registries": {
+    "@chatjs": "https://unpkg.com/@chat-js/registry@1/dist/r/{name}.json",
+    "@acme": "https://example.com/r/{name}.json"
+  }
+}
+```
+
+Install an external tool with `npx @chat-js/cli@latest add @acme/my-tool`.
+Replace the example registry address with your publisher's endpoint.
+
+A third-party gateway still belongs to the gateway category. Its namespace
+identifies who distributes it, while its metadata identifies its ChatJS contract.
+Review explicit file targets when composing items from different registries.
+A namespace does not automatically isolate installed files or registration keys.
+
+See [Tools Overview](../tools/overview) for direct shadcn installation and sync.

--- a/apps/docs/registry/testing.mdx
+++ b/apps/docs/registry/testing.mdx
@@ -1,0 +1,41 @@
+---
+title: Building and Testing
+description: Verify source behavior and the generated registry installation contract
+---
+
+Run these checks from the repository root with dependencies installed:
+
+```bash
+bun run --cwd packages/registry test:types
+bun run --cwd packages/registry test:unit
+bun run --cwd packages/registry build
+```
+
+## Check the distributed item
+
+Source tests verify implementation behavior. Install the generated JSON into an
+independent ChatJS app to also check file targets, dependencies, and registration.
+For a tool published at a test endpoint:
+
+```bash
+npx @chat-js/cli@latest add https://example.com/r/word-count.json
+```
+
+Replace the example URL with the built item's endpoint. Run the receiving app's
+type checks and environment validation, then exercise the installed item.
+For gateways, create an app with the selected gateway and send a real message.
+
+## What each check proves
+
+| Check | Detects |
+| --- | --- |
+| Source type checks and unit tests | Invalid contracts and incorrect implementation behavior |
+| Registry build | Invalid registry definitions and missing source files |
+| Installation into an independent app | Missing dependencies, incorrect targets, and registration problems |
+| Receiving app type checks | Incompatible imports and types in the actual composition |
+| Runtime request | Credential, provider, and runtime integration failures |
+
+Type checks cannot verify remote credentials or guarantee every combination of
+third-party source works. Test the composition you distribute and exercise its
+external integrations. See [Authoring and Publishing](./authoring) for the build's
+source ownership boundaries.

--- a/apps/docs/tools/authoring.mdx
+++ b/apps/docs/tools/authoring.mdx
@@ -1,10 +1,10 @@
 ---
-title: Tools
+title: Authoring Tools
 description: Author tested source files and publish them as shadcn registry items
 ---
 
 Author tools as real TypeScript files that you can import, type-check, and test.
-In this repository, canonical implementations live in `packages/registry/src`.
+In this repository, canonical implementations live in `packages/registry/src/tools/<id>/`.
 The app consumes installed copies through normal local imports.
 
 ## Server and renderer
@@ -89,6 +89,6 @@ app's TypeScript checks validate composition against its actual local contracts.
 
 ## Related
 
-- [Tool Registry](../core/tool-registry) for ownership and namespaces
-- [Adding Tools](./add-tools) for installation and sync
-- [Tool Part](./tool-part) for rendering tool results
+- [Tool Registry](./overview) for ownership and namespaces
+- [Adding Tools](./install) for installation and sync
+- [Tool Part](../cookbook/tool-part) for rendering tool results

--- a/apps/docs/tools/get-weather.mdx
+++ b/apps/docs/tools/get-weather.mdx
@@ -1,0 +1,36 @@
+---
+title: Get Weather
+description: Fetch current temperature and forecast data for coordinates
+---
+
+## Installation
+
+Start in a ChatJS app with `chat.config.ts` and `components.json`.
+No API key is configured by this item. It calls the Open-Meteo forecast endpoint.
+
+```bash
+npx @chat-js/cli@latest add get-weather
+```
+
+The command installs the server tool, renderer, and registration descriptor under
+`tools/chatjs/get-weather/`, along with required dependencies and shared renderer
+helpers. It then regenerates the app's tool registrations.
+
+## Usage
+
+Ask your chat model: “Get the weather at latitude 51.5074, longitude -0.1278.” Use a model that supports tool calling.
+
+The tool accepts numeric `latitude` and `longitude` values. It requests current
+temperature, hourly temperatures, and daily sunrise and sunset times, with
+the timezone determined by the provider.
+
+## Behavior and limitations
+
+This item does not geocode place names. Supply coordinates when verifying it.
+The implementation forwards provider JSON without runtime response validation.
+
+## Customize
+
+Edit the installed `tool.ts` and `renderer.tsx` to change behavior or presentation.
+See [Installation](./install) for updates and sync, and
+[Authoring Tools](./authoring) to publish your own item.

--- a/apps/docs/tools/install.mdx
+++ b/apps/docs/tools/install.mdx
@@ -46,6 +46,6 @@ an error.
 
 ## Related
 
-- [Tool Registry](../core/tool-registry) for ownership and migration
-- [Tools](./tools) for building a registry item
+- [Tool Registry](./overview) for ownership and migration
+- [Tools](./authoring) for building a registry item
 - [CLI add](../cli/add) for command options

--- a/apps/docs/tools/overview.mdx
+++ b/apps/docs/tools/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Tool Registry
+title: Tools Overview
 description: Install and distribute typed ChatJS tools with shadcn registries
 ---
 
@@ -74,6 +74,8 @@ metadata. `check-env` reads those descriptors without importing server tools.
 
 ## Related
 
+- [Registry Overview](../core/registry) for categories, source ownership, and distribution
+
 - [CLI add](../cli/add) for command options
-- [Adding Tools](../cookbook/add-tools) for the installation steps
-- [Tools](../cookbook/tools) for source authoring
+- [Adding Tools](./install) for the installation steps
+- [Tools](./authoring) for source authoring

--- a/apps/docs/tools/overview.mdx
+++ b/apps/docs/tools/overview.mdx
@@ -15,6 +15,14 @@ shadcn resolves the item and its dependencies, installs packages, and writes the
 source files. ChatJS then regenerates separate server and client registrations.
 Existing source follows shadcn's overwrite prompts. Pass `--overwrite` to replace it.
 
+## Available tools
+
+| Tool | Purpose | Credentials |
+| --- | --- | --- |
+| [Word Count](./word-count) | Count words, characters, and sentences | None |
+| [Get Weather](./get-weather) | Fetch weather for coordinates | None |
+| [Retrieve URL](./retrieve-url) | Extract a page through Firecrawl | `FIRECRAWL_API_KEY` |
+
 ## Installed files
 
 | File | Ownership |
@@ -74,7 +82,7 @@ metadata. `check-env` reads those descriptors without importing server tools.
 
 ## Related
 
-- [Registry Overview](../core/registry) for categories, source ownership, and distribution
+- [Registry Overview](../registry) for categories, source ownership, and distribution
 
 - [CLI add](../cli/add) for command options
 - [Adding Tools](./install) for the installation steps

--- a/apps/docs/tools/retrieve-url.mdx
+++ b/apps/docs/tools/retrieve-url.mdx
@@ -1,0 +1,38 @@
+---
+title: Retrieve URL
+description: Extract structured content from a single web page through Firecrawl
+---
+
+## Installation
+
+Start in a ChatJS app with `chat.config.ts` and `components.json`.
+Set `FIRECRAWL_API_KEY` in your app environment before starting the server.
+The installed descriptor declares this credential requirement.
+
+```bash
+npx @chat-js/cli@latest add retrieve-url
+```
+
+The command installs the server tool, renderer, and registration descriptor under
+`tools/chatjs/retrieve-url/`, along with required dependencies and shared renderer
+helpers. It then regenerates the app's tool registrations.
+
+## Usage
+
+Ask your chat model to retrieve a specific public page and provide its complete URL. Use a model that supports tool calling.
+
+The tool accepts a `url` string using HTTP or HTTPS. It scrapes the page and
+uses extraction when title, description, or content is missing. Successful
+results include title, content, URL, description, and optional language.
+
+## Behavior and limitations
+
+This item retrieves a supplied page, rather than searching the web. Missing
+credentials, invalid URLs, and provider failures produce error results.
+Returned URLs omit query strings and fragments.
+
+## Customize
+
+Edit the installed `tool.ts` and `renderer.tsx` to change behavior or presentation.
+See [Installation](./install) for updates and sync, and
+[Authoring Tools](./authoring) to publish your own item.

--- a/apps/docs/tools/word-count.mdx
+++ b/apps/docs/tools/word-count.mdx
@@ -1,0 +1,36 @@
+---
+title: Word Count
+description: Count words, characters, and sentences in supplied text
+---
+
+## Installation
+
+Start in a ChatJS app with `chat.config.ts` and `components.json`.
+No additional credentials are required.
+
+```bash
+npx @chat-js/cli@latest add word-count
+```
+
+The command installs the server tool, renderer, and registration descriptor under
+`tools/chatjs/word-count/`, along with required dependencies and shared renderer
+helpers. It then regenerates the app's tool registrations.
+
+## Usage
+
+Ask your chat model: “Count the words and characters in: Hello world.” Use a model that supports tool calling.
+
+The tool accepts a `text` string and returns `words`, `characters`,
+`charactersNoSpaces`, and `sentences`. The example text produces two words,
+12 characters, 11 characters without whitespace, and one sentence.
+
+## Behavior and limitations
+
+Words are split on whitespace and sentences on `.`, `!`, or `?`.
+These are simple counts rather than language-aware tokenization.
+
+## Customize
+
+Edit the installed `tool.ts` and `renderer.tsx` to change behavior or presentation.
+See [Installation](./install) for updates and sync, and
+[Authoring Tools](./authoring) to publish your own item.


### PR DESCRIPTION
Make Gateways and Tools independent sidebar groups so readers can discover installable items directly. Keep shared distribution mechanics in a separate Registry group, following the category organization used by shadcn/ui.

Add individual pages for Word Count, Get Weather, and Retrieve URL with installation, configuration, usage, and limitations verified against their source. Add shared namespace, authoring/publishing, and build/testing guides. Move existing tool guides into `/tools` and the registry overview into `/registry`, preserving previous URLs with redirects.

Validation: strict docs link validation, root lint, root type checks, and 13 docs visual capture tests pass locally. Browser review confirmed the category navigation, tool page rendering, and registry overview redirect. UI Verify fleet baseline comparison remains pending.

## Summary by Sourcery

Organize registry documentation into dedicated gateway, tool, and registry sections with discoverable guides and preserved legacy links.

New Features:
- Add dedicated documentation for the Word Count, Get Weather, and Retrieve URL tools, including installation, usage, configuration, and limitations.
- Add registry documentation covering namespaces, authoring and publishing, and building and testing.

Enhancements:
- Reorganize documentation navigation into independent Gateways, Tools, and Registry groups.
- Move existing tool and registry documentation to category-based URLs while preserving previous URLs through redirects.

Documentation:
- Document registry categories, source ownership, distribution, installation, and validation workflows.
- Update cross-references and CLI documentation to use the new category-based paths.

Tests:
- Expand visual documentation coverage for registry, tool, namespace, publishing, testing, and individual tool pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Registry section with overviews, namespaces, authoring guidance, and testing instructions.
  * Added documentation for the Word Count, Get Weather, and Retrieve URL tools, including installation, usage, limitations, and customization.
  * Updated tool and registry pages with clearer titles, available-tool listings, and related links.
* **Navigation**
  * Reorganized the sidebar into Gateway, Tools, and Registry sections.
  * Added redirects from legacy tool and registry paths to the updated documentation.
* **Tests**
  * Expanded visual coverage for registry and tool documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->