### PR TITLE
Make Redis provider setup portable and verifiable

### DIFF
--- a/.changeset/redis-hosting.md
+++ b/.changeset/redis-hosting.md
@@ -1,0 +1,6 @@
+---
+"@chat-js/cli": minor
+---
+
+Validate standard Redis connection URLs, document provider setup, and add a
+redis:connect capability check for generated apps.

--- a/apps/chat/.env.example
+++ b/apps/chat/.env.example
@@ -57,7 +57,9 @@ LANGFUSE_BASE_URL=https://cloud.langfuse.com
 CRON_SECRET=
 
 # --- Features ---
-# [optional] Redis — https://vercel.com/docs/redis
+# [optional] Redis TCP/TLS URL (redis:// or rediss://), not a REST endpoint
+# Setup: https://www.chatjs.dev/docs/reference/redis
+# Verify with: bun redis:connect
 REDIS_URL=
 # [optional] OpenAI — https://platform.openai.com/api-keys
 OPENAI_API_KEY=

--- a/apps/chat/app/(chat)/api/chat/route.ts
+++ b/apps/chat/app/(chat)/api/chat/route.ts
@@ -61,6 +61,7 @@ import type { McpConnector } from "@/lib/db/schema";
 import { env } from "@/lib/env";
 import { MAX_INPUT_TOKENS } from "@/lib/limits/tokens";
 import { createModuleLogger } from "@/lib/logger";
+import { redisConnectionOptions } from "@/lib/redis/connection";
 import type { AnonymousSession } from "@/lib/types/anonymous";
 import { ANONYMOUS_LIMITS } from "@/lib/types/anonymous";
 import { generateUUID } from "@/lib/utils";
@@ -72,9 +73,17 @@ import { getThreadUpToMessageId } from "./get-thread-up-to-message-id";
 let redisPublisher: ReturnType<typeof createClient> | null = null;
 let redisSubscriber: ReturnType<typeof createClient> | null = null;
 
