### PR TITLE
Make Postgres hosting configuration portable

### DIFF
--- a/.changeset/postgres-hosting.md
+++ b/.changeset/postgres-hosting.md
@@ -1,0 +1,7 @@
+---
+"@chat-js/cli": minor
+---
+
+Make generated Postgres setup independent of the database host. Support a separate
+schema connection and runtime pooling options, run explicit migrations without
+Vercel environment flags, and expose Neon branching through opt-in commands.

--- a/.changeset/postgres-hosting.md
+++ b/.changeset/postgres-hosting.md
@@ -5,3 +5,5 @@
 Make generated Postgres setup independent of the database host. Support a separate
 schema connection and runtime pooling options, run explicit migrations without
 Vercel environment flags, and expose Neon branching through opt-in commands.
+
+Guide Postgres setup by host and add an explicit, read-only `db:connect` check.

--- a/apps/chat/.env.example
+++ b/apps/chat/.env.example
@@ -2,8 +2,15 @@
 AUTH_SECRET=
 
 
-# [required] Postgres URL — https://vercel.com/docs/storage/vercel-postgres/quickstart
+# [required] Postgres connection URL from your database host
 DATABASE_URL=
+# [optional] Direct connection for migrations and Drizzle schema operations
+# Falls back to DATABASE_URL when omitted
+DATABASE_MIGRATION_URL=
+# Disable for transaction poolers that do not support prepared statements
+DATABASE_PREPARE=true
+# [optional] Runtime connections per app process (driver default when omitted)
+DATABASE_MAX_CONNECTIONS=
 
 # --- AI Gateway (pick one based on config.gateway) ---
 # Vercel AI Gateway (default) — https://vercel.com/ai-gateway

--- a/apps/chat/.env.example
+++ b/apps/chat/.env.example
@@ -2,6 +2,8 @@
 AUTH_SECRET=
 
 
+# Postgres setup: https://www.chatjs.dev/docs/reference/database
+# Verify configured connections with: bun db:connect
 # [required] Postgres connection URL from your database host
 DATABASE_URL=
 # [optional] Direct connection for migrations and Drizzle schema operations

--- a/apps/chat/drizzle.config.ts
+++ b/apps/chat/drizzle.config.ts
@@ -1,5 +1,6 @@
 import { config } from "dotenv";
 import { defineConfig } from "drizzle-kit";
