### PR TITLE
Add approved Threads launch video as an editable Remotion example

### DIFF
--- a/apps/videos/README.md
+++ b/apps/videos/README.md
@@ -23,3 +23,7 @@ The starter renders a 1920×1080, 30 fps brand card to `apps/videos/out/brand-ex
 5. Render key states and click frames, check backward seeking, then render the MP4. Run `bun lint` and `bun test:types`; decode the result with FFmpeg. Keep the prior approved render before revising.
 
 Label simulated data in illustrated walkthroughs. Keep generated media outside Git; share approved output separately. Prefer small reusable presentation pieces; product-specific scenes belong to their own composition.
+
+## Threads launch example
+
+The approved 48-second film is documented in [THREADS.md](THREADS.md). `bun run --cwd apps/videos render` renders Threads; `render:brand` renders the minimal starter. The Threads script demonstrates regeneration, switching while streaming, separate follow-ups, and editing an earlier message while preserving both versions. Copy its scenario/state structure for the next guided film and reuse the shared presentation pieces.

--- a/apps/videos/README.md
+++ b/apps/videos/README.md
@@ -12,7 +12,7 @@ bun run --cwd apps/videos studio
 bun run --cwd apps/videos render
 ```
 
-The starter renders a 1920×1080, 30 fps brand card to `apps/videos/out/brand-example.mp4`. The first render downloads Remotion's headless browser. Generated videos and frame captures are ignored by Git. Local logo and font assets avoid runtime asset requests.
+The default render writes the 1920×1080, 30 fps Threads film to `apps/videos/out/threads-launch.mp4`. Run `bun run --cwd apps/videos render:brand` for the minimal brand card at `apps/videos/out/brand-example.mp4`. The first render downloads Remotion's headless browser. Generated videos and frame captures are ignored by Git. Local logo and font assets avoid runtime asset requests.
 
 ## Make the next video
 