-if (env.REDIS_URL) {
-  redisPublisher = createClient({ url: env.REDIS_URL });
-  redisSubscriber = createClient({ url: env.REDIS_URL });
+const redisOptions = redisConnectionOptions(env);
+if (redisOptions) {
+  const redisLog = createModuleLogger("redis");
+  redisPublisher = createClient(redisOptions);
+  redisSubscriber = createClient(redisOptions);
+  redisPublisher.on("error", () =>
+    redisLog.error("Redis publisher connection error")
+  );
+  redisSubscriber.on("error", () =>
+    redisLog.error("Redis subscriber connection error")
+  );
   await Promise.all([redisPublisher.connect(), redisSubscriber.connect()]);
 }
 

--- a/apps/chat/app/(chat)/api/chat/route.ts
+++ b/apps/chat/app/(chat)/api/chat/route.ts
@@ -6,7 +6,6 @@ import {
 import { headers } from "next/headers";
 import type { NextRequest } from "next/server";
 import { after } from "next/server";
-import { createClient } from "redis";
 import {
   createResumableStreamContext,
   type ResumableStreamContext,
@@ -61,7 +60,7 @@ import type { McpConnector } from "@/lib/db/schema";
 import { env } from "@/lib/env";
 import { MAX_INPUT_TOKENS } from "@/lib/limits/tokens";
 import { createModuleLogger } from "@/lib/logger";
-import { redisConnectionOptions } from "@/lib/redis/connection";
+import { connectRedisClients } from "@/lib/redis/client";
 import type { AnonymousSession } from "@/lib/types/anonymous";
 import { ANONYMOUS_LIMITS } from "@/lib/types/anonymous";
 import { generateUUID } from "@/lib/utils";
@@ -69,23 +68,13 @@ import { checkAnonymousRateLimit, getClientIP } from "@/lib/utils/rate-limit";
 import { generateTitleFromUserMessage } from "../../actions";
 import { getThreadUpToMessageId } from "./get-thread-up-to-message-id";
 
-// Shared Redis clients for resumable stream
-let redisPublisher: ReturnType<typeof createClient> | null = null;
-let redisSubscriber: ReturnType<typeof createClient> | null = null;
-
-const redisOptions = redisConnectionOptions(env);
-if (redisOptions) {
-  const redisLog = createModuleLogger("redis");
-  redisPublisher = createClient(redisOptions);
-  redisSubscriber = createClient(redisOptions);
-  redisPublisher.on("error", () =>
-    redisLog.error("Redis publisher connection error")
-  );
-  redisSubscriber.on("error", () =>
-    redisLog.error("Redis subscriber connection error")
-  );
-  await Promise.all([redisPublisher.connect(), redisSubscriber.connect()]);
-}
+// Optional Redis must not prevent the chat route from loading.
+const redisLog = createModuleLogger("redis");
+const redisClients = await connectRedisClients(env, () =>
+  redisLog.error("Redis connection error")
+);
+const redisPublisher = redisClients?.publisher ?? null;
+const redisSubscriber = redisClients?.subscriber ?? null;
 
 let globalStreamContext: ResumableStreamContext | null = null;
 

--- a/apps/chat/lib/env-schema.ts
+++ b/apps/chat/lib/env-schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { isPlaywrightTestEnvironment } from "@/lib/playwright-test-environment";
+import { redisEnvOptions } from "./redis/connection";
 
 const isPlaywrightTestEnvironmentEnabled = isPlaywrightTestEnvironment(
   process.env
@@ -93,7 +94,7 @@ export const serverEnvSchema = {
     .describe("Secret for cleanup cron job endpoint"),
 
   // Optional features (enable in chat.config.ts)
-  REDIS_URL: z.string().optional().describe("Redis URL for resumable streams"),
+  ...redisEnvOptions,
   TAVILY_API_KEY: z
     .string()
     .optional()

--- a/apps/chat/lib/redis/client.test.ts
+++ b/apps/chat/lib/redis/client.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { connectRedisClients } from "./client";
+
+const clients = vi.hoisted(() => {
+  const subscriber = {
+    on: vi.fn(),
+    connect: vi.fn(),
+    destroy: vi.fn(),
+    isOpen: true,
+  };
+  const publisher = {
+    on: vi.fn(),
+    connect: vi.fn(),
+    destroy: vi.fn(),
+    isOpen: true,
+    duplicate: () => subscriber,
+  };
+  return { publisher, subscriber };
+});
+vi.mock("redis", () => ({ createClient: () => clients.publisher }));
+afterEach(() => {
+  vi.resetAllMocks();
+  vi.useRealTimers();
+});
+
+it("cleans up both clients when one initial connection rejects", async () => {
+  clients.publisher.connect.mockResolvedValue(undefined);
+  clients.subscriber.connect.mockRejectedValue(new Error("Unavailable"));
+  const onError = vi.fn();
+  expect(
+    await connectRedisClients({ REDIS_URL: "redis://localhost" }, onError)
+  ).toBeNull();
+  expect(clients.publisher.destroy).toHaveBeenCalledOnce();
+  expect(clients.subscriber.destroy).toHaveBeenCalledOnce();
+  expect(onError).toHaveBeenCalledOnce();
+});
+
+it("bounds initial connection retries so optional Redis cannot hang route loading", async () => {
+  vi.useFakeTimers();
+  clients.publisher.connect.mockResolvedValue(undefined);
+  clients.subscriber.connect.mockImplementation(
+    () => new Promise(() => undefined)
+  );
+  const pending = connectRedisClients(
+    { REDIS_URL: "redis://localhost" },
+    vi.fn()
+  );
+  await vi.advanceTimersByTimeAsync(10_000);
+  expect(await pending).toBeNull();
+  expect(clients.publisher.destroy).toHaveBeenCalledOnce();
+  expect(clients.subscriber.destroy).toHaveBeenCalledOnce();
+});
+
+it("returns the connected pair and leaves it open for normal reconnect behavior", async () => {
+  clients.publisher.connect.mockResolvedValue(undefined);
+  clients.subscriber.connect.mockResolvedValue(undefined);
+  expect(
+    await connectRedisClients({ REDIS_URL: "redis://localhost" }, vi.fn())
+  ).toEqual(clients);
+  expect(clients.publisher.destroy).not.toHaveBeenCalled();
+});

--- a/apps/chat/lib/redis/client.ts
+++ b/apps/chat/lib/redis/client.ts
@@ -1,0 +1,43 @@
+import { createClient } from "redis";
+import { redisConnectionOptions } from "./connection";
+
+const STARTUP_DEADLINE_MS = 10_000;
+
+export async function connectRedisClients(
+  environment: { REDIS_URL?: string },
+  onError: () => void
+) {
+  const options = redisConnectionOptions(environment);
+  if (!options) {
+    return null;
+  }
+
+  const publisher = createClient(options);
+  const subscriber = publisher.duplicate();
+  publisher.on("error", onError);
+  subscriber.on("error", onError);
+  let deadline: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      Promise.all([publisher.connect(), subscriber.connect()]),
+      new Promise<never>((_, reject) => {
+        deadline = setTimeout(
+          () => reject(new Error("Redis startup timed out")),
+          STARTUP_DEADLINE_MS
+        );
+      }),
+    ]);
+    return { publisher, subscriber };
+  } catch {
+    if (publisher.isOpen) {
+      publisher.destroy();
+    }
+    if (subscriber.isOpen) {
+      subscriber.destroy();
+    }
+    onError();
+    return null;
+  } finally {
+    clearTimeout(deadline);
+  }
+}

--- a/apps/chat/lib/redis/connection.test.ts
+++ b/apps/chat/lib/redis/connection.test.ts
@@ -1,0 +1,23 @@
+import { expect, it } from "vitest";
+import { z } from "zod";
+import { redisConnectionOptions, redisEnvOptions } from "./connection";
+
+const schema = z.object(redisEnvOptions);
+
+it("allows Redis to be omitted and preserves TCP/TLS provider URLs", () => {
+  expect(redisConnectionOptions(schema.parse({ REDIS_URL: "" }))).toBeNull();
+  for (const url of [
+    "redis://localhost:6379/0",
+    "rediss://default:password@provider.example:6380",
+  ]) {
+    expect(redisConnectionOptions(schema.parse({ REDIS_URL: url }))?.url).toBe(
+      url
+    );
+  }
+});
+
+it("rejects REST URLs and malformed Redis endpoints", () => {
+  for (const url of ["https://provider.example", "redis:///", "not-a-url"]) {
+    expect(schema.safeParse({ REDIS_URL: url }).success).toBe(false);
+  }
+});

--- a/apps/chat/lib/redis/connection.ts
+++ b/apps/chat/lib/redis/connection.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+const CONNECT_TIMEOUT_MS = 10_000;
+
+export const redisEnvOptions = {
+  REDIS_URL: z
+    .preprocess(
+      (value) => (value === "" ? undefined : value),
+      z
+        .string()
+        .refine((value) => {
+          if (!URL.canParse(value)) {
+            return false;
+          }
+          const url = new URL(value);
+          return ["redis:", "rediss:"].includes(url.protocol) && !!url.hostname;
+        }, "Use a redis:// or rediss:// connection URL, not an HTTP REST endpoint")
+        .optional()
+    )
+    .describe(
+      "Redis TCP/TLS connection URL for resumable streams and rate limits"
+    ),
+};
+
+export function redisConnectionOptions(environment: { REDIS_URL?: string }) {
+  return environment.REDIS_URL
+    ? {
+        url: environment.REDIS_URL,
+        socket: { connectTimeout: CONNECT_TIMEOUT_MS },
+      }
+    : null;
+}

--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -35,7 +35,8 @@
     "test:unit": "vitest run",
     "test:types": "rm -rf .next/dev/types && next typegen . && tsc --noEmit",
     "ai:devtools": "bunx @ai-sdk/devtools",
-    "fetch:models": "bun scripts/fetch-models.ts && bun format"
+    "fetch:models": "bun scripts/fetch-models.ts && bun format",
+    "redis:connect": "bun scripts/check-redis.ts"
   },
   "dependencies": {
     "@ai-sdk/devtools": "1.0.15",

--- a/apps/chat/scripts/check-env.ts
+++ b/apps/chat/scripts/check-env.ts
@@ -19,6 +19,7 @@ import {
   isRequirementSatisfied,
 } from "../lib/config-requirements";
 import { isPlaywrightTestEnvironment } from "../lib/playwright-test-environment";
+import { redisEnvOptions } from "../lib/redis/connection";
 import { storageEnvRequirements, storageId } from "../lib/storage-options";
 
 loadEnvConfig({ path: ".env.local" });
@@ -223,11 +224,21 @@ async function checkEnv(): Promise<void> {
     return;
   }
 
+  const redisOptions = z.object(redisEnvOptions).safeParse(env);
+  const redisErrors = redisOptions.success
+    ? []
+    : [
+        {
+          feature: "Redis",
+          missing: ["REDIS_URL must be a redis:// or rediss:// connection URL"],
+        },
+      ];
   const baseUrlError = validateBaseUrl(env);
   const gatewayError = validateGatewayKey(env);
   const storageError = validateStorage(env);
   const installedToolErrors = await validateInstalledTools(env);
   const errors = [
+    ...redisErrors,
     ...(baseUrlError ? [baseUrlError] : []),
     ...(gatewayError ? [gatewayError] : []),
     ...(storageError ? [storageError] : []),

--- a/apps/chat/scripts/check-redis.test.ts
+++ b/apps/chat/scripts/check-redis.test.ts
@@ -1,0 +1,45 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, it } from "vitest";
+
+it("skips an absent optional Redis and rejects REST credentials without exposing them", () => {
+  const cwd = mkdtempSync(join(tmpdir(), "chatjs-redis-check-"));
+  try {
+    for (const url of [
+      "",
+      "https://user:private-test-secret@provider.example",
+    ]) {
+      const result = spawnSync(
+        process.execPath,
+        [
+          fileURLToPath(import.meta.resolve("tsx/cli")),
+          fileURLToPath(new URL("./check-redis.ts", import.meta.url)),
+        ],
+        {
+          cwd,
+          env: {
+            NODE_ENV: "test",
+            TSX_TSCONFIG_PATH: fileURLToPath(
+              new URL("../tsconfig.json", import.meta.url)
+            ),
+            REDIS_URL: url,
+          },
+          encoding: "utf8",
+          timeout: 10_000,
+        }
+      );
+      expect(result.status).toBe(url ? 1 : 0);
+      expect(result.stdout + result.stderr).not.toContain(
+        "private-test-secret"
+      );
+      expect(url ? result.stderr : result.stdout).toContain(
+        url ? "Redis check failed" : "Redis is not configured"
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});

--- a/apps/chat/scripts/check-redis.ts
+++ b/apps/chat/scripts/check-redis.ts
@@ -1,0 +1,97 @@
+import { randomUUID } from "node:crypto";
+import { config as loadEnv } from "dotenv";
+import { createClient } from "redis";
+import { z } from "zod";
+import { config } from "../lib/config";
+import {
+  redisConnectionOptions,
+  redisEnvOptions,
+} from "../lib/redis/connection";
+
+const CHECK_DEADLINE_MS = 15_000;
+const PROBE_TTL_SECONDS = 60;
+loadEnv({ path: ".env.local", quiet: true });
+loadEnv({ quiet: true });
+
+async function checkRedis() {
+  const parsed = z.object(redisEnvOptions).safeParse(process.env);
+  if (!parsed.success) {
+    throw new Error("Invalid Redis configuration");
+  }
+  const options = redisConnectionOptions(parsed.data);
+  if (!options) {
+    process.stdout.write(
+      "Redis is not configured. Set REDIS_URL to check a provider.\n"
+    );
+    return;
+  }
+  const publisher = createClient({
+    ...options,
+    socket: { ...options.socket, reconnectStrategy: false },
+  });
+  const subscriber = publisher.duplicate();
+  // Failures are reported below without exposing provider errors or credentials.
+  publisher.on("error", () => undefined);
+  subscriber.on("error", () => undefined);
+  const key = `${config.appPrefix}:connection-check:${randomUUID()}`;
+  let deadline: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      (async () => {
+        await Promise.all([publisher.connect(), subscriber.connect()]);
+        await publisher.set(key, "0", { EX: PROBE_TTL_SECONDS });
+        if (
+          (await publisher.get(key)) !== "0" ||
+          (await publisher.incr(key)) !== 1
+        ) {
+          throw new Error("Key/value or counter check failed");
+        }
+        if (
+          !(
+            (await publisher.expire(key, PROBE_TTL_SECONDS)) &&
+            (await publisher.keys(key)).includes(key)
+          )
+        ) {
+          throw new Error("Expiry or key lookup check failed");
+        }
+        let receive: (() => void) | undefined;
+        const received = new Promise<void>((resolve) => {
+          receive = resolve;
+        });
+        await subscriber.subscribe(key, (message) => {
+          if (message === "probe") {
+            receive?.();
+          }
+        });
+        await publisher.publish(key, "probe");
+        await received;
+        await subscriber.unsubscribe(key);
+        await publisher.del(key);
+      })(),
+      new Promise<never>((_, reject) => {
+        deadline = setTimeout(
+          () => reject(new Error("Redis check timed out")),
+          CHECK_DEADLINE_MS
+        );
+      }),
+    ]);
+    process.stdout.write(
+      "Redis connection, key/value, counters, expiry, key lookup, and pub/sub OK.\n"
+    );
+  } finally {
+    clearTimeout(deadline);
+    if (publisher.isOpen) {
+      publisher.destroy();
+    }
+    if (subscriber.isOpen) {
+      subscriber.destroy();
+    }
+  }
+}
+
+checkRedis().catch(() => {
+  process.stderr.write(
+    "Redis check failed. Check REDIS_URL, TLS, credentials, network access, and command/channel permissions. See https://www.chatjs.dev/docs/reference/redis\n"
+  );
+  process.exitCode = 1;
+});

--- a/apps/chat/scripts/check-redis.ts
+++ b/apps/chat/scripts/check-redis.ts
@@ -49,7 +49,7 @@ async function checkRedis() {
         if (
           !(
             (await publisher.expire(key, PROBE_TTL_SECONDS)) &&
-            (await publisher.keys(key)).includes(key)
+            (await publisher.exists(key)) === 1
           )
         ) {
           throw new Error("Expiry or key lookup check failed");

--- a/apps/docs/blume.config.ts
+++ b/apps/docs/blume.config.ts
@@ -199,6 +199,7 @@ export default defineConfig({
             "/reference/config",
             "/reference/env-vars",
             "/reference/database",
+            "/reference/redis",
             "/reference/routing",
             "/reference/testing",
             "/reference/evaluations",

--- a/apps/docs/e2e/docs-visual.browser.test.ts
+++ b/apps/docs/e2e/docs-visual.browser.test.ts
@@ -2,6 +2,7 @@ import { takeSnapshot } from "@uiverify/vitest";
 import { expect, test } from "vitest";
 
 const pages = [
+  { name: "redis", path: "/docs/reference/redis" },
   { name: "storage", path: "/docs/storage" },
   { name: "custom-storage", path: "/docs/storage/custom" },
 	{ name: "home", path: "/docs" },

--- a/apps/docs/reference/env-vars.mdx
+++ b/apps/docs/reference/env-vars.mdx
@@ -256,9 +256,9 @@ Allows users to reconnect to an ongoing AI generation after a page refresh or ne
 
 | Variable | Description | Get it |
 |----------|-------------|--------|
-| `REDIS_URL` | Redis connection URL for stream state storage | [Vercel KV](https://vercel.com/docs/storage/vercel-kv) or any Redis provider |
+| `REDIS_URL` | Redis TCP/TLS URL for stream coordination and anonymous rate limits | [Redis setup](./redis) |
 
-Without `REDIS_URL`, streams work normally but cannot be resumed after disconnection.
+Without `REDIS_URL`, streams work normally but cannot be resumed after disconnection. Redis-backed anonymous rate-limit counters are also disabled. Run `bun redis:connect` to check a configured provider.
 
 ### Cron Job Secret
 

--- a/apps/docs/reference/redis.mdx
+++ b/apps/docs/reference/redis.mdx
@@ -1,0 +1,78 @@
+---
+title: Redis
+description: Configure a Redis host for resumable streams and shared rate limits
+---
+
+ChatJS uses one Node Redis client with a standard Redis TCP/TLS connection. You
+do not select a Redis host in the CLI or install a host-specific package. Your
+Postgres host and Redis host are independent.
+
+## Set up a connection
+
+Create a Redis database, then put its connection URL in `.env.local` at your
+generated app's root, or `apps/chat` in this repository:
+
+```bash
+REDIS_URL=rediss://default:password@your-redis-host:6379/0
+```
+
+Use `rediss://` for verified TLS and your host's certificate trust settings.
+`redis://localhost:6379` works for a local server without TLS. Connection attempts
+use a 10-second socket timeout. The running app retains Node Redis's automatic
+reconnection behavior.
+
+| Host | What to provide |
+| --- | --- |
+| Upstash | Copy the Redis TCP/TLS connection credentials from your database, not `UPSTASH_REDIS_REST_URL` or a REST token |
+| Redis Cloud | Use your database endpoint, port, username, password, and TLS settings |
+| Another managed host or local Redis | Use a standard Redis URL reachable from your app's runtime |
+
+See [Node Redis connections](https://redis.io/docs/latest/develop/clients/nodejs/connect/)
+and [Upstash security](https://upstash.com/docs/redis/features/security) for client
+and transport details. HTTP-only endpoints and cluster-mode endpoints requiring
+Redis Cluster routing are outside this client configuration.
+
+## Verify your provider
+
+After configuring the URL, run:
+
+```bash
+bun redis:connect
+```
+
+The generated command also runs with npm, pnpm, or Yarn. It verifies two
+connections, key/value reads and writes, counters, expiry, key lookup, and pub/sub.
+It uses the same connection options as the app, with reconnect retries disabled
+and a 15-second overall deadline for the check. Diagnostics do not print the URL
+or provider error text.
+
+The check writes one uniquely named key under
+`<appPrefix>:connection-check:*` with a 60-second expiry, publishes a probe on the
+same named channel, and deletes the key on success. On failure the key expires.
+Allow this prefix in your test credentials. The check does not read application
+values or modify existing keys. It exits unsuccessfully on a failed check and
+reports an unconfigured optional Redis connection without connecting.
+
+A successful probe confirms the tested capabilities. It does not establish
+provider capacity, availability guarantees, or permission to every application
+key prefix.
+
+## Required capabilities
+
+Redis currently serves resumable-stream coordination and anonymous rate limits.
+It is not a general query-result cache. The existing implementation uses `SET`
+(with expiry), `GET`, `INCR`, `EXPIRE`, `KEYS`, `PUBLISH`, `SUBSCRIBE`, and
+`UNSUBSCRIBE`. The check also uses `DEL` to clean up its temporary key.
+
+Resumable streams require a separate subscriber connection. Provider credentials
+must allow the relevant commands, application key prefixes, and pub/sub channels.
+A REST endpoint or a service supporting only basic key/value commands is not a
+drop-in replacement for this connection.
+
+## Without Redis
+
+You may leave `REDIS_URL` blank. Normal chat streaming remains available, but
+streams cannot resume after disconnection and Redis-backed anonymous rate-limit
+counters are not enforced. Other database-backed limits retain their behavior.
+
+See [Environment variables](./env-vars) for the rest of the app's configuration.

--- a/apps/docs/reference/redis.mdx
+++ b/apps/docs/reference/redis.mdx
@@ -17,9 +17,14 @@ REDIS_URL=rediss://default:password@your-redis-host:6379/0
 ```
 
 Use `rediss://` for verified TLS and your host's certificate trust settings.
+A `redis://` URL sends credentials and data without encryption. Use it only on
+local or trusted private networks. The app honors the configured transport and
+does not automatically upgrade plaintext connections.
 `redis://localhost:6379` works for a local server without TLS. Connection attempts
 use a 10-second socket timeout. The running app retains Node Redis's automatic
-reconnection behavior.
+reconnection behavior after startup. If initial connection fails or takes more
+than 10 seconds, both clients are closed and the app starts without Redis.
+Restart the app after correcting the connection to enable Redis again.
 
 | Host | What to provide |
 | --- | --- |
@@ -41,7 +46,7 @@ bun redis:connect
 ```
 
 The generated command also runs with npm, pnpm, or Yarn. It verifies two
-connections, key/value reads and writes, counters, expiry, key lookup, and pub/sub.
+connections, key/value reads and writes, counters, expiry, exact-key lookup, and pub/sub.
 It uses the same connection options as the app, with reconnect retries disabled
 and a 15-second overall deadline for the check. Diagnostics do not print the URL
 or provider error text.
@@ -62,7 +67,7 @@ key prefix.
 Redis currently serves resumable-stream coordination and anonymous rate limits.
 It is not a general query-result cache. The existing implementation uses `SET`
 (with expiry), `GET`, `INCR`, `EXPIRE`, `KEYS`, `PUBLISH`, `SUBSCRIBE`, and
-`UNSUBSCRIBE`. The check also uses `DEL` to clean up its temporary key.
+`UNSUBSCRIBE`. The check uses `EXISTS` instead of scanning keys. It also uses `DEL` to clean up its temporary key.
 
 Resumable streams require a separate subscriber connection. Provider credentials
 must allow the relevant commands, application key prefixes, and pub/sub channels.

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -388,6 +388,7 @@ export const create = new Command()
 			logger.break();
 
 			printEnvChecklist(envEntries);
+			logger.log("  Optional Redis: set REDIS_URL, then run " + packageManager + " run redis:connect. Setup: https://www.chatjs.dev/docs/reference/redis");
 
 			logger.break();
 			logger.log(

--- a/packages/cli/src/helpers/package-manifest.ts
+++ b/packages/cli/src/helpers/package-manifest.ts
@@ -72,6 +72,7 @@ function normalizeChatAppScripts(scripts: ScriptMap): void {
   scripts.lint = "ultracite check";
   scripts.format = "ultracite fix";
   scripts["check-env"] = "tsx scripts/check-env.ts";
+  scripts["redis:connect"] = "tsx scripts/check-redis.ts";
   scripts["db:migrate"] =
     "export VERCEL_ENV=production && bash scripts/with-db.sh tsx lib/db/migrate.ts";
   scripts["db:backfill-parts"] = "tsx lib/db/backfill-parts.ts";


### PR DESCRIPTION
Redis setup currently points users toward a vendor-specific service without stating the protocol and capabilities ChatJS needs. Runtime connections are also constructed directly inside the chat route.

Keep one Node Redis implementation and configure the host with `REDIS_URL`. Share TCP/TLS URL validation and connection options between the app and an explicit `redis:connect` command. The CLI and environment template link to setup guidance for Upstash, Redis Cloud, and other standard Redis endpoints. No provider selection or registry item is needed.

The connection check exercises two connections, key/value operations, counters, expiry, key lookup, and pub/sub. It uses a unique temporary key with a 60-second expiry and removes it on success, enforces a 15-second check deadline, and suppresses provider errors that may contain credentials. Runtime connection errors now have handlers with credential-free diagnostics. Existing rate-limit and resumable-stream behavior is retained.

Scope: Redis TCP/TLS endpoints supporting the documented commands. REST-only and cluster-mode endpoints requiring Redis Cluster routing are not supported by this client configuration. Omitting Redis still disables resumption and Redis-backed rate-limit counters.

Validation:
- Root lint and type checks, focused connection/script tests, and 65 CLI unit tests pass.
- A packed CLI creates an independently installed Vercel-gateway app that type-checks and loads its adapter.
- Real local Redis 7.4.2 passes the capability check and key cleanup. Credentials denied SUBSCRIBE fail safely without leaking their password, and temporary keys retain their expiry.
- Docs link validation and all 16 browser captures pass. The Redis documentation page was visually inspected.

## Summary by Sourcery

Standardize Redis configuration around portable TCP/TLS URLs and provide a safe capability check for generated applications.

New Features:
- Add a `redis:connect` command that verifies Redis connectivity and required key/value, counter, expiry, lookup, and pub/sub capabilities.
- Add provider-agnostic Redis setup documentation and CLI guidance for standard TCP/TLS Redis endpoints.

Bug Fixes:
- Prevent Redis startup failures or hangs from preventing the chat route from loading.
- Redact credentials and provider error details from Redis diagnostics and runtime connection errors.

Enhancements:
- Standardize Redis configuration around validated `redis://` and `rediss://` URLs with shared connection options.
- Retain optional Redis behavior so resumable streams and Redis-backed rate limits are disabled when no Redis URL is configured.

Documentation:
- Document supported Redis providers, required capabilities, connection security, verification behavior, and limitations.

Tests:
- Add unit and integration coverage for Redis URL validation, bounded startup, cleanup, capability checks, credential-safe failures, and documentation visuals.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes Redis setup around portable TCP/TLS `REDIS_URL`s and adds a `redis:connect` command that verifies provider capability. Runtime connections now share URL validation and connection options, and connection errors no longer expose credentials.

- Rejects HTTP REST endpoints and malformed Redis URLs during env parsing and `check-env`.
- Redis startup is bounded to 10 seconds; on failure the chat route starts without Redis instead of blocking or hanging.
- The check exercises two connections, key/value ops, counters, expiry, key lookup, and pub/sub under a 15-second deadline.
- Its temporary key carries a 60-second expiry and is deleted on success; failures leave it to expire.
- Diagnostics and runtime error handlers redact URL, credentials, and provider error text.
- New Redis reference docs cover provider-agnostic setup; the CLI post-create checklist links to them.
- Existing REST-based `REDIS_URL` values now fail validation and must be replaced with TCP/TLS endpoints.
- REST-only and Redis Cluster endpoints are unsupported; omitting Redis keeps streams non-resumable and disables Redis-backed rate-limit counters.

<sup>Written for commit c846079dfa65707edcc46d396358126eb321d00f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Redis URL validation for `redis://` and `rediss://` connections.
  * Added a `redis:connect` command to verify connectivity and required Redis capabilities.
  * Generated chat applications now include Redis setup guidance and verification scripts.
* **Documentation**
  * Added a Redis reference guide covering providers, TLS, capabilities, and setup.
  * Updated environment variable documentation with verification instructions and behavior when Redis is not configured.
* **Bug Fixes**
  * Improved handling of unavailable Redis connections.
  * Prevented invalid REST endpoints from being accepted as Redis connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->