+import { databaseConnection } from "./lib/db/connection";
 
 config({
   path: ".env.local",
@@ -10,7 +11,12 @@ export default defineConfig({
   out: "./lib/db/migrations",
   dialect: "postgresql",
   dbCredentials: {
-    // biome-ignore lint: Forbidden non-null assertion.
-    url: process.env.DATABASE_URL!,
+    url: databaseConnection(
+      {
+        DATABASE_URL: process.env.DATABASE_URL,
+        DATABASE_MIGRATION_URL: process.env.DATABASE_MIGRATION_URL,
+      },
+      "migration"
+    ).url,
   },
 });

--- a/apps/chat/lib/db/client.ts
+++ b/apps/chat/lib/db/client.ts
@@ -1,9 +1,11 @@
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { env } from "@/lib/env";
+import { databaseConnection } from "./connection";
 
 // Optionally, if not using email/pass login, you can
 // use the Drizzle adapter for Auth.js / NextAuth
 // https://authjs.dev/reference/adapter/drizzle
-const client = postgres(env.DATABASE_URL);
+const connection = databaseConnection(env);
+const client = postgres(connection.url, connection.options);
 export const db = drizzle(client);

--- a/apps/chat/lib/db/connection.test.ts
+++ b/apps/chat/lib/db/connection.test.ts
@@ -38,6 +38,7 @@ describe("Postgres connection selection", () => {
       })
     ).toEqual({ DATABASE_PREPARE: false, DATABASE_MAX_CONNECTIONS: 2 });
     const blank = databaseOptionsSchema.parse({
+      DATABASE_PREPARE: "",
       DATABASE_MIGRATION_URL: "",
       DATABASE_MAX_CONNECTIONS: "",
     });

--- a/apps/chat/lib/db/connection.test.ts
+++ b/apps/chat/lib/db/connection.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { databaseConnection, databaseEnvOptions } from "./connection";
+
+const databaseOptionsSchema = z.object(databaseEnvOptions);
+
+describe("Postgres connection selection", () => {
+  it("keeps runtime and migration destinations separate", () => {
+    const environment = {
+      DATABASE_URL: "postgres://runtime.invalid/app",
+      DATABASE_MIGRATION_URL: "postgres://direct.invalid/app",
+      DATABASE_PREPARE: false,
+      DATABASE_MAX_CONNECTIONS: 3,
+    };
+    expect(databaseConnection(environment)).toEqual({
+      url: environment.DATABASE_URL,
+      options: { prepare: false, max: 3 },
+    });
+    expect(databaseConnection(environment, "migration")).toEqual({
+      url: environment.DATABASE_MIGRATION_URL,
+      options: { prepare: false, max: 1 },
+    });
+  });
+  it("falls back to the application URL for schema operations", () => {
+    expect(
+      databaseConnection(
+        { DATABASE_URL: "postgres://localhost/app" },
+        "migration"
+      ).url
+    ).toBe("postgres://localhost/app");
+    expect(() => databaseConnection({})).toThrow("DATABASE_URL");
+  });
+  it("parses explicit pool settings and treats blank optional variables as absent", () => {
+    expect(
+      databaseOptionsSchema.parse({
+        DATABASE_PREPARE: "false",
+        DATABASE_MAX_CONNECTIONS: "2",
+      })
+    ).toEqual({ DATABASE_PREPARE: false, DATABASE_MAX_CONNECTIONS: 2 });
+    const blank = databaseOptionsSchema.parse({
+      DATABASE_MIGRATION_URL: "",
+      DATABASE_MAX_CONNECTIONS: "",
+    });
+    expect(blank.DATABASE_PREPARE).toBe(true);
+    expect(blank.DATABASE_MIGRATION_URL).toBeUndefined();
+    expect(blank.DATABASE_MAX_CONNECTIONS).toBeUndefined();
+    expect(() =>
+      databaseOptionsSchema.parse({ DATABASE_MAX_CONNECTIONS: "0" })
+    ).toThrow();
+    expect(() =>
+      databaseOptionsSchema.parse({ DATABASE_PREPARE: "maybe" })
+    ).toThrow();
+  });
+});

--- a/apps/chat/lib/db/connection.ts
+++ b/apps/chat/lib/db/connection.ts
@@ -8,8 +8,10 @@ export const databaseEnvOptions = {
     )
     .describe("Optional direct Postgres connection for schema operations"),
   DATABASE_PREPARE: z
-    .enum(["true", "false"])
-    .default("true")
+    .preprocess(
+      (value) => (value === "" ? undefined : value),
+      z.enum(["true", "false"]).default("true")
+    )
     .transform((value) => value === "true")
     .describe("Enable prepared statements for runtime queries"),
   DATABASE_MAX_CONNECTIONS: z

--- a/apps/chat/lib/db/connection.ts
+++ b/apps/chat/lib/db/connection.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+export const databaseEnvOptions = {
+  DATABASE_MIGRATION_URL: z
+    .preprocess(
+      (value) => (value === "" ? undefined : value),
+      z.string().min(1).optional()
+    )
+    .describe("Optional direct Postgres connection for schema operations"),
+  DATABASE_PREPARE: z
+    .enum(["true", "false"])
+    .default("true")
+    .transform((value) => value === "true")
+    .describe("Enable prepared statements for runtime queries"),
+  DATABASE_MAX_CONNECTIONS: z
+    .preprocess(
+      (value) => (value === "" ? undefined : value),
+      z.coerce.number().int().positive().optional()
+    )
+    .describe("Maximum runtime connections per app process"),
+};
+
+export function databaseConnection(
+  environment: {
+    DATABASE_URL?: string;
+    DATABASE_MIGRATION_URL?: string;
+    DATABASE_PREPARE?: boolean;
+    DATABASE_MAX_CONNECTIONS?: number;
+  },
+  purpose: "runtime" | "migration" = "runtime"
+) {
+  const url =
+    purpose === "migration"
+      ? environment.DATABASE_MIGRATION_URL || environment.DATABASE_URL
+      : environment.DATABASE_URL;
+  if (!url) {
+    throw new Error(
+      "DATABASE_URL is required (or DATABASE_MIGRATION_URL for schema operations)"
+    );
+  }
+  const max =
+    purpose === "migration" ? 1 : environment.DATABASE_MAX_CONNECTIONS;
+  return {
+    url,
+    options: {
+      prepare:
+        purpose === "migration"
+          ? false
+          : (environment.DATABASE_PREPARE ?? true),
+      ...(max === undefined ? {} : { max }),
+    },
+  };
+}

--- a/apps/chat/lib/db/migrate.ts
+++ b/apps/chat/lib/db/migrate.ts
@@ -2,40 +2,50 @@ import { config } from "dotenv";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 import postgres from "postgres";
+import { databaseConnection } from "./connection";
 
 config({
   path: ".env.local",
 });
 
 const runMigrate = async () => {
-  // Only run migrations on production deployments
-  // Skip for preview deployments and local development
-  if (process.env.VERCEL_ENV !== "production") {
+  // Deployment builds preserve the Vercel preview safeguard. Explicit db:migrate
+  // runs on every host and never relies on a deployment vendor's environment.
+  if (
+    process.argv.includes("--deployment") &&
+    process.env.VERCEL_ENV !== "production"
+  ) {
     console.log(
-      `⏭️  Skipping migrations (VERCEL_ENV=${process.env.VERCEL_ENV ?? "undefined"})`
+      "Skipping automatic migrations outside a production Vercel deployment"
     );
-    process.exit(0);
+    return;
   }
 
-  if (!process.env.DATABASE_URL) {
-    throw new Error("DATABASE_URL is not defined");
-  }
-
-  const connection = postgres(process.env.DATABASE_URL, { max: 1 });
+  const settings = databaseConnection(
+    {
+      DATABASE_URL: process.env.DATABASE_URL,
+      DATABASE_MIGRATION_URL: process.env.DATABASE_MIGRATION_URL,
+    },
+    "migration"
+  );
+  const connection = postgres(settings.url, settings.options);
   const db = drizzle(connection);
 
   console.log("⏳ Running migrations...");
 
   const start = Date.now();
-  await migrate(db, { migrationsFolder: "./lib/db/migrations" });
+  try {
+    await migrate(db, { migrationsFolder: "./lib/db/migrations" });
+  } finally {
+    await connection.end();
+  }
   const end = Date.now();
 
   console.log("✅ Migrations completed in", end - start, "ms");
-  process.exit(0);
 };
 
 runMigrate().catch((err) => {
   console.error("❌ Migration failed");
   console.error(err);
-  process.exit(1);
+  process.exitCode = 1;
 });

--- a/apps/chat/lib/env-schema.ts
+++ b/apps/chat/lib/env-schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { isPlaywrightTestEnvironment } from "@/lib/playwright-test-environment";
+import { databaseEnvOptions } from "./db/connection";
 
 const isPlaywrightTestEnvironmentEnabled = isPlaywrightTestEnvironment(
   process.env
@@ -16,6 +17,7 @@ const isPlaywrightTestEnvironmentEnabled = isPlaywrightTestEnvironment(
  * without triggering `createEnv` runtime validation.
  */
 export const serverEnvSchema = {
+  ...databaseEnvOptions,
   // Required core
   DATABASE_URL: z
     .preprocess(

--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -37,7 +37,8 @@
     "ai:devtools": "bunx @ai-sdk/devtools",
     "fetch:models": "bun scripts/fetch-models.ts && bun format",
     "dev:neon": "bash scripts/with-db.sh bun dev",
-    "db:migrate:neon": "bash scripts/with-db.sh bun db:migrate"
+    "db:migrate:neon": "bash scripts/with-db.sh bun db:migrate",
+    "db:connect": "tsx scripts/check-db.ts"
   },
   "dependencies": {
     "@ai-sdk/devtools": "1.0.15",

--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -5,9 +5,9 @@
   "license": "Apache-2.0",
   "scripts": {
     "prebuild": "bun --filter @chat-js/thread build && bun --filter @chat-js/gateways build && bun run check-env",
-    "dev": "bun run check-env && bash scripts/with-db.sh next dev",
-    "dev:inspect": "bash scripts/with-db.sh next dev --inspect",
-    "build": "tsx lib/db/migrate && next build",
+    "dev": "bun run check-env && next dev",
+    "dev:inspect": "bun run check-env && next dev --inspect",
+    "build": "tsx lib/db/migrate.ts --deployment && next build",
     "analyze": "next experimental-analyze",
     "start": "next start",
     "prod": "bun run build && bun run start",
@@ -15,7 +15,7 @@
     "format": "ultracite fix",
     "check-env": "bun scripts/check-env.ts",
     "db:generate": "drizzle-kit generate",
-    "db:migrate": "export VERCEL_ENV=production && bash scripts/with-db.sh bunx tsx lib/db/migrate.ts",
+    "db:migrate": "bunx tsx lib/db/migrate.ts",
     "db:backfill-parts": "npx tsx lib/db/backfill-parts.ts",
     "db:studio": "drizzle-kit studio",
     "db:push": "drizzle-kit push",
@@ -35,7 +35,9 @@
     "test:unit": "vitest run",
     "test:types": "rm -rf .next/dev/types && next typegen . && tsc --noEmit",
     "ai:devtools": "bunx @ai-sdk/devtools",
-    "fetch:models": "bun scripts/fetch-models.ts && bun format"
+    "fetch:models": "bun scripts/fetch-models.ts && bun format",
+    "dev:neon": "bash scripts/with-db.sh bun dev",
+    "db:migrate:neon": "bash scripts/with-db.sh bun db:migrate"
   },
   "dependencies": {
     "@ai-sdk/devtools": "1.0.15",

--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -38,7 +38,7 @@
     "fetch:models": "bun scripts/fetch-models.ts && bun format",
     "dev:neon": "bash scripts/with-db.sh bun dev",
     "db:migrate:neon": "bash scripts/with-db.sh bun db:migrate",
-    "db:connect": "tsx scripts/check-db.ts"
+    "db:connect": "bun scripts/check-db.ts"
   },
   "dependencies": {
     "@ai-sdk/devtools": "1.0.15",

--- a/apps/chat/scripts/check-db.test.ts
+++ b/apps/chat/scripts/check-db.test.ts
@@ -1,0 +1,47 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, it } from "vitest";
+
+it("reports failed endpoint names without exposing connection credentials", () => {
+  const cwd = mkdtempSync(join(tmpdir(), "chatjs-check-db-"));
+  try {
+    let failed = false;
+    try {
+      execFileSync(
+        process.execPath,
+        [
+          fileURLToPath(import.meta.resolve("tsx/cli")),
+          fileURLToPath(new URL("./check-db.ts", import.meta.url)),
+        ],
+        {
+          cwd,
+          env: {
+            NODE_ENV: "test",
+            DATABASE_URL: "postgres://user:secret-runtime@127.0.0.1:1/app",
+            DATABASE_MIGRATION_URL:
+              "postgres://user:secret-migration@127.0.0.1:1/app",
+          },
+          stdio: "pipe",
+          timeout: 10_000,
+        }
+      );
+    } catch (error) {
+      failed = true;
+      if (!(error instanceof Error && "stderr" in error && "status" in error)) {
+        throw error;
+      }
+      expect(error.status).toBe(1);
+      const output = String(error.stderr);
+      expect(output).toContain("runtime: connection failed");
+      expect(output).toContain("DATABASE_MIGRATION_URL");
+      expect(output).not.toContain("secret-");
+      expect(output).not.toContain("postgres://");
+    }
+    expect(failed).toBe(true);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});

--- a/apps/chat/scripts/check-db.ts
+++ b/apps/chat/scripts/check-db.ts
@@ -6,6 +6,10 @@ import { databaseConnection, databaseEnvOptions } from "../lib/db/connection";
 config({ path: ".env.local", quiet: true });
 config({ quiet: true });
 
+const CONNECT_TIMEOUT_SECONDS = 10;
+const CHECK_DEADLINE_MS = 15_000;
+const CLOSE_TIMEOUT_SECONDS = 1;
+
 async function checkDatabase() {
   const parsed = z
     .object({
@@ -26,14 +30,14 @@ async function checkDatabase() {
     const sql = postgres(settings.url, {
       ...settings.options,
       max: 1,
-      connect_timeout: 10,
+      connect_timeout: CONNECT_TIMEOUT_SECONDS,
     });
     const deadline = setTimeout(() => {
       sql.end({ timeout: 0 }).catch(() => undefined);
-    }, 15_000);
+    }, CHECK_DEADLINE_MS);
     try {
       await sql`select 1`;
-      console.log(`${purpose}: connection OK`);
+      process.stdout.write(`${purpose}: connection OK\n`);
     } catch {
       const variable =
         purpose === "migration" && parsed.data.DATABASE_MIGRATION_URL
@@ -45,7 +49,7 @@ async function checkDatabase() {
       process.exitCode = 1;
     } finally {
       clearTimeout(deadline);
-      await sql.end({ timeout: 1 });
+      await sql.end({ timeout: CLOSE_TIMEOUT_SECONDS });
     }
   }
 }

--- a/apps/chat/scripts/check-db.ts
+++ b/apps/chat/scripts/check-db.ts
@@ -1,0 +1,58 @@
+import { config } from "dotenv";
+import postgres from "postgres";
+import { z } from "zod";
+import { databaseConnection, databaseEnvOptions } from "../lib/db/connection";
+
+config({ path: ".env.local", quiet: true });
+config({ quiet: true });
+
+async function checkDatabase() {
+  const parsed = z
+    .object({
+      ...databaseEnvOptions,
+      DATABASE_URL: z.string().min(1),
+    })
+    .safeParse(process.env);
+  if (!parsed.success) {
+    console.error(
+      `Invalid database configuration: ${parsed.error.issues.map((issue) => issue.path.join(".")).join(", ")}. Check .env.local.`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  for (const purpose of ["runtime", "migration"] as const) {
+    const settings = databaseConnection(parsed.data, purpose);
+    const sql = postgres(settings.url, {
+      ...settings.options,
+      max: 1,
+      connect_timeout: 10,
+    });
+    const deadline = setTimeout(() => {
+      sql.end({ timeout: 0 }).catch(() => undefined);
+    }, 15_000);
+    try {
+      await sql`select 1`;
+      console.log(`${purpose}: connection OK`);
+    } catch {
+      const variable =
+        purpose === "migration" && parsed.data.DATABASE_MIGRATION_URL
+          ? "DATABASE_MIGRATION_URL"
+          : "DATABASE_URL";
+      console.error(
+        `${purpose}: connection failed. Check ${variable}, credentials, TLS settings, and network access. See https://www.chatjs.dev/docs/reference/database`
+      );
+      process.exitCode = 1;
+    } finally {
+      clearTimeout(deadline);
+      await sql.end({ timeout: 1 });
+    }
+  }
+}
+
+checkDatabase().catch(() => {
+  console.error(
+    "Database check failed. Check your connection settings in .env.local."
+  );
+  process.exitCode = 1;
+});

--- a/apps/chat/scripts/check-env.ts
+++ b/apps/chat/scripts/check-env.ts
@@ -18,6 +18,7 @@ import {
   getMissingRequirement,
   isRequirementSatisfied,
 } from "../lib/config-requirements";
+import { databaseEnvOptions } from "../lib/db/connection";
 import { isPlaywrightTestEnvironment } from "../lib/playwright-test-environment";
 import { storageEnvRequirements, storageId } from "../lib/storage-options";
 
@@ -223,11 +224,24 @@ async function checkEnv(): Promise<void> {
     return;
   }
 
+  const databaseOptions = z.object(databaseEnvOptions).safeParse(env);
+  const databaseErrors = databaseOptions.success
+    ? []
+    : [
+        {
+          feature: "database",
+          missing: databaseOptions.error.issues.map(
+            (issue) => `${issue.path.join(".")}: ${issue.message}`
+          ),
+        },
+      ];
+
   const baseUrlError = validateBaseUrl(env);
   const gatewayError = validateGatewayKey(env);
   const storageError = validateStorage(env);
   const installedToolErrors = await validateInstalledTools(env);
   const errors = [
+    ...databaseErrors,
     ...(baseUrlError ? [baseUrlError] : []),
     ...(gatewayError ? [gatewayError] : []),
     ...(storageError ? [storageError] : []),

--- a/apps/chat/scripts/with-db.sh
+++ b/apps/chat/scripts/with-db.sh
@@ -25,7 +25,7 @@ if [ -f "$BRANCH_FILE" ]; then
   MASKED_URL=$(echo "$BRANCH_URL" | sed 's/:[^:@]*@/:****@/')
   echo "🔀 Using branch '$BRANCH_NAME': $MASKED_URL"
   
-  DATABASE_URL="$BRANCH_URL" exec "$@"
+  DATABASE_URL="$BRANCH_URL" DATABASE_MIGRATION_URL="$BRANCH_URL" exec "$@"
 else
   exec "$@"
 fi

--- a/apps/docs/cookbook/neon-branching.mdx
+++ b/apps/docs/cookbook/neon-branching.mdx
@@ -35,7 +35,7 @@ This creates a `.neon` file in the current directory (gitignored).
 
 ### How It Works
 
-Instead of updating `.env.local`, the branch name is stored in a `.neon-branch` file (gitignored). The `scripts/with-db.sh` wrapper reads this file at runtime and injects the correct `DATABASE_URL` when running database commands.
+Instead of updating `.env.local`, the branch name is stored in a `.neon-branch` file (gitignored). The `scripts/with-db.sh` wrapper reads this file at runtime and injects both `DATABASE_URL` and `DATABASE_MIGRATION_URL` for explicitly wrapped commands.
 
 This means your `.env.local` stays pointing to main, and branch switching is instant.
 
@@ -65,11 +65,11 @@ The `package.json` scripts use three bash scripts under `scripts/`:
 bun db:branch:start
 
 # Your app now uses the dev branch (DATABASE_URL injected via with-db.sh)
-bun dev
+bun dev:neon
 
 # Make schema changes
 bun db:generate   # Generate migration
-bun db:migrate    # Apply migration
+bun db:migrate:neon # Apply migration to the selected branch
 
 # When done, clean up and switch back to main
 bun db:branch:stop
@@ -87,7 +87,8 @@ bun db:branch:stop
 | `bun db:branch:delete [name]`    | Delete branch only                                 |
 | `bun db:branch:list`             | List all branches                                  |
 
-Default branch name is `dev-local` if not specified.
+Default branch name is `dev-local` if not specified. Normal `bun dev` and
+`bun db:migrate` use the configured URLs, without reading `.neon-branch`.
 
 ## Considerations
 

--- a/apps/docs/e2e/docs-visual.browser.test.ts
+++ b/apps/docs/e2e/docs-visual.browser.test.ts
@@ -2,6 +2,7 @@ import { takeSnapshot } from "@uiverify/vitest";
 import { expect, test } from "vitest";
 
 const pages = [
+  { name: "database", path: "/docs/reference/database" },
   { name: "storage", path: "/docs/storage" },
   { name: "custom-storage", path: "/docs/storage/custom" },
 	{ name: "home", path: "/docs" },

--- a/apps/docs/reference/database.mdx
+++ b/apps/docs/reference/database.mdx
@@ -9,6 +9,37 @@ ChatJS uses **PostgreSQL** with **Drizzle ORM** for type-safe, schema-first data
 
 ---
 
+## Set up your database
+
+The CLI installs the same Drizzle and Postgres.js code for every Postgres host.
+You do not select a database host during installation. Create your database with
+your host, then put its connection strings in `.env.local` at your generated app's
+root (or `apps/chat` when working in this repository).
+
+| Host | Where to get the connection | Settings |
+| --- | --- | --- |
+| Neon | Project dashboard → **Connect**, then select your branch, role, and database | Use the pooled URL for runtime if needed and the direct URL for migrations |
+| Supabase | Project **Connect** panel | Use the connection mode appropriate to your deployment. Transaction pooling requires `DATABASE_PREPARE=false`. Use a direct or suitable session connection for migrations |
+| Local or another Postgres host | Your database administrator or host's Postgres connection details | Set `DATABASE_URL`. Leave the migration URL and pooling overrides unset unless needed |
+
+Use Postgres credentials, not a host's HTTP API URL or API key. Both connection
+URLs must target the same database and branch. The URLs can use different
+endpoints and roles, such as a limited runtime role and a migration role.
+
+After filling in `.env.local`, run:
+
+```bash
+bun db:connect
+```
+
+This checks both configured connections with `SELECT 1`, using the runtime
+prepared-statement setting for the runtime check. Each endpoint has a 15-second
+deadline. The command closes connections, reports the failing configuration name
+without printing credentials, and exits unsuccessfully if either check fails.
+It does not apply migrations or change your schema. A successful check confirms
+connectivity, not migration permissions, schema readiness, or that both URLs
+point to the same database. Verify those details before applying migrations.
+
 ## Connection settings
 
 Set `DATABASE_URL` to the Postgres connection string from your host. The same

--- a/apps/docs/reference/database.mdx
+++ b/apps/docs/reference/database.mdx
@@ -54,14 +54,19 @@ Neon-specific driver is required.
 | `DATABASE_MAX_CONNECTIONS` | Optional positive integer limiting runtime connections per process |
 
 ```bash
-DATABASE_URL=postgres://user:password@runtime-host/app
-DATABASE_MIGRATION_URL=postgres://user:password@direct-host/app
+DATABASE_URL=postgres://user:password@runtime-host/app?sslmode=verify-full
+DATABASE_MIGRATION_URL=postgres://user:password@direct-host/app?sslmode=verify-full
 DATABASE_PREPARE=false
 DATABASE_MAX_CONNECTIONS=5
 ```
 
 Use your host's connection strings and TLS settings. Do not disable certificate
-verification to make a connection succeed. Keep passwords in your environment.
+verification to make a connection succeed. For remote connections, require verified
+TLS (for example, `sslmode=verify-full`) and configure your host's CA trust when
+needed. Postgres.js does not enable TLS for a URL without TLS settings.
+`db:connect` uses those same settings and does not enforce a separate TLS policy.
+Local or private-network connections retain the settings you explicitly supply.
+Keep passwords in your environment.
 
 For [Supabase transaction pooling](https://supabase.com/docs/guides/database/postgres-js),
 disable prepared statements. Use a direct or suitable session connection for

--- a/apps/docs/reference/database.mdx
+++ b/apps/docs/reference/database.mdx
@@ -5,16 +5,45 @@ description: PostgreSQL database management commands and schema workflow
 
 ## Overview
 
-ChatJS uses **PostgreSQL** with **Drizzle ORM** for type-safe, schema-first database access. The schema is defined in `apps/chat/lib/db/schema.ts` — edit it to change the database structure.
+ChatJS uses **PostgreSQL** with **Drizzle ORM** for type-safe, schema-first database access. The schema is defined in `apps/chat/lib/db/schema.ts`. Edit it to change the database structure.
 
 ---
+
+## Connection settings
+
+Set `DATABASE_URL` to the Postgres connection string from your host. The same
+schema and query implementation works with standard Postgres connections. No
+Neon-specific driver is required.
+
+| Variable | Purpose |
+| --- | --- |
+| `DATABASE_URL` | Runtime queries |
+| `DATABASE_MIGRATION_URL` | Optional direct connection for migrations and Drizzle schema operations, falling back to `DATABASE_URL` |
+| `DATABASE_PREPARE` | `true` by default. Set `false` for transaction poolers that do not support prepared statements |
+| `DATABASE_MAX_CONNECTIONS` | Optional positive integer limiting runtime connections per process |
+
+```bash
+DATABASE_URL=postgres://user:password@runtime-host/app
+DATABASE_MIGRATION_URL=postgres://user:password@direct-host/app
+DATABASE_PREPARE=false
+DATABASE_MAX_CONNECTIONS=5
+```
+
+Use your host's connection strings and TLS settings. Do not disable certificate
+verification to make a connection succeed. Keep passwords in your environment.
+
+For [Supabase transaction pooling](https://supabase.com/docs/guides/database/postgres-js),
+disable prepared statements. Use a direct or suitable session connection for
+schema operations. [Neon](https://neon.com/docs/connect/connection-pooling)
+also recommends a direct connection for migration tools. A local Postgres instance
+or another host can use one URL for both purposes.
 
 ## Database Management
 
 Run these commands from the `apps/chat` directory:
 
 ```bash
-# Push schema changes directly to the database (dev only — no migration file)
+# Push schema changes directly to the database (dev only, no migration file)
 bun db:push
 
 # Open Drizzle Studio at https://local.drizzle.studio
@@ -27,9 +56,9 @@ bun db:generate
 bun db:migrate
 ```
 
-- **`db:push`** — fastest for local iteration; skips migration files. Not safe for production.
-- **`db:generate` + `db:migrate`** — the production workflow; creates a versioned SQL file and applies it.
-- **`db:studio`** — inspect, query, and edit data via a browser UI.
+- **`db:push`**: fastest for local iteration, skips migration files. Not safe for production.
+- **`db:generate` + `db:migrate`**: the production workflow, creates a versioned SQL file and applies it.
+- **`db:studio`**: inspect, query, and edit data via a browser UI.
 
 ---
 
@@ -37,8 +66,27 @@ bun db:migrate
 
 All schema changes start in `apps/chat/lib/db/schema.ts`. After editing:
 
-1. Run `bun db:generate` to produce a migration file in `drizzle/`.
+1. Run `bun db:generate` to produce a migration file in `lib/db/migrations/`.
 2. Review the generated SQL to confirm the diff is correct.
 3. Run `bun db:migrate` to apply it.
 
-For production schema changes, use Neon branching to isolate the change first. See [Neon Branching](/cookbook/neon-branching).
+Test schema changes against an isolated database before applying them to production.
+If you use Neon, [Neon Branching](../cookbook/neon-branching) is an optional workflow.
+
+## Deployment and migrations
+
+`bun db:migrate` explicitly applies pending migrations on any host. It does not
+require `VERCEL_ENV`. The migration connection uses one connection and closes it
+on success or failure.
+
+The app build runs migrations with `--deployment`, preserving the existing
+production-only Vercel behavior. Preview and local builds skip automatic
+migrations. On other hosts, run `bun db:migrate` as an explicit deployment step
+before starting the updated app.
+
+## Optional Neon development
+
+Normal `bun dev` and `bun db:migrate` use your configured URLs. They do not read
+`.neon-branch`. To use the branch selected by the Neon helper scripts, run
+`bun dev:neon` or `bun db:migrate:neon`. The wrapper overrides both runtime and
+migration URLs so a main-database migration URL cannot leak into a branch session.

--- a/apps/docs/reference/env-vars.mdx
+++ b/apps/docs/reference/env-vars.mdx
@@ -187,6 +187,14 @@ openssl rand -base64 32
   The key must be exactly 44 characters (32 bytes encoded as base64). Changing this key after deployment will invalidate all stored MCP connector credentials.
 </Callout>
 
+### Postgres Hosting
+
+`DATABASE_URL` is the runtime connection. Set `DATABASE_MIGRATION_URL` when your
+host provides a separate direct endpoint for schema operations. It falls back to
+`DATABASE_URL` when omitted. Set `DATABASE_PREPARE=false` for a transaction pooler
+without prepared-statement support, and optionally set `DATABASE_MAX_CONNECTIONS`
+to a positive per-process limit. See [Database](./database) for deployment behavior.
+
 ### File Storage
 
 Attachments, image generation, and video generation require a durable storage

--- a/apps/docs/reference/env-vars.mdx
+++ b/apps/docs/reference/env-vars.mdx
@@ -266,7 +266,7 @@ Allows users to reconnect to an ongoing AI generation after a page refresh or ne
 |----------|-------------|--------|
 | `REDIS_URL` | Redis TCP/TLS URL for stream coordination and anonymous rate limits | [Redis setup](./redis) |
 
-Without `REDIS_URL`, streams work normally but cannot be resumed after disconnection. Redis-backed anonymous rate-limit counters are also disabled. Run `bun redis:connect` to check a configured provider.
+Without `REDIS_URL`, streams work normally but cannot be resumed after disconnection. Redis-backed anonymous rate-limit counters are also disabled. To check a configured provider, use your package manager: `npm run redis:connect`, `pnpm redis:connect`, `yarn redis:connect`, or `bun redis:connect`.
 
 ### Cron Job Secret
 

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -373,7 +373,7 @@ export const create = new Command()
 				`  ${highlighter.dim("2.")} Copy ${highlighter.info(".env.example")} to ${highlighter.info(".env.local")} and fill in the values below`,
 			);
 			logger.log(
-				`  ${highlighter.dim("3.")} ${highlighter.info(`${packageManager} run db:push`)}`,
+				`  ${highlighter.dim("3.")} ${highlighter.info(`${packageManager} run db:connect`)} then ${highlighter.info(`${packageManager} run db:push`)}`,
 			);
 			logger.log(
 				`  ${highlighter.dim("4.")} ${highlighter.info(`${packageManager} run dev`)}`,
@@ -388,6 +388,7 @@ export const create = new Command()
 			logger.break();
 
 			printEnvChecklist(envEntries);
+			logger.log("  Postgres setup (Neon, Supabase, or another host): https://www.chatjs.dev/docs/reference/database");
 
 			logger.break();
 			logger.log(

--- a/packages/cli/src/helpers/package-manifest.ts
+++ b/packages/cli/src/helpers/package-manifest.ts
@@ -64,16 +64,18 @@ function normalizeChatAppScripts(scripts: ScriptMap): void {
   const defaultBranchName = "$" + "{1:-dev-local}";
 
   scripts.prebuild = "tsx scripts/check-env.ts";
-  scripts.dev = "tsx scripts/check-env.ts && bash scripts/with-db.sh next dev";
+  scripts.dev = "tsx scripts/check-env.ts && next dev";
   scripts["dev:inspect"] =
-    "tsx scripts/check-env.ts && bash scripts/with-db.sh next dev --inspect";
+    "tsx scripts/check-env.ts && next dev --inspect";
   scripts.prod =
     "tsx scripts/check-env.ts && tsx lib/db/migrate.ts && next build && next start";
   scripts.lint = "ultracite check";
   scripts.format = "ultracite fix";
   scripts["check-env"] = "tsx scripts/check-env.ts";
   scripts["db:migrate"] =
-    "export VERCEL_ENV=production && bash scripts/with-db.sh tsx lib/db/migrate.ts";
+    "tsx lib/db/migrate.ts";
+  scripts["dev:neon"] = "bash scripts/with-db.sh tsx scripts/check-env.ts && bash scripts/with-db.sh next dev";
+  scripts["db:migrate:neon"] = "bash scripts/with-db.sh tsx lib/db/migrate.ts";
   scripts["db:backfill-parts"] = "tsx lib/db/backfill-parts.ts";
   scripts["db:branch:start"] =
     `bash -c 'N=${defaultBranchName}; bash scripts/db-branch-create.sh "$N" && bash scripts/db-branch-use.sh "$N"' --`;

--- a/packages/cli/src/helpers/package-manifest.ts
+++ b/packages/cli/src/helpers/package-manifest.ts
@@ -72,6 +72,7 @@ function normalizeChatAppScripts(scripts: ScriptMap): void {
   scripts.lint = "ultracite check";
   scripts.format = "ultracite fix";
   scripts["check-env"] = "tsx scripts/check-env.ts";
+  scripts["db:connect"] = "tsx scripts/check-db.ts";
   scripts["db:migrate"] =
     "tsx lib/db/migrate.ts";
   scripts["dev:neon"] = "bash scripts/with-db.sh tsx scripts/check-env.ts && bash scripts/with-db.sh next dev";


### PR DESCRIPTION
Postgres setup currently couples manual migrations to Vercel and normal development to the Neon branch wrapper. Apps also use the runtime URL for every schema operation, which is inconvenient when a host supplies separate pooled and direct endpoints.

Make explicit migrations work on any host, add an optional `DATABASE_MIGRATION_URL` for schema operations, and validate runtime prepared-statement and connection-limit settings. Normal development uses the configured URLs. Neon branch commands become opt-in and override both URLs for the selected branch. Automatic build migrations retain the existing production-only Vercel safeguard.

All supported Postgres hosts use the same Drizzle/Postgres.js implementation. Installation does not ask for a database host. The CLI and env template link to setup guidance for Neon, Supabase, and other Postgres hosts, and recommend `db:connect` before schema setup. This explicit check probes runtime and migration connections without changing the schema, bounds each probe, and keeps credentials out of diagnostics. It does not verify migration permissions or that the endpoints target the same database.

Validation:
- Root lint and type checks, CLI unit tests, and focused connection tests pass. A subprocess regression verifies that failed checks exit unsuccessfully and do not expose credentials.
- A packed CLI generates an independently installed Vercel-gateway app that type-checks and loads its adapter.
- The new connection check passes against disposable local Postgres. Migration verification confirms manual migrations work without `VERCEL_ENV`, target only the separate migration database, are repeatable, and skip preview builds.
- An isolated Neon wrapper check confirms both URLs select the branch.
- Docs links and all 16 browser captures pass locally. The updated database page was visually inspected.

## Summary by Sourcery

Make Postgres setup, connection validation, and migration workflows portable across hosting providers.

New Features:
- Add portable Postgres configuration with separate runtime and migration URLs, prepared-statement control, and runtime connection limits.
- Add an explicit read-only `db:connect` command that checks runtime and migration endpoints without exposing credentials.
- Make Neon branch usage opt-in while ensuring selected branches override both database URLs.

Bug Fixes:
- Allow explicit migrations to run on any host without requiring Vercel environment flags while retaining production-only safeguards for automatic build migrations.

Enhancements:
- Standardize all supported Postgres hosts on the same Drizzle/Postgres.js setup and remove host selection from installation.
- Update development and schema workflows to use configured database URLs by default.
- Improve database setup guidance for Neon, Supabase, and other Postgres providers.

Deployment:
- Preserve production-only automatic migrations for Vercel deployments and document explicit migration steps for other hosts.

Documentation:
- Expand database and environment-variable documentation with host-specific setup, connection settings, migration behavior, and optional Neon workflows.

Tests:
- Add coverage for connection selection and validation, credential-safe failed connection checks, packaged CLI app generation, migration behavior, Neon branch URL overrides, and database documentation visuals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added flexible PostgreSQL hosting with separate runtime and migration URLs.
  * Added prepared-statement controls and per-process connection limits.
  * Added `db:connect` and `redis:connect` health checks.
  * Added opt-in Neon branching commands for development and migrations.
  * Added guided database setup for PostgreSQL and optional Redis.
* **Bug Fixes**
  * Improved database and Redis configuration validation.
  * Improved migration cleanup and failure reporting.
* **Documentation**
  * Expanded PostgreSQL setup, deployment, pooling, and Neon branching guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->