--- a/apps/videos/THREADS.md
+++ b/apps/videos/THREADS.md
@@ -1,0 +1,58 @@
+# ChatJS videos
+
+The approved Threads launch film migrated to native React/Remotion. A 48-second, 1920×1080 composition at 30 fps, with ChatJS branding and deterministic simulated replies. No HTML iframe, DOM mutation playback, Playwright capture loop, API credentials, or network response timing is involved in rendering.
+
+## Preview and render
+
+From the repository root, after `bun install`:
+
+```sh
+bun run --cwd apps/videos studio
+bun run --cwd apps/videos render
+bun run --cwd apps/videos stills
+bun run --cwd apps/videos test:unit
+```
+
+Studio provides named timeline sections and frame scrubbing. The MP4 is written to `apps/videos/out/threads-launch.mp4`; representative PNGs go to `out/stills`. Outputs are ignored by Git. Remotion downloads its headless browser on first use. All fonts and images are bundled locally.
+
+## Editing the next film
+
+- `src/story.ts`: typed content, captions, chapter times, branch states, and cursor actions. Change the `script` object to tell another story with the same structure.
+- `src/ThreadsLaunch.tsx`: React chat, tree, status, brand, and title-card components. Every animated value derives from the current frame. Do not introduce timers or CSS animation.
+- `src/index.tsx`: composition registration, dimensions, fps, and default props. Register another composition here for a separate film.
+- `src/styles.css`: the approved visual design, ported from the illustrated walkthrough.
+- `public/brand`: ChatJS logo and Geist/Geist Mono font assets copied from the site. The SVG uses the navbar logo paths with transparent cutouts.
+
+Content can also be overridden through Remotion input props (`--props=path/to/props.json`) with a complete `content` object matching `LaunchScript`.
+
+This is deliberately one reusable launch-film composition, not a general video editor. Structural changes such as adding another branch or changing the timeline require adjusting the state function and tree layout. Portrait and square layouts have not been implemented.
+
+## Quality and verification
+
+The previous film captured at 15 fps and duplicated frames into a 30 fps file. This composition renders 30 distinct frames per second, using lossless PNG intermediates before H.264 encoding (CRF 18). The current cut uses the same design with revised copy and editing the original prompt to create a Porto conversation.
+
+`test:unit` protects background streaming and branch context. `stills` renders every chapter's meaningful state and checks repeated out-of-order rendering for deterministic output. The root `bun lint` and `bun test:types` include this workspace.
+
+The film is an illustrated walkthrough with simulated replies, not a live product screen recording. The install card is a launch asset and does not verify npm publication.
+
+Remotion references: [composition fundamentals](https://www.remotion.dev/docs/the-fundamentals), [render CLI](https://www.remotion.dev/docs/cli/render), [local fonts](https://www.remotion.dev/docs/fonts-api/load-font).
+
+## Current edit: two paths, one story
+
+- 0–3s: npm package introduction.
+- 3–8s: original answer streams, then a short reading hold.
+- 8–9.5s: “Try another answer” caption.
+- 9.5–14.5s: explicit regenerate press; reveal the split.
+- 14.5–16s: “Switch while replies stream” caption.
+- 17s: press the previous-answer arrow; original returns while the alternative streams, with a live word count and progress bar showing continued generation.
+- 20.5–22s: “Continue either conversation” caption.
+- 22–26.5s: kid-friendly follow-up and a short reading hold.
+- 26.5–28s: “Continue the other” caption.
+- 29s: press the next-answer arrow.
+- 30–34.5s: vegetarian follow-up.
+- 34.5–36s: “Edit any message. Keep both versions.” caption.
+- 36–39.3s: reveal the original prompt, click Edit, change Lisbon to Porto, then Save.
+- 39.3–43s: Porto reply streams; both Lisbon conversations remain in the tree.
+- 43–48s: installation and URL.
+
+The three-reply/stop sequence is omitted from this film. Earlier MP4s remain in `out/threads-launch-before-caption-beats.mp4` and `out/threads-launch-caption-cut.mp4`. The original approved render is preserved outside Git; this example consumes the shared branding, captions, pointer, and click effects.

--- a/apps/videos/package.json
+++ b/apps/videos/package.json
@@ -4,10 +4,13 @@
 	"version": "0.0.0",
 	"scripts": {
 		"studio": "remotion studio src/index.tsx",
-		"render": "remotion render src/index.tsx BrandExample out/brand-example.mp4 --codec=h264 --crf=18 --image-format=png --concurrency=4",
+		"render": "remotion render src/index.tsx ThreadsLaunch out/threads-launch.mp4 --codec=h264 --crf=18 --image-format=png --concurrency=4",
 		"lint": "biome check .",
 		"format": "biome check --write .",
-		"test:types": "tsc --noEmit"
+		"test:types": "tsc --noEmit",
+		"render:brand": "remotion render src/index.tsx BrandExample out/brand-example.mp4 --codec=h264 --crf=18 --image-format=png --concurrency=4",
+		"stills": "bun scripts/stills.ts",
+		"test:unit": "bun test src/story.test.ts"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.4.10",

--- a/apps/videos/scripts/stills.ts
+++ b/apps/videos/scripts/stills.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { bundle } from "@remotion/bundler";
+import { renderStill, selectComposition } from "@remotion/renderer";
+
+import { webpackOverride } from "../webpack";
+
+const serveUrl = await bundle({
+	entryPoint: resolve("src/index.tsx"),
+	webpackOverride,
+});
+const composition = await selectComposition({ serveUrl, id: "ThreadsLaunch" });
+await mkdir("out/stills", { recursive: true });
+// One representative capture per meaningful state, plus an out-of-order seek.
+const seen = new Set<number>();
+for (const second of [
+	0, 7, 8.5, 9.9, 15, 16.9, 17.2, 18.5, 20, 20.3, 25, 28.9, 31, 34, 35, 36.5,
+	36.7, 37, 38, 39, 40, 42.5, 45, 7,
+]) {
+	const output = `out/stills/${second}${seen.has(second) ? "-seek" : ""}.png`;
+	await renderStill({
+		serveUrl,
+		composition,
+		frame: Math.round(second * composition.fps),
+		output,
+	});
+	if (seen.has(second)) {
+		assert.deepEqual(
+			await readFile(output),
+			await readFile(`out/stills/${second}.png`),
+			"Out-of-order renders must be identical",
+		);
+	}
+	seen.add(second);
+	console.log(`Rendered ${second}s`);
+}

--- a/apps/videos/src/ThreadsLaunch.tsx
+++ b/apps/videos/src/ThreadsLaunch.tsx
@@ -164,9 +164,9 @@ function Chat({
 			style={{ left: 320 - 236 * s.reveal, width: 1120 - 160 * s.reveal }}
 		>
 			<div className="chatheader">
-				{s.edited ? "Porto weekend" : content.title}
+				{s.edited ? content.porto.title : content.title}
 				<span className="pathlabel">
-					{s.edited ? "Porto" : content[s.selected].label}
+					{s.edited ? content.porto.label : content[s.selected].label}
 				</span>
 			</div>
 			<div className="messages">
@@ -407,13 +407,13 @@ function ConversationTree({
 					<div
 						className={`node selected portoReply ${s.portoState === "streaming" ? "live" : ""}`}
 					>
-						<div className="nodetitle">Porto weekend</div>
+						<div className="nodetitle">{content.porto.title}</div>
 						<div className="nodestatus">
 							<Status state={s.portoState} t={t} />
 						</div>
 						<div className="count">New conversation</div>
 					</div>
-					<div className="preservedLabel">Both Lisbon conversations kept</div>
+					<div className="preservedLabel">{content.porto.preservedNote}</div>
 				</div>
 			)}
 			{t < 24 && !s.following && !s.edited && (

--- a/apps/videos/src/ThreadsLaunch.tsx
+++ b/apps/videos/src/ThreadsLaunch.tsx
@@ -1,0 +1,492 @@
+import {
+	AbsoluteFill,
+	Sequence,
+	useCurrentFrame,
+	useVideoConfig,
+} from "remotion";
+import { Logo } from "./shared/brand";
+import { Caption, ClickPulse, Pointer } from "./shared/presentation";
+import {
+	beats,
+	cursorAt,
+	DURATION,
+	ease,
+	type LaunchScript,
+	presentationAt,
+	type ReplyState,
+	type StoryState,
+	stateAt,
+} from "./story";
+import "./styles.css";
+
+function Author() {
+	return (
+		<>
+			<div className="avatar">
+				<Logo />
+			</div>
+			Assistant
+		</>
+	);
+}
+function Status({
+	state,
+	t,
+	background = false,
+}: {
+	state: ReplyState;
+	t: number;
+	background?: boolean;
+}) {
+	return (
+		<>
+			{state === "streaming" ? (
+				<>
+					<span
+						className="ring"
+						style={{ transform: `rotate(${t * 300}deg)` }}
+					/>{" "}
+					{background ? "Still streaming" : "Streaming"}
+				</>
+			) : state === "stopped" ? (
+				"■ Stopped"
+			) : (
+				"✓ Complete"
+			)}
+		</>
+	);
+}
+function ActionIcon({
+	name,
+}: {
+	name: "edit" | "copy" | "previous" | "next" | "regenerate";
+}) {
+	const paths = {
+		regenerate:
+			"M20 7v5h-5 M4 17v-5h5 M6.1 7a7 7 0 0 1 11.6-2L20 8 M4 16l2.3 3A7 7 0 0 0 17.9 17",
+		edit: "M16 3a2.83 2.83 0 0 1 4 4L7 20l-5 1 1-5Z M14.5 4.5l4 4",
+		copy: "M9 9h12v12H9z M5 15H3V3h12v2",
+		previous: "m15 18-6-6 6-6",
+		next: "m9 18 6-6-6-6",
+	};
+	return (
+		<svg
+			aria-hidden="true"
+			width="17"
+			height="17"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.7"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		>
+			<path d={paths[name]} />
+		</svg>
+	);
+}
+function MessageActions({
+	user = false,
+	index = 1,
+	count = 1,
+	streaming = false,
+	className = "",
+	regenerateHint = false,
+	actionTime = 0,
+}: {
+	user?: boolean;
+	index?: number;
+	count?: number;
+	streaming?: boolean;
+	className?: string;
+	regenerateHint?: boolean;
+	actionTime?: number;
+}) {
+	return (
+		<div className={`messageActions ${className}`}>
+			{user && (
+				<span
+					className={`messageAction ${actionTime >= 41.8 && actionTime < 42.2 ? "highlightAction" : ""}`}
+					title="Edit message"
+				>
+					<ActionIcon name="edit" />
+				</span>
+			)}
+			{count > 1 && (
+				<>
+					<span
+						className={`messageAction ${actionTime >= 18.5 && actionTime < 19 ? "highlightAction" : ""}`}
+						style={{ opacity: index === 1 ? 0.3 : 1 }}
+					>
+						<ActionIcon name="previous" />
+					</span>
+					<span className="versionCount">
+						{index} / {count}
+					</span>
+					<span
+						className={`messageAction ${actionTime >= 32.5 && actionTime < 33 ? "highlightAction" : ""}`}
+						style={{ opacity: index === count ? 0.3 : 1 }}
+					>
+						<ActionIcon name="next" />
+					</span>
+				</>
+			)}
+			{!user && !streaming && (
+				<span
+					className={`messageAction regenerateAction ${regenerateHint ? "highlightAction" : ""}`}
+				>
+					<ActionIcon name="regenerate" />
+					{regenerateHint && (
+						<span className="actionTooltip">Regenerate response</span>
+					)}
+				</span>
+			)}
+			{!streaming && (
+				<span className="messageAction" title="Copy">
+					<ActionIcon name="copy" />
+				</span>
+			)}
+		</div>
+	);
+}
+function Chat({
+	s,
+	t,
+	content,
+}: {
+	s: StoryState;
+	t: number;
+	content: LaunchScript;
+}) {
+	return (
+		<div
+			className={`chat ${s.following ? "following" : ""}`}
+			style={{ left: 320 - 236 * s.reveal, width: 1120 - 160 * s.reveal }}
+		>
+			<div className="chatheader">
+				{s.edited ? "Porto weekend" : content.title}
+				<span className="pathlabel">
+					{s.edited ? "Porto" : content[s.selected].label}
+				</span>
+			</div>
+			<div className="messages">
+				<div className="user">
+					<div className="role">You</div>
+					<div className={`bubble ${s.editing ? "editingBubble" : ""}`}>
+						{s.editing
+							? s.editText
+							: s.edited
+								? content.porto.prompt
+								: content.prompt}
+						{s.editing && <span className="editCaret">|</span>}
+					</div>
+					{s.editing && (
+						<div className="editControls">
+							<span>Cancel</span>
+							<button
+								type="button"
+								className={t >= 44.3 ? "highlightAction" : ""}
+							>
+								Save
+							</button>
+						</div>
+					)}
+					{!s.editing && (
+						<MessageActions
+							user
+							className="promptActions"
+							actionTime={t}
+							index={2}
+							count={s.edited ? 2 : 1}
+						/>
+					)}
+				</div>
+				<div className="assistant" style={{ opacity: s.editing ? 0.25 : 1 }}>
+					<div className="author">
+						<Author />
+						{!s.following && (
+							<span
+								className="assistantStatus"
+								style={{
+									color:
+										s.states[s.selected] === "stopped" ? "#f3ba6a" : "#89bda9",
+								}}
+							>
+								<Status
+									state={s.edited ? s.portoState : s.states[s.selected]}
+									t={t}
+								/>
+							</span>
+						)}
+					</div>
+					<div className="answer" style={{ fontSize: 24 }}>
+						{s.edited ? s.portoAnswer : s.answer}
+					</div>
+					<MessageActions
+						className="replyActions"
+						regenerateHint={t >= 11.65 && t < 12.2}
+						actionTime={t}
+						index={s.selected === "city" ? 1 : 2}
+						count={!s.edited && s.foodVisible ? 2 : 1}
+						streaming={
+							s.edited
+								? s.portoState === "streaming"
+								: !s.following && s.states[s.selected] === "streaming"
+						}
+					/>
+				</div>
+			</div>
+			{s.following && (
+				<div className="followup" style={{ display: "block" }}>
+					<div className="followupUser">
+						<div className="role">You</div>
+						<div className="bubble">{s.followup.prompt}</div>
+						<MessageActions user className="followupPromptActions" />
+					</div>
+					<div className="author">
+						<Author />
+						<span className="followupStatus">
+							<Status state={s.followup.state} t={t} />
+						</span>
+					</div>
+					<div className="followupAnswer">{s.followup.text}</div>
+					<MessageActions
+						className="followupReplyActions"
+						streaming={s.followup.state === "streaming"}
+					/>
+				</div>
+			)}
+			<div className="composer">
+				Message this branch… <span>↑</span>
+			</div>
+		</div>
+	);
+}
+function ConversationTree({
+	s,
+	t,
+	content,
+}: {
+	s: StoryState;
+	t: number;
+	content: LaunchScript;
+}) {
+	return (
+		<div className="map" style={{ opacity: s.reveal }}>
+			<div className="maptitle">YOUR CONVERSATION</div>
+			<div
+				style={{
+					position: "absolute",
+					width: 735,
+					top: 0,
+					left: 0,
+					height: 640,
+					transformOrigin: "top left",
+					transform: `translateY(${100 * ease((t - 44.8) / 0.5)}px) scale(${1 - 0.38 * ease((t - 44.8) / 0.5)})`,
+				}}
+			>
+				<svg
+					aria-hidden="true"
+					width="735"
+					height="640"
+					style={{ position: "absolute", top: 0 }}
+				>
+					{(["city", "food"] as const).map((id) => {
+						const x = id === "city" ? 176 : 560;
+						return (
+							(id === "city" || s.foodVisible) && (
+								<path
+									key={id}
+									d={`M367 171 V235 Q367 249 ${id === "city" ? 353 : 381} 249 H${x} V322`}
+									fill="none"
+									stroke={
+										!s.edited && s.selected === id ? "#83b2ff" : "#404040"
+									}
+									strokeWidth={3}
+								/>
+							)
+						);
+					})}
+					{t >= 24 && (
+						<path
+							d="M176 464 V514"
+							fill="none"
+							stroke={!s.edited && s.family ? "#83b2ff" : "#404040"}
+							strokeWidth={3}
+						/>
+					)}
+					{s.budget && (
+						<path
+							d="M560 464 V514"
+							fill="none"
+							stroke={
+								!s.edited && s.selected === "food" ? "#83b2ff" : "#404040"
+							}
+							strokeWidth={3}
+						/>
+					)}
+				</svg>
+				<div className="node root">
+					<span>{content.prompt}</span>
+				</div>
+				{(["city", "food"] as const).map(
+					(id) =>
+						(id === "city" || s.foodVisible) && (
+							<div
+								key={id}
+								className={`node ${!s.edited && s.selected === id ? "selected" : ""} ${s.states[id] === "streaming" ? "live" : ""}`}
+								style={{ left: id === "city" ? 35 : 419, top: 322, width: 282 }}
+							>
+								{!s.edited && s.selected === id && !s.following && (
+									<div className="badge">Viewing this path</div>
+								)}
+								<div className="nodetitle">{content[id].label}</div>
+								<div className="nodestatus">
+									<Status
+										state={s.states[id]}
+										t={t}
+										background={s.selected !== id}
+									/>
+								</div>
+								<div className="count">
+									{s.states[id] === "streaming"
+										? `${s.texts[id].trim().split(/\s+/).filter(Boolean).length} words generated`
+										: id === "city"
+											? "Original answer"
+											: "Alternative answer"}
+								</div>
+								{s.states[id] === "streaming" && (
+									<div className="streamProgress">
+										<i
+											style={{
+												width: `${(100 * s.texts[id].length) / content[id].text.length}%`,
+											}}
+										/>
+									</div>
+								)}
+							</div>
+						),
+				)}
+				{t >= 24 && (
+					<div
+						className={`followupNode ${!s.edited && s.family ? "selected" : ""}`}
+						style={{ left: 35, width: 282 }}
+					>
+						<div className="nodetitle">{content.family.title}</div>
+						<div className="nodestatus">City follow-up</div>
+					</div>
+				)}
+				{s.budget && (
+					<div
+						className={`followupNode ${!s.edited && s.selected === "food" ? "selected" : ""}`}
+						style={{ left: 419, width: 282 }}
+					>
+						<div className="nodetitle">{content.budget.title}</div>
+						<div className="nodestatus">Food follow-up</div>
+					</div>
+				)}
+			</div>
+			{s.edited && (
+				<div style={{ opacity: ease((t - 44.8) / 0.5) }}>
+					<svg
+						aria-hidden="true"
+						width="735"
+						height="640"
+						style={{ position: "absolute", top: 0 }}
+					>
+						<path
+							d="M228 153 V70 H600 V185 M600 271 V375"
+							fill="none"
+							stroke="#83b2ff"
+							strokeWidth={3}
+						/>
+					</svg>
+					<div className="node selected portoPrompt">
+						<span>{content.porto.prompt}</span>
+					</div>
+					<div
+						className={`node selected portoReply ${s.portoState === "streaming" ? "live" : ""}`}
+					>
+						<div className="nodetitle">Porto weekend</div>
+						<div className="nodestatus">
+							<Status state={s.portoState} t={t} />
+						</div>
+						<div className="count">New conversation</div>
+					</div>
+					<div className="preservedLabel">Both Lisbon conversations kept</div>
+				</div>
+			)}
+			{t < 24 && !s.following && !s.edited && (
+				<div className="mapnote">{s.note}</div>
+			)}
+		</div>
+	);
+}
+export function ThreadsLaunch({ content }: { content: LaunchScript }) {
+	const frame = useCurrentFrame(),
+		{ fps } = useVideoConfig(),
+		wallTime = frame / fps,
+		presentation = presentationAt(wallTime),
+		t = presentation.demoTime,
+		s = stateAt(t, content),
+		cursor = cursorAt(t);
+	return (
+		<AbsoluteFill className="stage">
+			<div className="brand">
+				<Logo />
+				ChatJS Threads
+			</div>
+			<div className="eyebrow">NPM PACKAGE / COMPATIBLE WITH AI SDK</div>
+			<div className="demoStage">
+				<Chat s={s} t={t} content={content} />
+				<ConversationTree s={s} t={t} content={content} />
+				{[
+					{ at: 11.85, x: 178, y: 716 },
+					{ at: 18.8, x: 178, y: 716 },
+					{ at: 32.8, x: 249, y: 572 },
+					{ at: 41.9, x: 964, y: 522 },
+					{ at: 44.5, x: 962, y: 555 },
+				].map(({ at, x, y }) => (
+					<ClickPulse key={at} age={t - at} x={x} y={y} />
+				))}
+				{cursor && <Pointer {...cursor} />}
+			</div>
+			{presentation.caption && (
+				<Caption opacity={presentation.opacity}>{presentation.caption}</Caption>
+			)}
+
+			<div className="footer">ILLUSTRATED WALKTHROUGH · SIMULATED REPLIES</div>
+			<div className="url">{content.url}</div>
+			<div className="progress">
+				<i style={{ width: `${(wallTime / DURATION) * 100}%` }} />
+			</div>
+			<Sequence
+				name="Package introduction"
+				durationInFrames={3 * fps}
+				layout="none"
+			>
+				<div className="package" style={{ opacity: 1 - ease((t - 2.7) / 0.3) }}>
+					<div className="kicker">
+						<Logo />
+						CHATJS THREADS
+					</div>
+					<h2>{beats[0].title}</h2>
+					<p>{beats[0].subtitle}</p>
+					<code>{content.package}</code>
+					<small>An npm package for your app.</small>
+				</div>
+			</Sequence>
+			<Sequence name="Install and call to action" from={43 * fps} layout="none">
+				<div className="outro" style={{ opacity: ease((t - 48.5) / 0.4) }}>
+					<div className="glyph">
+						<Logo />
+					</div>
+					<h2>{beats.at(-1)?.title}</h2>
+					<p>{beats.at(-1)?.subtitle}</p>
+					<code>npm install {content.package}</code>
+					<strong>{content.url}</strong>
+				</div>
+			</Sequence>
+		</AbsoluteFill>
+	);
+}

--- a/apps/videos/src/index.tsx
+++ b/apps/videos/src/index.tsx
@@ -1,16 +1,29 @@
 import { Composition, registerRoot } from "remotion";
 import { BrandExample } from "./BrandExample";
+import { DURATION, FPS, script } from "./story";
+import { ThreadsLaunch } from "./ThreadsLaunch";
 
 function Root() {
 	return (
-		<Composition
-			id="BrandExample"
-			component={BrandExample}
-			width={1920}
-			height={1080}
-			fps={30}
-			durationInFrames={90}
-		/>
+		<>
+			<Composition
+				id="BrandExample"
+				component={BrandExample}
+				width={1920}
+				height={1080}
+				fps={30}
+				durationInFrames={90}
+			/>
+			<Composition
+				id="ThreadsLaunch"
+				component={ThreadsLaunch}
+				width={1920}
+				height={1080}
+				fps={FPS}
+				durationInFrames={DURATION * FPS}
+				defaultProps={{ content: script }}
+			/>
+		</>
 	);
 }
 registerRoot(Root);

--- a/apps/videos/src/story.test.ts
+++ b/apps/videos/src/story.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { presentationAt, stateAt } from "./story";
+import { presentationAt, script, stateAt } from "./story";
 
 describe("Two-path story", () => {
 	it("keeps the original while its alternative streams in the background", () => {
@@ -22,6 +22,16 @@ describe("Two-path story", () => {
 		expect(branched.texts).toEqual(stateAt(38).texts);
 		expect(branched.budget).toBe(true);
 		expect(branched.following).toBe(false);
+	});
+	it("uses overridden prompt copy throughout the edit", () => {
+		const content = {
+			...script,
+			prompt: "Explore Paris.",
+			porto: { ...script.porto, prompt: "Explore Rome." },
+		};
+		expect(stateAt(42.3, content).editText).toBe("Explore Paris.");
+		expect(stateAt(43, content).editText.startsWith("Explore ")).toBe(true);
+		expect(stateAt(44, content).editText).toBe("Explore Rome.");
 	});
 	it("is seekable without stale follow-ups", () => {
 		const a = stateAt(8);

--- a/apps/videos/src/story.test.ts
+++ b/apps/videos/src/story.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { presentationAt, stateAt } from "./story";
+
+describe("Two-path story", () => {
+	it("keeps the original while its alternative streams in the background", () => {
+		expect(stateAt(20).selected).toBe("city");
+		expect(stateAt(20).texts.city).toBe(stateAt(8).texts.city);
+		expect(stateAt(21).texts.food.length).toBeGreaterThan(
+			stateAt(19).texts.food.length,
+		);
+	});
+	it("continues each branch with its own follow-up", () => {
+		expect(stateAt(29).followup.prompt).toBe("Make it kid-friendly.");
+		expect(stateAt(38).followup.prompt).toBe("Make it vegetarian.");
+		expect(stateAt(38).selected).toBe("food");
+	});
+	it("branches an edited prompt while retaining both original conversations", () => {
+		expect(stateAt(43).editing).toBe(true);
+		const branched = stateAt(48);
+		expect(branched.edited).toBe(true);
+		expect(branched.portoState).toBe("complete");
+		expect(branched.texts).toEqual(stateAt(38).texts);
+		expect(branched.budget).toBe(true);
+		expect(branched.following).toBe(false);
+	});
+	it("is seekable without stale follow-ups", () => {
+		const a = stateAt(8);
+		stateAt(38);
+		expect(stateAt(8)).toEqual(a);
+	});
+	it("holds for reading without accelerating the following actions", () => {
+		expect(presentationAt(8.5).demoTime).toBe(10);
+		expect(presentationAt(9.4).demoTime).toBe(10);
+		expect(presentationAt(12).demoTime).toBe(14);
+	});
+});

--- a/apps/videos/src/story.ts
+++ b/apps/videos/src/story.ts
@@ -1,0 +1,144 @@
+export const FPS = 30;
+export const DURATION = 48;
+export type PathId = "city" | "food";
+export type ReplyState = "streaming" | "stopped" | "complete";
+export const script = {
+	title: "Lisbon weekend",
+	prompt: "Plan a weekend in Lisbon.",
+	package: "@chat-js/thread",
+	url: "chatjs.dev/threads",
+	city: {
+		label: "City sights",
+		text: "Saturday — Explore Alfama, then ride tram 28.\n\nSunday — Visit Belém and watch the sunset by the river.",
+	},
+	food: {
+		label: "Food trip",
+		text: "Saturday — Try the pastries and visit the food market.\n\nSunday — Find a local tasca for lunch, then share petiscos.",
+	},
+	family: {
+		prompt: "Make it kid-friendly.",
+		title: "With the kids",
+		reply: "Try the aquarium, a park picnic, and an ice cream stop.",
+	},
+	porto: {
+		prompt: "Plan a weekend in Porto.",
+		reply:
+			"Saturday — Explore Ribeira and walk across the Dom Luís I Bridge.\n\nSunday — Visit the gardens, then catch the sunset by the river.",
+	},
+	budget: {
+		prompt: "Make it vegetarian.",
+		title: "Vegetarian",
+		reply: "Try vegetable petiscos, market salads, and a vegetarian tasca.",
+	},
+};
+export type LaunchScript = typeof script;
+export const beats = [
+	{
+		at: 0,
+		title: "Branching conversations for AI SDK",
+		subtitle: "Regenerate. Switch answers. Keep chatting.",
+	},
+	{
+		at: 48.5,
+		title: "Add branching to your chat",
+		subtitle: "An npm package for your AI SDK app.",
+	},
+];
+export const clamp = (x: number) => Math.max(0, Math.min(1, x));
+export const ease = (x: number) => {
+	const v = clamp(x);
+	return v * v * (3 - 2 * v);
+};
+function textAt(text: string, fraction: number) {
+	return text.slice(0, Math.floor(clamp(fraction) * text.length));
+}
+export function stateAt(t: number, content: LaunchScript = script) {
+	const selected: PathId =
+		t >= 33 ? "food" : t >= 19 ? "city" : t >= 12.2 ? "food" : "city";
+	const editing = t >= 42.2 && t < 44.8;
+	const edited = t >= 44.8;
+	const following = t >= 24 && t < 41.5,
+		family = t >= 24 && t < 33,
+		budget = t >= 34;
+	const followup = family ? content.family : content.budget;
+	const progress = clamp((t - (family ? 24.6 : 34.6)) / 2.4);
+	const texts = {
+		city: textAt(content.city.text, (t - 3.5) / 3),
+		food: textAt(content.food.text, (t - 12.2) / 10),
+	};
+	const states: Record<PathId, ReplyState> = {
+		city: t < 6.5 ? "streaming" : "complete",
+		food: t < 22.2 ? "streaming" : "complete",
+	};
+	return {
+		selected,
+		editing,
+		edited,
+		editText:
+			t < 42.6
+				? content.prompt
+				: `Plan a weekend in ${textAt("Porto.", (t - 42.6) / 1.1)}`,
+		portoAnswer: textAt(content.porto.reply, (t - 45) / 2.5),
+		portoState: t < 47.5 ? ("streaming" as const) : ("complete" as const),
+		following: following && (family || budget),
+		family,
+		budget,
+		foodVisible: t >= 12.2,
+		reveal: ease((t - 11.5) / 0.3),
+		texts,
+		states,
+		answer: texts[selected],
+		followup: {
+			...followup,
+			text: textAt(followup.reply, progress),
+			state: progress < 1 ? ("streaming" as const) : ("complete" as const),
+		},
+		note:
+			t >= 19 && t < 22
+				? "Your original is here. The other reply keeps going."
+				: t >= 12 && t < 18
+					? "One prompt. Two answers."
+					: t >= 22
+						? "Both paths are yours to keep."
+						: "",
+	};
+}
+export type StoryState = ReturnType<typeof stateAt>;
+export const captionBeats = [
+	{ start: 10, end: 11.5, label: "Try another answer" },
+	{ start: 16.5, end: 18, label: "Switch while replies stream" },
+	{ start: 22.5, end: 24, label: "Continue either conversation" },
+	{ start: 30.5, end: 32, label: "Continue the other" },
+	{ start: 40, end: 41.5, label: "Edit any message. Keep both versions." },
+];
+export function presentationAt(wallTime: number) {
+	// Cut only completed-reply holds; keep action and streaming speed unchanged.
+	const time =
+		wallTime +
+		(wallTime >= 8 ? 2 : 0) +
+		(wallTime >= 26.5 ? 2 : 0) +
+		(wallTime >= 34.5 ? 1.5 : 0);
+	const beat = captionBeats.find((b) => time >= b.start && time < b.end);
+	if (!beat) return { demoTime: time, caption: null, opacity: 0 };
+	const elapsed = time - beat.start,
+		duration = beat.end - beat.start;
+	return {
+		demoTime: beat.start,
+		caption: beat.label,
+		opacity: Math.min(ease(elapsed / 0.15), ease((duration - elapsed) / 0.15)),
+	};
+}
+export function cursorAt(t: number) {
+	const moves = [
+		[11.5, 12.5, 0.2, 600, 740, 178, 716],
+		[18.1, 19.5, 0.4, 600, 740, 178, 716],
+		[32.1, 33.5, 0.4, 600, 620, 249, 572],
+		[41.5, 42.4, 0.3, 600, 620, 964, 522],
+		[44, 45.1, 0.3, 650, 620, 962, 555],
+	];
+	const move = moves.find(([start, end]) => t >= start && t < end);
+	if (!move) return null;
+	const [start, , duration, ax, ay, bx, by] = move,
+		k = ease((t - start) / duration);
+	return { x: ax + (bx - ax) * k, y: ay + (by - ay) * k };
+}

--- a/apps/videos/src/story.ts
+++ b/apps/videos/src/story.ts
@@ -21,6 +21,9 @@ export const script = {
 		reply: "Try the aquarium, a park picnic, and an ice cream stop.",
 	},
 	porto: {
+		title: "Porto weekend",
+		label: "Porto",
+		preservedNote: "Both Lisbon conversations kept",
 		prompt: "Plan a weekend in Porto.",
 		reply:
 			"Saturday — Explore Ribeira and walk across the Dom Luís I Bridge.\n\nSunday — Visit the gardens, then catch the sunset by the river.",
@@ -53,6 +56,15 @@ function textAt(text: string, fraction: number) {
 	return text.slice(0, Math.floor(clamp(fraction) * text.length));
 }
 export function stateAt(t: number, content: LaunchScript = script) {
+	let prefixLength = 0;
+	while (
+		prefixLength < content.prompt.length &&
+		prefixLength < content.porto.prompt.length &&
+		content.prompt[prefixLength] === content.porto.prompt[prefixLength]
+	)
+		prefixLength++;
+	const editPrefix = content.porto.prompt.slice(0, prefixLength);
+	const editSuffix = content.porto.prompt.slice(prefixLength);
 	const selected: PathId =
 		t >= 33 ? "food" : t >= 19 ? "city" : t >= 12.2 ? "food" : "city";
 	const editing = t >= 42.2 && t < 44.8;
@@ -77,7 +89,7 @@ export function stateAt(t: number, content: LaunchScript = script) {
 		editText:
 			t < 42.6
 				? content.prompt
-				: `Plan a weekend in ${textAt("Porto.", (t - 42.6) / 1.1)}`,
+				: `${editPrefix}${textAt(editSuffix, (t - 42.6) / 1.1)}`,
 		portoAnswer: textAt(content.porto.reply, (t - 45) / 2.5),
 		portoState: t < 47.5 ? ("streaming" as const) : ("complete" as const),
 		following: following && (family || budget),

--- a/apps/videos/src/styles.css
+++ b/apps/videos/src/styles.css
@@ -1,0 +1,689 @@
+* {
+	box-sizing: border-box;
+}
+body {
+	margin: 0;
+	background: hsl(0 0% 4%);
+	color: hsl(40 6% 93%);
+	font-family: Geist, Arial, sans-serif;
+}
+.stage {
+	background-color: hsl(0 0% 4%);
+	color: hsl(40 6% 93%);
+	font-family: Geist, Arial, sans-serif;
+	width: 1920px;
+	height: 1080px;
+	position: relative;
+	overflow: hidden;
+	background-image: radial-gradient(
+		ellipse at 50% 70%,
+		#171717 0,
+		transparent 65%
+	);
+}
+.brand {
+	position: absolute;
+	left: 84px;
+	top: 52px;
+	font-size: 26px;
+	font-weight: 700;
+	letter-spacing: -1px;
+}
+.eyebrow {
+	position: absolute;
+	right: 84px;
+	top: 61px;
+	color: #999793;
+	font-size: 15px;
+	letter-spacing: 3px;
+}
+h1 {
+	position: absolute;
+	left: 84px;
+	top: 115px;
+	margin: 0;
+	font-size: 64px;
+	letter-spacing: -2.5px;
+	font-weight: 600;
+}
+.subtitle {
+	position: absolute;
+	left: 88px;
+	top: 205px;
+	color: #a6a39f;
+	font-size: 25px;
+}
+.chat {
+	position: absolute;
+	left: 320px;
+	top: 288px;
+	width: 1120px;
+	height: 646px;
+	background: hsl(0 0% 8%);
+	border: 1px solid hsl(0 0% 16%);
+	border-radius: 24px;
+	box-shadow: 0 30px 100px #0005;
+	overflow: hidden;
+}
+.chatheader {
+	height: 76px;
+	border-bottom: 1px solid #292929;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0 32px;
+	font-size: 23px;
+	font-weight: 600;
+}
+.pathlabel {
+	font-size: 17px;
+	color: #91baff;
+	background: #20314a;
+	border-radius: 20px;
+	padding: 9px 15px;
+}
+.messages {
+	padding: 28px 32px;
+}
+.user {
+	max-width: 80%;
+	margin-left: auto;
+}
+.role {
+	text-align: right;
+	color: #b7b5b1;
+	font-size: 17px;
+	margin-bottom: 12px;
+}
+.bubble {
+	padding: 20px 24px;
+	background: hsl(0 0% 12%);
+	border: 1px solid #393939;
+	border-radius: 20px 20px 4px 20px;
+	font-size: 25px;
+	line-height: 1.4;
+}
+.assistant {
+	margin-top: 34px;
+}
+.author {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	font-weight: 600;
+	font-size: 20px;
+}
+.avatar {
+	display: grid;
+	place-items: center;
+	width: 36px;
+	height: 36px;
+	background: #17332e;
+	border: 1px solid #2c6657;
+	border-radius: 11px;
+	color: #59d9bb;
+	font-size: 24px;
+}
+.answer {
+	margin: 16px 0 0 48px;
+	font-size: 25px;
+	line-height: 1.55;
+	white-space: pre-line;
+	max-width: 820px;
+	min-height: 0;
+}
+.status {
+	margin: 14px 0 0 48px;
+	display: flex;
+	align-items: center;
+	gap: 9px;
+	font-size: 17px;
+	color: #89a095;
+}
+.composer {
+	position: absolute;
+	bottom: 24px;
+	left: 32px;
+	right: 32px;
+	border: 1px solid #303030;
+	border-radius: 15px;
+	color: #8c8985;
+	font-size: 20px;
+	padding: 19px 22px;
+	background: #171717;
+}
+.composer span {
+	float: right;
+	color: #b4cbef;
+}
+.map {
+	position: absolute;
+	left: 1100px;
+	top: 308px;
+	width: 735px;
+	height: 600px;
+	opacity: 0;
+}
+.maptitle {
+	font-size: 18px;
+	letter-spacing: 2px;
+	color: #999793;
+	text-align: center;
+}
+.node {
+	position: absolute;
+	background: hsl(0 0% 8%);
+	border: 2px solid #353535;
+	border-radius: 16px;
+	padding: 20px 22px;
+	width: 282px;
+	height: 142px;
+}
+.node.selected {
+	border-color: #83b2ff;
+	background: #1a2b42;
+	box-shadow: 0 0 0 5px #82b2ff15;
+}
+.node.live {
+	border-color: #59d9bb;
+	box-shadow: 0 0 0 4px #59d9bb20;
+}
+.streamProgress {
+	position: absolute;
+	left: 22px;
+	right: 22px;
+	bottom: 10px;
+	height: 3px;
+	background: #59d9bb20;
+	border-radius: 3px;
+	overflow: hidden;
+}
+.streamProgress i {
+	display: block;
+	height: 100%;
+	background: #59d9bb;
+}
+.node.selected.live {
+	box-shadow: 0 0 0 5px #82b2ff50;
+}
+.root {
+	top: 85px;
+	left: 224px;
+	height: 86px;
+	font-size: 20px;
+	width: 286px;
+	text-align: center;
+	line-height: 1.5;
+}
+.nodetitle {
+	font-size: 25px;
+	margin-bottom: 14px;
+	font-weight: 600;
+}
+.nodestatus {
+	display: flex;
+	align-items: center;
+	gap: 9px;
+	font-size: 18px;
+	color: #87a397;
+}
+.badge {
+	position: absolute;
+	top: -32px;
+	left: 16px;
+	font-size: 15px;
+	color: #a8caff;
+}
+.ring {
+	width: 18px;
+	height: 18px;
+	border: 2px solid #264f46;
+	border-top-color: #59d9bb;
+	border-right-color: #59d9bb;
+	border-radius: 50%;
+	display: inline-block;
+}
+.live .nodestatus {
+	color: #59d9bb;
+}
+.count {
+	position: absolute;
+	bottom: 16px;
+	left: 22px;
+	color: #999793;
+	font-size: 16px;
+	font-variant-numeric: tabular-nums;
+}
+.mapnote {
+	position: absolute;
+	top: 515px;
+	left: 0;
+	width: 100%;
+	text-align: center;
+	font-size: 23px;
+	color: #aaa7a2;
+}
+.footer {
+	position: absolute;
+	bottom: 38px;
+	left: 84px;
+	font-size: 14px;
+	letter-spacing: 1.4px;
+	color: #85827e;
+}
+.url {
+	position: absolute;
+	bottom: 35px;
+	right: 84px;
+	font-size: 20px;
+	color: #bbb8b3;
+}
+.progress {
+	position: absolute;
+	left: 84px;
+	right: 84px;
+	bottom: 0;
+	height: 4px;
+	background: #22333e;
+}
+.progress i {
+	display: block;
+	height: 100%;
+	background: hsl(40 6% 93%);
+}
+.outro {
+	position: absolute;
+	inset: 0;
+	background: hsl(0 0% 4%);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-direction: column;
+	opacity: 0;
+}
+.outro .glyph {
+	font-size: 90px;
+	color: hsl(40 6% 93%);
+	margin-bottom: 38px;
+}
+.outro h2 {
+	font-size: 74px;
+	letter-spacing: -3px;
+	margin: 0 0 25px;
+}
+.outro p {
+	font-size: 31px;
+	color: #b7b5b1;
+	margin: 0 0 58px;
+}
+.outro strong {
+	font-size: 28px;
+	color: hsl(40 6% 93%);
+	font-weight: 400;
+}
+
+.package {
+	position: absolute;
+	inset: 0;
+	z-index: 8;
+	background: radial-gradient(ellipse at center, #191919, hsl(0 0% 4%) 70%);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-direction: column;
+}
+.package .kicker {
+	font-size: 24px;
+	color: hsl(40 6% 93%);
+	margin-bottom: 26px;
+	letter-spacing: 3px;
+}
+.package h2 {
+	font-size: 76px;
+	letter-spacing: -4px;
+	margin: 0 0 26px;
+}
+.package p {
+	font-size: 34px;
+	color: #b7b5b1;
+	margin: 0;
+}
+.package code,
+.outro code {
+	font-family: "Geist Mono", monospace;
+	font-size: 32px;
+	background: #171717;
+	border: 1px solid #353535;
+	border-radius: 14px;
+	padding: 24px 32px;
+	margin-top: 40px;
+	color: hsl(40 6% 93%);
+}
+.package small {
+	margin-top: 26px;
+	color: #999793;
+	font-size: 20px;
+}
+.stop {
+	position: absolute;
+	right: 32px;
+	bottom: 104px;
+	color: #ffd095;
+	border: 1px solid #9e7851;
+	border-radius: 9px;
+	background: #382a1d;
+	padding: 11px 17px;
+	font-size: 18px;
+}
+.node.stopped {
+	border-color: #b58a56;
+}
+.node.stopped .nodestatus {
+	color: #f3ba6a;
+}
+.outro {
+	z-index: 9;
+}
+.outro p {
+	margin-bottom: 0;
+}
+.outro strong {
+	margin-top: 32px;
+}
+.answer {
+	font-size: 24px;
+	line-height: 1.45;
+}
+.eyebrow {
+	letter-spacing: 1px;
+}
+
+button {
+	font-family: inherit;
+}
+.brand {
+	display: flex;
+	align-items: center;
+	gap: 14px;
+	font-weight: 600;
+}
+.brand img {
+	width: 32px;
+	height: 34px;
+}
+.avatar {
+	background: #202020;
+	border-color: #353535;
+}
+.avatar img {
+	width: 25px;
+	height: 27px;
+}
+.glyph img {
+	width: 88px;
+	height: 93px;
+}
+.package .kicker {
+	display: flex;
+	align-items: center;
+	gap: 18px;
+}
+.kicker img {
+	width: 42px;
+	height: 45px;
+}
+.outro code,
+.package code {
+	font-size: 30px;
+}
+.outro h2 {
+	font-weight: 600;
+	font-size: 70px;
+}
+.package h2 {
+	font-weight: 600;
+}
+.subtitle {
+	font-size: 24px;
+}
+.count {
+	font-size: 14px;
+}
+.nodetitle {
+	font-size: 23px;
+}
+.nodestatus {
+	font-size: 17px;
+}
+.answer {
+	font-size: 24px;
+}
+.status {
+	color: #aaa7a2;
+}
+
+.followup {
+	position: absolute;
+	top: 355px;
+	left: 32px;
+	right: 32px;
+	display: none;
+}
+.followupUser {
+	width: fit-content;
+	max-width: 85%;
+	margin-left: auto;
+}
+.followupUser .role {
+	font-size: 15px;
+	margin-bottom: 6px;
+}
+.followupUser .bubble {
+	font-size: 22px;
+	padding: 12px 20px;
+}
+.followup .author {
+	margin-top: 16px;
+	font-size: 18px;
+}
+.followup .avatar {
+	width: 30px;
+	height: 30px;
+}
+.followup .avatar img {
+	width: 22px;
+	height: 24px;
+}
+.followupAnswer {
+	font-size: 21px;
+	line-height: 1.4;
+	margin: 8px 0 0 42px;
+}
+.followupStatus {
+	margin-left: auto;
+	font-size: 15px;
+	color: #59d9bb;
+}
+.followupNode {
+	position: absolute;
+	top: 514px;
+	left: 0;
+	width: 220px;
+	height: 103px;
+	border: 2px solid #383838;
+	background: #141414;
+	border-radius: 14px;
+	padding: 18px;
+}
+.followupNode .nodetitle {
+	font-size: 21px;
+	margin-bottom: 8px;
+}
+.followupNode.selected {
+	border-color: #83b2ff;
+	background: #1a2b42;
+	box-shadow: 0 0 0 5px #82b2ff15;
+}
+.budget {
+	left: 510px;
+}
+
+.root {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+.root span {
+	max-width: 200px;
+}
+
+.messageActions {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	color: #999793;
+	height: 28px;
+}
+.messageAction {
+	display: grid;
+	place-items: center;
+	width: 28px;
+	height: 28px;
+	border-radius: 6px;
+}
+.versionCount {
+	font-size: 16px;
+	font-variant-numeric: tabular-nums;
+	white-space: nowrap;
+}
+.promptActions {
+	position: absolute;
+	right: 32px;
+	top: 220px;
+}
+.replyActions {
+	margin: 4px 0 0 48px;
+}
+.followupPromptActions {
+	position: absolute;
+	right: 0;
+	top: 82px;
+}
+.followupReplyActions {
+	margin-left: 42px;
+}
+
+.regenerateAction {
+	position: relative;
+}
+.highlightAction {
+	background: #292929;
+	color: #eeece7;
+}
+.actionTooltip {
+	position: absolute;
+	bottom: 36px;
+	left: 0;
+	background: #eeece7;
+	color: #151515;
+	font-size: 15px;
+	white-space: nowrap;
+	padding: 8px 12px;
+	border-radius: 7px;
+}
+
+.assistantStatus,
+.followupStatus {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	margin-left: 10px;
+	font-size: 15px;
+	font-weight: 400;
+}
+.replyActions {
+	margin-top: 8px;
+}
+
+.demoStage {
+	position: absolute;
+	inset: 0;
+	transform: translateY(-70px);
+}
+.cursorLabel {
+	position: absolute;
+	z-index: 5;
+	padding: 8px 12px;
+	border-radius: 7px;
+	background: #eeece7;
+	color: #151515;
+	font-size: 15px;
+	white-space: nowrap;
+}
+
+.chat.following .messages > .user {
+	display: none;
+}
+.chat.following .messages > .assistant {
+	margin-top: 0;
+}
+.chat.following .followup {
+	top: 320px;
+}
+
+.highlightAction {
+	outline: 2px solid #83b2ff;
+	background: #234371;
+	color: #fff;
+	transform: scale(1.35);
+}
+
+.editingBubble {
+	border-color: #83b2ff;
+	box-shadow: 0 0 0 3px #83b2ff20;
+}
+.editCaret {
+	color: #83b2ff;
+}
+.editControls {
+	position: absolute;
+	right: 32px;
+	top: 244px;
+	display: flex;
+	gap: 18px;
+	align-items: center;
+	font-size: 18px;
+}
+.editControls button {
+	background: #83b2ff;
+	color: #101010;
+	border: 0;
+	border-radius: 8px;
+	padding: 8px 24px;
+	font-size: 18px;
+}
+.portoPrompt {
+	left: 485px;
+	top: 185px;
+	width: 230px;
+	height: 86px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	text-align: center;
+	font-size: 20px;
+}
+.portoReply {
+	left: 485px;
+	top: 375px;
+	width: 230px;
+}
+.preservedLabel {
+	position: absolute;
+	left: 0;
+	top: 525px;
+	width: 455px;
+	text-align: center;
+	color: #b7b5b1;
+	font-size: 21px;
+}


### PR DESCRIPTION
Add the approved 48-second illustrated Threads launch film as an editable native Remotion example. It demonstrates regenerating an answer, switching while another reply continues streaming, separate follow-ups, and editing the original prompt from Lisbon to Porto while preserving the Lisbon conversations.

Uses the private video foundation from #353. Scenario and deterministic frame state are separate from chat/tree presentation. Includes the script, message action choreography, representative frame capture command, and instructions for making the next ChatJS video. Simulated replies are labeled in the film. Generated media remains outside Git.

Validation: root lint and type checks; five state tests covering background streaming, branch follow-ups, editing, seeking, and caption timing; repeated-frame determinism; all 24 compared frames pixel-identical to the approved cut after extracting shared presentation components; full 1920×1080, 30fps render.

Preview: `bun run --cwd apps/videos studio`
Render: `bun run --cwd apps/videos render`

Base is #353 so this diff contains only the Threads example.

## Summary by Sourcery

Add the approved Threads launch film as an editable, deterministic native Remotion example.

New Features:
- Add a native Remotion Threads launch-film example demonstrating conversation branching, background streaming, follow-ups, and editing while preserving prior conversations.

Enhancements:
- Make the Threads film the default video render while retaining the brand card as an explicit alternative.
- Add deterministic story-state modeling, reusable chat/tree presentation, captions, cursor choreography, and local media assets for the illustrated walkthrough.

Build:
- Add Remotion commands for rendering the brand card, capturing representative stills, and running story unit tests.

Documentation:
- Document the Threads example, editing workflow, timeline, rendering commands, and verification guidance.

Tests:
- Add state tests covering background streaming, branch follow-ups, editing, prompt overrides, seeking, and presentation timing.
- Add representative still capture validation, including deterministic out-of-order frame comparisons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a 48-second ChatJS Threads launch film showcasing conversation branching, streaming responses, follow-ups, regeneration, and message editing.
  - Added a branded video composition with animated chat interactions, captions, progress indicators, and an outro.
  - Added support for rendering video stills for review and verification.
  - Preserved the existing brand video as a separate rendering option.

- **Documentation**
  - Added guidance for previewing, rendering, reviewing, and adapting the Threads launch film.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->