### PR TITLE
Make Threads demo selection and concurrent streaming visible

### DIFF
--- a/apps/site/.gitignore
+++ b/apps/site/.gitignore
@@ -1,2 +1,5 @@
 .next
 node_modules
+
+# Deterministic browser captures, uploaded to UI Verify
+/uiverify-screenshots/

--- a/apps/site/biome.jsonc
+++ b/apps/site/biome.jsonc
@@ -5,7 +5,7 @@
   },
   "css": {
     "parser": {
-      "cssModules": false
+      "cssModules": true
     },
     "linter": {
       "enabled": false

--- a/apps/site/components/thread-playground-model.ts
+++ b/apps/site/components/thread-playground-model.ts
@@ -136,6 +136,8 @@ function delay(ms: number, signal?: AbortSignal) {
   });
 }
 
+const RESPONSE_NUMBER_PATTERN = /\d+/;
+
 export class PlaygroundTransport implements ChatTransport<PlaygroundMessage> {
   sendMessages({
     abortSignal,
@@ -147,8 +149,13 @@ export class PlaygroundTransport implements ChatTransport<PlaygroundMessage> {
     const streamId = crypto.randomUUID();
     const userMessage = messages.at(-1);
     const prompt = userMessage ? getMessageText(userMessage) : "this branch";
-    const response = `${responseLabel}: I am streaming independently from "${prompt}". Select another node while I run, or start more responses from the same prompt.`;
+    const response = `${responseLabel}: Let’s explore "${prompt}". Start with a small release that people can try immediately. Show one clear workflow, collect feedback from real integrations, and use it to decide what to improve next. This response has its own stream: you can explore another branch, stop a sibling, or return here without losing any of this progress.`;
     const words = response.split(" ");
+    // Different cadences make independent streams easy to follow in the demo.
+    const responseNumber = Number(
+      responseLabel.match(RESPONSE_NUMBER_PATTERN)?.[0] ?? 1
+    );
+    const tokenDelay = 140 + (responseNumber % 3) * 35;
 
     return Promise.resolve(
       new ReadableStream<UIMessageChunk<PlaygroundMetadata>>({
@@ -165,7 +172,7 @@ export class PlaygroundTransport implements ChatTransport<PlaygroundMessage> {
             controller.enqueue({ id: "text", type: "text-start" });
 
             for (const [index, word] of words.entries()) {
-              await delay(55, abortSignal);
+              await delay(tokenDelay, abortSignal);
               controller.enqueue({
                 delta: index === 0 ? word : ` ${word}`,
                 id: "text",
@@ -236,7 +243,7 @@ export function buildTreeLayout({
         childColumns.length;
     }
 
-    positions.set(id, { depth, id, x: column * 172 + 92, y: depth * 104 + 54 });
+    positions.set(id, { depth, id, x: column * 164 + 92, y: depth * 122 + 64 });
     return column;
   }
 
@@ -246,9 +253,9 @@ export function buildTreeLayout({
   }
 
   return {
-    height: Math.max(420, (maxDepth + 1) * 104 + 48),
+    height: Math.max(420, (maxDepth + 1) * 122 + 48),
     nodes: [...positions.values()],
     positions,
-    width: Math.max(430, Math.max(1, nextLeaf - 1) * 172 + 184),
+    width: Math.max(430, Math.max(0, nextLeaf - 2) * 164 + 184),
   };
 }

--- a/apps/site/components/thread-showcase.module.css
+++ b/apps/site/components/thread-showcase.module.css
@@ -254,7 +254,7 @@
 .treeScroll {
   flex: 1;
   min-height: 0;
-  overflow: hidden;
+  overflow: auto;
   overscroll-behavior: contain;
   background-color: color-mix(in srgb, var(--secondary) 35%, var(--card));
   background-image: radial-gradient(

--- a/apps/site/components/thread-showcase.module.css
+++ b/apps/site/components/thread-showcase.module.css
@@ -1,0 +1,436 @@
+.playground {
+  --thread-blue: #2867dc;
+  --thread-teal: #087f70;
+  --thread-amber: #a15b0b;
+  margin-top: 3rem;
+  overflow: hidden;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: 0 24px 70px -30px #163c5133;
+}
+:global(.dark) .playground {
+  --thread-blue: #83b2ff;
+  --thread-teal: #59d9bb;
+  --thread-amber: #f3ba6a;
+}
+.playground button {
+  cursor: pointer;
+}
+.playground button:disabled {
+  cursor: not-allowed;
+}
+.playground button:focus-visible {
+  outline: 3px solid var(--thread-blue);
+  outline-offset: 4px;
+}
+.playgroundTitle {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+}
+.brandGlyph {
+  font-size: 26px;
+  color: var(--thread-teal);
+}
+.demoButton {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 10px 14px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--card);
+  background: var(--thread-blue);
+  border: 1px solid var(--thread-blue);
+  border-radius: 7px;
+  transition:
+    transform 0.2s,
+    opacity 0.2s;
+}
+.demoButton:hover {
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+.demoButton:disabled {
+  opacity: 0.4;
+}
+.responseStatus {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  min-height: 16px;
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  white-space: nowrap;
+}
+.responseStatus[data-state="streaming"],
+.responseStatus[data-state="submitted"] {
+  color: var(--thread-teal);
+}
+.responseStatus[data-state="stopped"] {
+  color: var(--thread-amber);
+}
+.responseStatus[data-state="error"] {
+  color: #dd4848;
+}
+.tokens {
+  margin-left: auto;
+  font-family: var(--font-geist-mono), monospace;
+  font-variant-numeric: tabular-nums;
+}
+.streamingRing {
+  display: inline-block;
+  flex-shrink: 0;
+  width: 13px;
+  height: 13px;
+  border: 2px solid color-mix(in srgb, var(--thread-teal) 22%, transparent);
+  border-top-color: var(--thread-teal);
+  border-right-color: var(--thread-teal);
+  border-radius: 50%;
+  animation: orbit 1.2s linear infinite;
+}
+.statusDot {
+  display: inline-block;
+  flex-shrink: 0;
+  width: 6px;
+  height: 6px;
+  margin: 0 3px;
+  background: currentColor;
+  border-radius: 50%;
+}
+.conversation {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  height: 43rem;
+}
+.viewingBadge {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  font-size: 10px;
+  color: var(--thread-blue);
+}
+.viewingBadge > span {
+  width: 6px;
+  height: 6px;
+  background: currentColor;
+  border-radius: 50%;
+}
+.transcript {
+  flex: 1;
+  min-height: 0;
+  padding: 24px;
+  overflow-y: auto;
+  scroll-padding: 24px;
+}
+.message {
+  position: relative;
+  min-width: 0;
+}
+.message + .message {
+  margin-top: 32px;
+}
+.messageAuthor {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  min-height: 28px;
+  margin-bottom: 8px;
+  font-size: 12px;
+  font-weight: 600;
+}
+.assistantAvatar {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  color: var(--thread-teal);
+  background: color-mix(in srgb, var(--thread-teal) 10%, var(--card));
+  border: 1px solid color-mix(in srgb, var(--thread-teal) 24%, transparent);
+  border-radius: 9px;
+}
+.currentTurn {
+  font-size: 9px;
+  font-weight: 500;
+  color: var(--thread-blue);
+}
+.userMessage {
+  width: fit-content;
+  max-width: 82%;
+  margin-left: auto;
+}
+.userMessage .messageAuthor {
+  justify-content: flex-end;
+}
+.userMessage .messageBody {
+  padding: 12px 16px;
+  background: color-mix(in srgb, var(--thread-blue) 8%, var(--secondary));
+  border: 1px solid color-mix(in srgb, var(--thread-blue) 12%, transparent);
+  border-radius: 18px 18px 4px 18px;
+}
+.userMessage[data-selected="true"] .messageBody {
+  border-color: var(--thread-blue);
+}
+.assistantMessage {
+  margin-right: 24px;
+}
+.assistantMessage .messageBody,
+.assistantMessage .messageActions,
+.assistantMessage > .responseStatus {
+  margin-left: 36px;
+}
+.assistantMessage > .responseStatus {
+  margin-top: 12px;
+}
+.messageActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+  min-height: 28px;
+  margin-top: 8px;
+}
+.userMessage .messageActions {
+  justify-content: flex-end;
+}
+@media (max-width: 640px) {
+  .transcript {
+    padding: 20px 16px;
+  }
+  .assistantMessage {
+    margin-right: 0;
+  }
+  .assistantMessage .messageBody,
+  .assistantMessage .messageActions,
+  .assistantMessage > .responseStatus {
+    margin-left: 0;
+  }
+}
+.branchButton {
+  display: inline-flex;
+  gap: 5px;
+  align-items: center;
+  height: 28px;
+  padding: 0 7px;
+  font-size: 10px;
+  color: var(--thread-blue);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+}
+.branchButton:hover {
+  background: color-mix(in srgb, var(--thread-blue) 8%, transparent);
+}
+.branchButton:disabled {
+  opacity: 0.4;
+}
+.composerContext {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  margin-bottom: 8px;
+  font-size: 10px;
+  color: var(--muted-foreground);
+}
+.composerContext strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 500;
+  color: var(--thread-blue);
+  white-space: nowrap;
+}
+.treePanel {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  height: 43rem;
+  border-left: 1px solid var(--border);
+}
+.treeScroll {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  overscroll-behavior: contain;
+  background-color: color-mix(in srgb, var(--secondary) 35%, var(--card));
+  background-image: radial-gradient(
+    color-mix(in srgb, var(--muted-foreground) 20%, transparent) 0.75px,
+    transparent 0.75px
+  );
+  background-size: 16px 16px;
+}
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+  padding: 10px 20px;
+  font-size: 10px;
+  color: var(--muted-foreground);
+  border-bottom: 1px solid var(--border);
+}
+.legend > span {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+}
+.legendSelected {
+  width: 14px;
+  height: 3px;
+  background: var(--thread-blue);
+  border-radius: 2px;
+}
+.edge {
+  stroke: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  stroke-width: 1.5;
+  transition: stroke 0.25s;
+}
+.selectedEdge {
+  stroke: var(--thread-blue);
+  stroke-width: 3;
+  transition: stroke 0.25s;
+}
+.treeNode {
+  position: absolute;
+  width: 146px;
+  height: 88px;
+  padding: 10px;
+  text-align: left;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  box-shadow: 0 3px 7px #00000006;
+  transform: translate(-50%, -50%);
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s,
+    background 0.2s;
+}
+.treeNode:hover {
+  border-color: var(--thread-blue);
+  box-shadow: 0 4px 12px #00000012;
+}
+.treeNode[data-path="true"] {
+  background: color-mix(in srgb, var(--thread-blue) 5%, var(--card));
+  border-color: color-mix(in srgb, var(--thread-blue) 50%, var(--border));
+}
+.treeNode[aria-pressed="true"] {
+  padding: 9px;
+  border: 2px solid var(--thread-blue);
+  box-shadow:
+    0 0 0 4px color-mix(in srgb, var(--thread-blue) 12%, transparent),
+    0 6px 18px #0000000d;
+}
+.treeNode[data-state="streaming"],
+.treeNode[data-state="submitted"] {
+  outline: 2px solid color-mix(in srgb, var(--thread-teal) 60%, transparent);
+  outline-offset: 4px;
+  animation: breathe 1.8s ease-in-out infinite;
+}
+.nodeTitle {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 10px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.assistantGlyph {
+  font-size: 15px;
+  line-height: 14px;
+  color: var(--thread-teal);
+}
+.nodePreview {
+  display: block;
+  margin: 7px 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 10px;
+  color: var(--muted-foreground);
+  white-space: nowrap;
+}
+.promptLabel {
+  font-size: 9px;
+  color: var(--muted-foreground);
+}
+.selectedFlag {
+  position: absolute;
+  top: -18px;
+  left: 7px;
+  display: flex;
+  gap: 3px;
+  align-items: center;
+  padding: 2px 6px;
+  font-size: 9px;
+  line-height: 13px;
+  color: var(--card);
+  background: var(--thread-blue);
+  border-radius: 4px 4px 0 0;
+}
+.mapHint {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: space-between;
+  padding: 10px 14px;
+  font-size: 10px;
+  color: var(--muted-foreground);
+  border-top: 1px solid var(--border);
+}
+.demoFooter {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 12px;
+  font-size: 10px;
+  color: var(--muted-foreground);
+}
+.demoFooter button {
+  display: flex;
+  flex-shrink: 0;
+  gap: 5px;
+  align-items: center;
+  cursor: pointer;
+}
+@keyframes orbit {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@keyframes breathe {
+  50% {
+    outline-color: var(--thread-teal);
+    outline-offset: 6px;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .playground *,
+  .playground *::before {
+    transition: none !important;
+    animation: none !important;
+  }
+}
+@media (max-width: 1023px) {
+  .treePanel {
+    height: 36rem;
+    border-top: 1px solid var(--border);
+    border-left: 0;
+  }
+}
+@media (max-width: 600px) {
+  .playgroundTitle {
+    font-size: 13px;
+  }
+  .legend {
+    gap: 10px;
+  }
+  .conversation {
+    height: 40rem;
+  }
+}

--- a/apps/site/components/thread-showcase.tsx
+++ b/apps/site/components/thread-showcase.tsx
@@ -9,28 +9,78 @@ import {
   Copy,
   GitBranch,
   Package,
+  Play,
+  RotateCcw,
   Send,
+  Sparkles,
   Square,
 } from "lucide-react";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   buildTreeLayout,
   initialTree,
-  type PlaygroundChat,
   type PlaygroundMessage,
   PlaygroundTransport,
+  type PlaygroundChat as ThreadChat,
 } from "./thread-playground-model";
+
+import styles from "./thread-showcase.module.css";
 
 const INSTALL_COMMAND =
   "bun add @chat-js/thread ai@^7.0.93 @ai-sdk/react@^4.0.96 react";
 const MAX_ACTIVE_RUNS = 8;
 
-const STATUS_CLASS = {
-  error: "text-red-600 dark:text-red-400",
-  ready: "text-emerald-600 dark:text-emerald-400",
-  streaming: "text-blue-600 dark:text-blue-400",
-  submitted: "text-amber-600 dark:text-amber-400",
-} as const;
+type PlaygroundChat = ThreadChat & { stoppedIds: ReadonlySet<string> };
+
+function responseState(chat: PlaygroundChat, message: PlaygroundMessage) {
+  if (message.role !== "assistant") {
+    return "complete";
+  }
+  const status = chat.tree.getRunForMessage(message.id)?.status;
+  if (status === "streaming" || status === "submitted") {
+    return status;
+  }
+  if (status === "error") {
+    return "error";
+  }
+  if (chat.stoppedIds.has(message.id)) {
+    return "stopped";
+  }
+  return "complete";
+}
+
+function ResponseStatus({
+  chat,
+  message,
+}: {
+  chat: PlaygroundChat;
+  message: PlaygroundMessage;
+}) {
+  const state = responseState(chat, message);
+  const live = state === "streaming" || state === "submitted";
+  const tokens = Math.ceil(getMessageText(message).length / 4);
+  return (
+    <span className={styles.responseStatus} data-state={state}>
+      <span
+        aria-hidden="true"
+        className={live ? styles.streamingRing : styles.statusDot}
+      />
+      <span>
+        {state === "submitted"
+          ? "Starting"
+          : state.charAt(0).toUpperCase() + state.slice(1)}
+      </span>
+      {message.role === "assistant" && (
+        <span
+          className={styles.tokens}
+          title="Estimated tokens: text length divided by four"
+        >
+          ≈{tokens} tok
+        </span>
+      )}
+    </span>
+  );
+}
 
 export function ThreadInstallCommand() {
   const [copied, setCopied] = useState(false);
@@ -90,26 +140,69 @@ function Conversation({
   playgroundError: string | null;
   responseCount: number;
 }) {
+  const transcript = useRef<HTMLDivElement>(null);
+  const followTranscript = useRef(true);
+  useEffect(() => {
+    const element = transcript.current;
+    if (!element) {
+      return;
+    }
+    const observer = new ResizeObserver(() => {
+      if (followTranscript.current) {
+        element.scrollTop = element.scrollHeight;
+      }
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+  const cursorId = chat.tree.cursorId;
+  const textLength = chat.messages.reduce(
+    (length, message) => length + getMessageText(message).length,
+    0
+  );
+  useEffect(() => {
+    if (textLength && followTranscript.current) {
+      transcript.current?.scrollTo({
+        top: transcript.current.scrollHeight,
+        behavior: "instant",
+      });
+    }
+  }, [textLength]);
+  useEffect(() => {
+    followTranscript.current = true;
+    if (cursorId) {
+      transcript.current?.scrollTo({
+        top: transcript.current.scrollHeight,
+        behavior: "instant",
+      });
+    }
+  }, [cursorId]);
+
   return (
-    <section className="flex h-[43rem] min-w-0 flex-col">
+    <section className={styles.conversation}>
       <header className="flex min-h-16 flex-wrap items-center justify-between gap-3 border-border border-b px-5 py-3">
         <div>
-          <p className="font-medium text-sm">Active conversation</p>
+          <p className="font-medium text-sm">Chat</p>
           <p className="font-mono text-[11px] text-muted-foreground">
-            messages = tree.getPath(cursorId)
+            {chat.tree.messagesById[chat.tree.cursorId ?? ""]?.metadata
+              ?.title ?? "Start a conversation"}
           </p>
         </div>
-        <div className="flex items-center gap-4 font-mono text-[10px]">
-          <span>{chat.messages.length} path nodes</span>
-          <span
-            className={`flex items-center gap-1.5 ${STATUS_CLASS[chat.status]}`}
-          >
-            <span className="size-1.5 rounded-full bg-current" /> {chat.status}
-          </span>
-        </div>
+        <span className={styles.viewingBadge}>
+          <span /> Viewing this path
+        </span>
       </header>
 
-      <div className="min-h-0 flex-1 space-y-5 overflow-y-auto p-5 sm:p-7">
+      <div
+        className={styles.transcript}
+        onScroll={(event) => {
+          const element = event.currentTarget;
+          followTranscript.current =
+            element.scrollHeight - element.scrollTop - element.clientHeight <
+            80;
+        }}
+        ref={transcript}
+      >
         {chat.messages.map((message) => {
           const isUser = message.role === "user";
           const siblings = chat.tree.getSiblings(message.id);
@@ -129,23 +222,30 @@ function Conversation({
 
           return (
             <article
-              className={
-                isUser
-                  ? "group ml-auto max-w-[82%] bg-foreground px-4 py-3 text-background"
-                  : "group max-w-[90%] border-foreground/20 border-l-2 px-4 py-1"
-              }
+              className={`${styles.message} ${isUser ? styles.userMessage : styles.assistantMessage}`}
+              data-selected={chat.tree.cursorId === message.id}
               key={message.id}
             >
-              <div className="mb-1 flex items-center gap-2 text-[10px] uppercase opacity-60">
-                <span>{message.role}</span>
-                <span className="font-mono normal-case">{message.id}</span>
+              <div className={styles.messageAuthor}>
+                {!isUser && (
+                  <span aria-hidden="true" className={styles.assistantAvatar}>
+                    <Sparkles size={14} />
+                  </span>
+                )}
+                <span>{isUser ? "You" : "Assistant"}</span>
+                {chat.tree.cursorId === message.id && (
+                  <span className={styles.currentTurn}>Selected</span>
+                )}
               </div>
-              <p className="whitespace-pre-wrap text-sm leading-6">
-                {getMessageText(message) || "Streaming..."}
-              </p>
-              <div className="mt-2 flex min-h-7 items-center gap-1 opacity-60 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+              <div className={styles.messageBody}>
+                <p className="whitespace-pre-wrap text-sm leading-6">
+                  {getMessageText(message) || "Streaming..."}
+                </p>
+              </div>
+              {!isUser && <ResponseStatus chat={chat} message={message} />}
+              <div className={styles.messageActions}>
                 <button
-                  className="inline-flex h-7 items-center gap-1.5 px-1 text-[11px] hover:bg-background/10 disabled:opacity-30"
+                  className={styles.branchButton}
                   disabled={chat.tree.activeRuns.length >= MAX_ACTIVE_RUNS}
                   onClick={async () => {
                     await onBranch(message.id);
@@ -153,7 +253,7 @@ function Conversation({
                   type="button"
                 >
                   <GitBranch className="size-3" />
-                  Branch here
+                  Branch from here
                 </button>
                 {hasSiblings ? (
                   <fieldset className="ml-auto flex items-center gap-0.5">
@@ -171,7 +271,7 @@ function Conversation({
                       <ChevronLeft className="size-3.5" />
                     </button>
                     <span className="min-w-8 text-center font-mono text-[10px]">
-                      {siblingIndex + 1}/{siblings.length}
+                      Branch {siblingIndex + 1} / {siblings.length}
                     </span>
                     <button
                       aria-label={`Next branch for ${message.id}`}
@@ -198,12 +298,19 @@ function Conversation({
           await onSend();
         }}
       >
-        <div className="border border-border focus-within:border-foreground/40">
+        <p className={styles.composerContext}>
+          <GitBranch size={12} /> Continuing from{" "}
+          <strong>
+            {chat.tree.messagesById[chat.tree.cursorId ?? ""]?.metadata
+              ?.title ?? "the beginning"}
+          </strong>
+        </p>
+        <div className="rounded-lg border border-border focus-within:border-foreground/40">
           <textarea
             aria-label="Message this branch"
             className="block min-h-16 w-full resize-none bg-transparent px-3 py-3 text-sm outline-none"
             onChange={(event) => onDraftChange(event.target.value)}
-            placeholder={`Continue from ${chat.tree.cursorId ?? "root"}`}
+            placeholder="Message this branch…"
             rows={2}
             value={draft}
           />
@@ -229,7 +336,7 @@ function Conversation({
             <div className="flex items-center gap-1.5">
               <button
                 aria-label="Stop selected response"
-                className="h-8 px-2 text-muted-foreground text-xs hover:bg-secondary hover:text-foreground disabled:opacity-30"
+                className="h-8 rounded-md px-2 text-muted-foreground text-xs hover:bg-secondary hover:text-foreground disabled:opacity-30"
                 disabled={
                   chat.status !== "submitted" && chat.status !== "streaming"
                 }
@@ -253,7 +360,7 @@ function Conversation({
                 aria-label={`Send message with ${responseCount} ${
                   responseCount === 1 ? "response" : "responses"
                 }`}
-                className="grid size-8 place-items-center bg-primary text-primary-foreground disabled:opacity-40"
+                className="grid size-8 place-items-center rounded-md bg-primary text-primary-foreground disabled:opacity-40"
                 disabled={
                   !draft.trim() ||
                   chat.tree.activeRuns.length + responseCount > MAX_ACTIVE_RUNS
@@ -287,12 +394,42 @@ function TreeCanvas({ chat }: { chat: PlaygroundChat }) {
     [chat.tree.childrenByParentId, chat.tree.rootIds]
   );
   const activeIds = new Set(chat.messages.map((message) => message.id));
+  const canvas = useRef<HTMLDivElement>(null);
+  const [viewportSize, setViewportSize] = useState({ width: 0, height: 0 });
+  useEffect(() => {
+    const viewport = canvas.current;
+    if (!viewport) {
+      return;
+    }
+    const observer = new ResizeObserver(() =>
+      setViewportSize({
+        width: viewport.clientWidth,
+        height: viewport.clientHeight,
+      })
+    );
+    observer.observe(viewport);
+    return () => observer.disconnect();
+  }, []);
+  const scale = viewportSize.width
+    ? Math.min(
+        1,
+        (viewportSize.width - 24) / layout.width,
+        (viewportSize.height - 24) / layout.height
+      )
+    : 1;
 
   return (
-    <div className="min-h-0 flex-1 overflow-auto">
+    <div className={styles.treeScroll} ref={canvas}>
       <div
         className="relative"
-        style={{ height: layout.height, width: layout.width }}
+        style={{
+          height: layout.height,
+          width: layout.width,
+          transform: `scale(${scale})`,
+          transformOrigin: "top left",
+          left: Math.max(12, (viewportSize.width - layout.width * scale) / 2),
+          top: 12,
+        }}
       >
         <svg
           aria-hidden="true"
@@ -309,7 +446,10 @@ function TreeCanvas({ chat }: { chat: PlaygroundChat }) {
               }
               return (
                 <path
-                  d={`M${node.x} ${node.y + 25} V${node.y + 52} H${child.x} V${child.y - 25}`}
+                  className={
+                    activeIds.has(childId) ? styles.selectedEdge : styles.edge
+                  }
+                  d={`M${node.x} ${node.y + 43} C${node.x} ${node.y + 65}, ${child.x} ${child.y - 65}, ${child.x} ${child.y - 43}`}
                   fill="none"
                   key={`${node.id}-${childId}`}
                   stroke="currentColor"
@@ -324,40 +464,45 @@ function TreeCanvas({ chat }: { chat: PlaygroundChat }) {
           if (!message) {
             return null;
           }
-          const run = chat.tree.getRunForMessage(node.id);
           const isActive = activeIds.has(node.id);
           const isCursor = chat.tree.cursorId === node.id;
-          let nodeClass =
-            "border-border bg-card/90 text-muted-foreground hover:border-foreground/40 hover:text-foreground";
-          if (isActive) {
-            nodeClass = "border-foreground/30 bg-card text-foreground";
-          }
-          if (isCursor) {
-            nodeClass = "border-foreground bg-foreground text-background";
-          }
+          const state = responseState(chat, message);
 
           return (
             <button
-              className={`absolute w-36 -translate-x-1/2 -translate-y-1/2 border px-2.5 py-2 text-left shadow-sm transition-colors ${nodeClass}`}
+              aria-pressed={isCursor}
+              className={styles.treeNode}
+              data-node-id={node.id}
+              data-path={isActive}
+              data-state={state}
               key={node.id}
               onClick={() => chat.tree.setCursor(node.id)}
               style={{ left: node.x, top: node.y }}
               type="button"
             >
-              <span className="flex items-center justify-between gap-2">
-                <span className="truncate font-medium text-[10px] uppercase">
-                  {message.role}
+              {isCursor && (
+                <span className={styles.selectedFlag}>
+                  <Check size={10} /> Selected
                 </span>
-                <span className="shrink-0 font-mono text-[9px] opacity-60">
-                  {run?.status ?? "ready"}
+              )}
+              <span className={styles.nodeTitle}>
+                {message.role === "user" ? (
+                  <GitBranch size={12} />
+                ) : (
+                  <span className={styles.assistantGlyph}>✦</span>
+                )}
+                {message.metadata?.title ?? message.role}
+              </span>
+              <span className={styles.nodePreview}>
+                {getMessageText(message) || "Waiting for first token…"}
+              </span>
+              {message.role === "assistant" ? (
+                <ResponseStatus chat={chat} message={message} />
+              ) : (
+                <span className={styles.promptLabel}>
+                  Prompt{isActive ? " · on selected path" : ""}
                 </span>
-              </span>
-              <span className="mt-1 block truncate text-[11px]">
-                {getMessageText(message) || "Streaming..."}
-              </span>
-              <span className="mt-1 block font-mono text-[9px] opacity-55">
-                {node.id} · {getMessageText(message).length} chars
-              </span>
+              )}
             </button>
           );
         })}
@@ -366,7 +511,7 @@ function TreeCanvas({ chat }: { chat: PlaygroundChat }) {
   );
 }
 
-export function ThreadPlayground() {
+function PlaygroundSession() {
   const [draft, setDraft] = useState("");
   const [playgroundError, setPlaygroundError] = useState<string | null>(null);
   const [responseCount, setResponseCount] = useState(1);
@@ -377,12 +522,19 @@ export function ThreadPlayground() {
     return `msg_${idCounter.current}`;
   }
 
-  const chat = useThread<PlaygroundMessage>({
+  const [stoppedIds, setStoppedIds] = useState<ReadonlySet<string>>(new Set());
+  const thread = useThread<PlaygroundMessage>({
+    onFinish: ({ message, isAbort }) => {
+      if (isAbort) {
+        setStoppedIds((previous) => new Set([...previous, message.id]));
+      }
+    },
     concurrency: { maxActiveRuns: MAX_ACTIVE_RUNS },
     generateId: generateMessageId,
     initialTree,
     transport: new PlaygroundTransport(),
   });
+  const chat: PlaygroundChat = { ...thread, stoppedIds };
 
   function messageInput(text: string, title: string, messageId?: string) {
     return {
@@ -396,8 +548,7 @@ export function ThreadPlayground() {
     };
   }
 
-  async function sendDraft() {
-    const text = draft.trim();
+  async function sendDraft(text = draft.trim(), count = responseCount) {
     if (!text) {
       return;
     }
@@ -409,22 +560,20 @@ export function ThreadPlayground() {
         request: {
           body: {
             responseLabel:
-              responseCount === 1
-                ? "Assistant reply"
-                : `Response 1 of ${responseCount}`,
+              count === 1 ? "Assistant reply" : `Response 1 of ${count}`,
           },
         },
       });
       setDraft("");
 
       const siblingRuns: ThreadRunHandle[] = await Promise.all(
-        Array.from({ length: responseCount - 1 }, (_, index) =>
+        Array.from({ length: count - 1 }, (_, index) =>
           chat.tree.startRun({
             follow: false,
             from: userMessageId,
             request: {
               body: {
-                responseLabel: `Response ${index + 2} of ${responseCount}`,
+                responseLabel: `Response ${index + 2} of ${count}`,
               },
             },
           })
@@ -470,43 +619,84 @@ export function ThreadPlayground() {
   }
 
   return (
-    <div className="mt-12 overflow-hidden border border-border bg-card shadow-2xl shadow-foreground/5">
+    <div className={styles.playground} data-testid="thread-playground">
       <div className="flex min-h-16 flex-wrap items-center justify-between gap-3 border-border border-b px-4 py-3">
         <div>
-          <p className="font-medium text-sm">useThread playground</p>
+          <p className={styles.playgroundTitle}>
+            <span className={styles.brandGlyph}>✦</span> One conversation. Every
+            possibility.
+          </p>
           <p className="text-muted-foreground text-xs">
             Real tree state with simulated local streams
           </p>
         </div>
-        <p className="font-mono text-[10px] text-muted-foreground">
-          {chat.tree.activeRuns.length} active runs
-        </p>
+        <button
+          className={styles.demoButton}
+          disabled={chat.tree.activeRuns.length + 3 > MAX_ACTIVE_RUNS}
+          onClick={() => sendDraft("How should we launch this?", 3)}
+          type="button"
+        >
+          <Play fill="currentColor" size={13} /> Run 3 replies
+        </button>
       </div>
 
-      <div className="grid lg:grid-cols-[minmax(0,0.95fr)_minmax(28rem,1.05fr)]">
+      <div className="grid lg:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)]">
         <Conversation
           chat={chat}
           draft={draft}
           onBranch={branchFrom}
           onDraftChange={setDraft}
           onResponseCountChange={setResponseCount}
-          onSend={sendDraft}
+          onSend={() => sendDraft()}
           playgroundError={playgroundError}
           responseCount={responseCount}
         />
-        <aside className="flex h-[43rem] min-w-0 flex-col border-border border-t bg-muted/15 lg:border-t-0 lg:border-l">
+        <aside className={styles.treePanel}>
           <header className="flex min-h-16 items-center justify-between border-border border-b px-5 py-3">
             <div>
-              <p className="font-medium text-sm">Message tree</p>
+              <p className="font-medium text-sm">Conversation map</p>
               <p className="font-mono text-[11px] text-muted-foreground">
-                {Object.keys(chat.tree.messagesById).length} nodes ·{" "}
-                {chat.tree.activeRuns.length} active runs
+                Click a card to follow its path
               </p>
             </div>
-            <GitBranch className="size-4 text-muted-foreground" />
+            <span className={styles.viewingBadge}>
+              {chat.tree.activeRuns.length} streaming
+            </span>
           </header>
+          <div className={styles.legend}>
+            <span>
+              <i className={styles.legendSelected} /> Selected path
+            </span>
+            <span>
+              <i className={styles.streamingRing} /> Streaming
+            </span>
+            <span>
+              <i className={styles.statusDot} /> Complete
+            </span>
+          </div>
           <TreeCanvas chat={chat} />
+          <p className={styles.mapHint}>
+            Explore freely. Hidden branches keep streaming.{" "}
+            <span>Entire tree in view</span>
+          </p>
         </aside>
+      </div>
+    </div>
+  );
+}
+
+export function ThreadPlayground() {
+  const [session, setSession] = useState(0);
+  return (
+    <div>
+      <PlaygroundSession key={session} />
+      <div className={styles.demoFooter}>
+        <span>
+          Local simulation · ≈ token counts are estimates, not provider usage
+        </span>
+        <button onClick={() => setSession((value) => value + 1)} type="button">
+          <RotateCcw size={12} /> Reset demo
+        </button>
       </div>
     </div>
   );

--- a/apps/site/components/thread-showcase.tsx
+++ b/apps/site/components/thread-showcase.tsx
@@ -411,101 +411,112 @@ function TreeCanvas({ chat }: { chat: PlaygroundChat }) {
     return () => observer.disconnect();
   }, []);
   const scale = viewportSize.width
-    ? Math.min(
-        1,
-        (viewportSize.width - 24) / layout.width,
-        (viewportSize.height - 24) / layout.height
+    ? Math.max(
+        0.75,
+        Math.min(
+          1,
+          (viewportSize.width - 24) / layout.width,
+          (viewportSize.height - 24) / layout.height
+        )
       )
     : 1;
 
   return (
     <div className={styles.treeScroll} ref={canvas}>
       <div
-        className="relative"
         style={{
-          height: layout.height,
-          width: layout.width,
-          transform: `scale(${scale})`,
-          transformOrigin: "top left",
-          left: Math.max(12, (viewportSize.width - layout.width * scale) / 2),
-          top: 12,
+          position: "relative",
+          width: Math.max(viewportSize.width, layout.width * scale + 24),
+          height: layout.height * scale + 24,
         }}
       >
-        <svg
-          aria-hidden="true"
-          className="absolute inset-0 text-border"
-          height={layout.height}
-          width={layout.width}
+        <div
+          className="absolute"
+          style={{
+            height: layout.height,
+            width: layout.width,
+            transform: `scale(${scale})`,
+            transformOrigin: "top left",
+            left: Math.max(12, (viewportSize.width - layout.width * scale) / 2),
+            top: 12,
+          }}
         >
-          {layout.nodes.flatMap((node) => {
-            const children = chat.tree.childrenByParentId[node.id] ?? [];
-            return children.map((childId) => {
-              const child = layout.positions.get(childId);
-              if (!child) {
-                return null;
-              }
-              return (
-                <path
-                  className={
-                    activeIds.has(childId) ? styles.selectedEdge : styles.edge
-                  }
-                  d={`M${node.x} ${node.y + 43} C${node.x} ${node.y + 65}, ${child.x} ${child.y - 65}, ${child.x} ${child.y - 43}`}
-                  fill="none"
-                  key={`${node.id}-${childId}`}
-                  stroke="currentColor"
-                />
-              );
-            });
-          })}
-        </svg>
+          <svg
+            aria-hidden="true"
+            className="absolute inset-0 text-border"
+            height={layout.height}
+            width={layout.width}
+          >
+            {layout.nodes.flatMap((node) => {
+              const children = chat.tree.childrenByParentId[node.id] ?? [];
+              return children.map((childId) => {
+                const child = layout.positions.get(childId);
+                if (!child) {
+                  return null;
+                }
+                return (
+                  <path
+                    className={
+                      activeIds.has(childId) ? styles.selectedEdge : styles.edge
+                    }
+                    d={`M${node.x} ${node.y + 43} C${node.x} ${node.y + 65}, ${child.x} ${child.y - 65}, ${child.x} ${child.y - 43}`}
+                    fill="none"
+                    key={`${node.id}-${childId}`}
+                    stroke="currentColor"
+                  />
+                );
+              });
+            })}
+          </svg>
 
-        {layout.nodes.map((node) => {
-          const message = chat.tree.messagesById[node.id];
-          if (!message) {
-            return null;
-          }
-          const isActive = activeIds.has(node.id);
-          const isCursor = chat.tree.cursorId === node.id;
-          const state = responseState(chat, message);
+          {layout.nodes.map((node) => {
+            const message = chat.tree.messagesById[node.id];
+            if (!message) {
+              return null;
+            }
+            const isActive = activeIds.has(node.id);
+            const isCursor = chat.tree.cursorId === node.id;
+            const state = responseState(chat, message);
 
-          return (
-            <button
-              aria-pressed={isCursor}
-              className={styles.treeNode}
-              data-node-id={node.id}
-              data-path={isActive}
-              data-state={state}
-              key={node.id}
-              onClick={() => chat.tree.setCursor(node.id)}
-              style={{ left: node.x, top: node.y }}
-              type="button"
-            >
-              {isCursor && (
-                <span className={styles.selectedFlag}>
-                  <Check size={10} /> Selected
-                </span>
-              )}
-              <span className={styles.nodeTitle}>
-                {message.role === "user" ? (
-                  <GitBranch size={12} />
-                ) : (
-                  <span className={styles.assistantGlyph}>✦</span>
+            return (
+              <button
+                aria-pressed={isCursor}
+                className={styles.treeNode}
+                data-node-id={node.id}
+                data-path={isActive}
+                data-state={state}
+                key={node.id}
+                onClick={() => chat.tree.setCursor(node.id)}
+                style={{ left: node.x, top: node.y }}
+                type="button"
+              >
+                {isCursor && (
+                  <span className={styles.selectedFlag}>
+                    <Check size={10} /> Selected
+                  </span>
                 )}
-                {message.metadata?.title ?? message.role}
-              </span>
-              <span className={styles.nodePreview}>
-                {getMessageText(message) || "Waiting for first token…"}
-              </span>
-              {message.role === "assistant" ? (
-                <ResponseStatus chat={chat} message={message} />
-              ) : (
-                <span className={styles.promptLabel}>
-                  Prompt{isActive ? " · on selected path" : ""}
+                <span className={styles.nodeTitle}>
+                  {message.role === "user" ? (
+                    <GitBranch size={12} />
+                  ) : (
+                    <span className={styles.assistantGlyph}>✦</span>
+                  )}
+                  {message.metadata?.title ?? message.role}
                 </span>
-              )}
-            </button>
-          );
-        })}
+                <span className={styles.nodePreview}>
+                  {getMessageText(message) || "Waiting for first token…"}
+                </span>
+                {message.role === "assistant" ? (
+                  <ResponseStatus chat={chat} message={message} />
+                ) : (
+                  <span className={styles.promptLabel}>
+                    Prompt{isActive ? " · on selected path" : ""}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
       </div>
     </div>
   );
@@ -677,7 +688,7 @@ function PlaygroundSession() {
           <TreeCanvas chat={chat} />
           <p className={styles.mapHint}>
             Explore freely. Hidden branches keep streaming.{" "}
-            <span>Entire tree in view</span>
+            <span>Scroll to explore the tree</span>
           </p>
         </aside>
       </div>

--- a/apps/site/tests/thread-playground.visual.ts
+++ b/apps/site/tests/thread-playground.visual.ts
@@ -1,11 +1,14 @@
 import assert from "node:assert/strict";
 import { mkdir } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { chromium, type Page } from "playwright";
 
 // Run through `bun test:visual:site` with `bun dev:site` already running.
 // Frozen time and reduced motion make stream states and captures repeatable.
 const browser = await chromium.launch();
-const output = new URL("../uiverify-screenshots/", import.meta.url).pathname;
+const output = fileURLToPath(
+  new URL("../uiverify-screenshots/", import.meta.url)
+);
 await mkdir(output, { recursive: true });
 const errors: string[] = [];
 
@@ -14,7 +17,7 @@ async function capture(page: Page, name: string) {
     animations: "disabled",
     style:
       "header:has(> nav), nextjs-portal { visibility: hidden !important; }",
-    path: `${output}/${name}.png`,
+    path: `${output}${name}.png`,
   });
 }
 
@@ -189,6 +192,22 @@ try {
     ),
     true,
     "No page-level horizontal overflow on mobile"
+  );
+  const mobileBranch = monitor
+    .getByRole("button")
+    .filter({ hasText: "Response 3 of 3" });
+  await mobileBranch.scrollIntoViewIfNeeded();
+  assert.ok(
+    await mobileBranch.evaluate(
+      (element) => element.getBoundingClientRect().width >= 100
+    ),
+    "Mobile branch targets remain readable"
+  );
+  await mobileBranch.click();
+  assert.equal(
+    await mobileBranch.getAttribute("aria-pressed"),
+    "true",
+    "Offscreen mobile branches remain reachable"
   );
   await capture(page, "threads-mobile-live");
   assert.deepEqual(errors, [], "No browser runtime errors");

--- a/apps/site/tests/thread-playground.visual.ts
+++ b/apps/site/tests/thread-playground.visual.ts
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import { mkdir } from "node:fs/promises";
+import { chromium, type Page } from "playwright";
+
+// Run through `bun test:visual:site` with `bun dev:site` already running.
+// Frozen time and reduced motion make stream states and captures repeatable.
+const browser = await chromium.launch();
+const output = new URL("../uiverify-screenshots/", import.meta.url).pathname;
+await mkdir(output, { recursive: true });
+const errors: string[] = [];
+
+async function capture(page: Page, name: string) {
+  await page.getByTestId("thread-playground").screenshot({
+    animations: "disabled",
+    style:
+      "header:has(> nav), nextjs-portal { visibility: hidden !important; }",
+    path: `${output}/${name}.png`,
+  });
+}
+
+try {
+  const page = await browser.newPage({
+    viewport: { width: 1440, height: 1200 },
+    reducedMotion: "reduce",
+  });
+  page.on("pageerror", (error) => errors.push(error.message));
+  await page.clock.install({ time: new Date("2026-01-01T00:00:00Z") });
+  await page.goto(`http://localhost:${process.env.PORT}/threads`);
+  await page.getByTestId("thread-playground").waitFor();
+  await page.evaluate(() => document.fonts.ready);
+  await page.clock.pauseAt(new Date("2026-01-01T00:01:00Z"));
+  const initialHeight = await page
+    .getByTestId("thread-playground")
+    .evaluate((element) => element.clientHeight);
+  assert.equal(
+    await page
+      .locator("article")
+      .filter({ hasText: "You" })
+      .first()
+      .evaluate((user) => {
+        const assistant = user.nextElementSibling;
+        return (
+          assistant !== null &&
+          user.getBoundingClientRect().left >
+            assistant.getBoundingClientRect().left + 40
+        );
+      }),
+    true,
+    "User bubbles are visibly inset from assistant replies"
+  );
+  await capture(page, "threads-initial");
+
+  await page.getByRole("button", { name: "Run 3 replies" }).click();
+  const monitor = page.locator("aside");
+  await page.waitForFunction(
+    () =>
+      document.querySelectorAll('[data-node-id][data-state="streaming"]')
+        .length === 3
+  );
+  await page.clock.runFor(1800);
+  assert.equal(
+    await page
+      .getByTestId("thread-playground")
+      .evaluate((element) => element.clientHeight),
+    initialHeight,
+    "Starting three replies does not shift the map or conversation"
+  );
+  const first = monitor
+    .getByRole("button")
+    .filter({ hasText: "Response 1 of 3" });
+  const second = monitor
+    .getByRole("button")
+    .filter({ hasText: "Response 2 of 3" });
+  const before = await second.textContent();
+  await page.getByRole("button", { name: "Stop selected response" }).click();
+  await page.waitForFunction(() =>
+    document.querySelector('[data-node-id][data-state="stopped"]')
+  );
+  const stoppedText = await first.textContent();
+  await page.clock.runFor(1200);
+  assert.match(stoppedText ?? "", /Stopped/);
+  assert.equal(
+    await first.textContent(),
+    stoppedText,
+    "Stopped response stops growing"
+  );
+  assert.notEqual(
+    await second.textContent(),
+    before,
+    "Other responses keep growing"
+  );
+  assert.equal(
+    await page.locator('[data-node-id][data-state="streaming"]').count(),
+    2
+  );
+  assert.equal(
+    await page.getByRole("region", { name: "Response activity" }).count(),
+    0
+  );
+  assert.equal(
+    await page.locator("aside").evaluate((panel) => {
+      const viewport =
+        panel.querySelector("[data-node-id]")?.parentElement?.parentElement;
+      if (!viewport) {
+        return false;
+      }
+      const bounds = viewport.getBoundingClientRect();
+      return [...panel.querySelectorAll("[data-node-id]")].every((node) => {
+        const box = node.getBoundingClientRect();
+        return (
+          box.left >= bounds.left &&
+          box.right <= bounds.right &&
+          box.top >= bounds.top &&
+          box.bottom <= bounds.bottom
+        );
+      });
+    }),
+    true,
+    "Every node fits inside the map viewport"
+  );
+  await capture(page, "threads-live-and-stopped");
+
+  await second.click();
+  assert.equal(await second.getAttribute("aria-pressed"), "true");
+  assert.match(
+    (await page.locator('[data-node-id][aria-pressed="true"]').textContent()) ??
+      "",
+    /Response 2 of 3/
+  );
+  await page.locator('[data-node-id="msg_02"]').click();
+  assert.equal(
+    await page.locator('[data-node-id="msg_02"]').getAttribute("aria-pressed"),
+    "true"
+  );
+  assert.equal(
+    await page
+      .getByRole("button", { name: "Stop selected response" })
+      .isDisabled(),
+    true
+  );
+  await page.clock.runFor(20_000);
+  assert.equal(
+    await page.locator('[data-node-id][data-state="streaming"]').count(),
+    0
+  );
+  assert.match((await second.textContent()) ?? "", /Complete/);
+  await second.click();
+  await capture(page, "threads-complete");
+
+  // Branch creation must preserve the original branch and select the new reply.
+  const originalCount = await page.locator("[data-node-id]").count();
+  await page
+    .getByRole("button", { name: "Branch from here", exact: true })
+    .last()
+    .click();
+  await page.waitForFunction(
+    (count) => document.querySelectorAll("[data-node-id]").length === count + 2,
+    originalCount
+  );
+  await page.getByRole("button", { name: "Stop all responses" }).click();
+  await page.waitForFunction(
+    () =>
+      document.querySelectorAll('[data-node-id][data-state="streaming"]')
+        .length === 0
+  );
+  assert.match(
+    (await page.locator('[data-node-id][aria-pressed="true"]').textContent()) ??
+      "",
+    /Branch response/
+  );
+  await capture(page, "threads-new-branch");
+
+  await page.getByRole("button", { name: "Reset demo" }).click();
+  assert.equal(await page.locator("[data-node-id]").count(), 7);
+  await page.getByRole("button", { name: "Run 3 replies" }).click();
+  await page.waitForFunction(
+    () =>
+      document.querySelectorAll('[data-node-id][data-state="streaming"]')
+        .length === 3
+  );
+  await page.clock.runFor(1800);
+  await page.evaluate(() => document.documentElement.classList.add("dark"));
+  await capture(page, "threads-dark-live");
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.evaluate(() => document.documentElement.classList.remove("dark"));
+  assert.equal(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= window.innerWidth
+    ),
+    true,
+    "No page-level horizontal overflow on mobile"
+  );
+  await capture(page, "threads-mobile-live");
+  assert.deepEqual(errors, [], "No browser runtime errors");
+  console.log(
+    `Threads interaction checks passed; six deterministic captures in ${output}`
+  );
+} finally {
+  await browser.close();
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
 		"release": "changeset publish",
 		"dev:electron": "dotenv -e .env.worktree.local -e .env.local -- bun run worktree-env electron -- turbo run electron:dev --filter=@chat-js/electron",
 		"build:electron": "turbo run electron:build --filter=@chat-js/electron",
-		"dist:electron": "turbo run electron:make --filter=@chat-js/electron"
+		"dist:electron": "turbo run electron:make --filter=@chat-js/electron",
+		"test:visual:site": "dotenv -e .env.worktree.local -e .env.local -- bun run worktree-env site -- bun apps/site/tests/thread-playground.visual.ts"
 	},
 	"overrides": {
 		"//@better-auth/core": "Pinned because @better-auth/electron and other @better-auth/* packages declare a strict peerDependency on @better-auth/core@1.5.6. Do not remove without auditing all @better-auth/* peer ranges.",


### PR DESCRIPTION
Make the interactive Threads playground easier to read when multiple replies run concurrently. Separate the chat transcript from the conversation map, distinguish user and assistant messages, and make the selected branch and streaming/stopped/completed states visible with path styling, rings, and live estimated token counts.

Keep navigation and branch actions tied to the displayed conversation and fit the tree within its panel. Add deterministic interaction checks and desktop, dark-mode, and mobile captures.

This independent PR changes only the site demo and its verification command. It does not import the private video workspace. It retains the existing interactive scenario; the illustrated Lisbon/Porto launch film is in #354.

Validation: root lint and type checks; `bun run test:visual:site` against this checkout's local site passed and generated six deterministic captures. Remote UI Verify upload was not run.

## Summary by Sourcery

Make concurrent Threads demo activity and branch selection easy to understand at a glance.

New Features:
- Make the Threads playground clearly distinguish chat messages, conversation branches, selected paths, and concurrent response states.
- Show live response status and estimated token counts for streaming, stopped, and completed replies.
- Add responsive conversation-map presentation with branch navigation and controls tied to the displayed conversation.

Enhancements:
- Improve transcript behavior by keeping the active conversation in view while allowing users to explore other branches.
- Fit the conversation tree within its panel across desktop and mobile layouts, including dark-mode styling.

Build:
- Add a root command for running the site’s deterministic visual verification.

Tests:
- Add deterministic interaction checks and six visual captures covering initial, concurrent, stopped, completed, branched, dark-mode, and mobile states.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously, the Threads demo mixed transcript and tree state, making concurrent replies hard to follow. It now separates the chat and conversation map, highlights the selected path, and shows streaming, stopped, and completed replies with estimated token counts.

- Keeps navigation and branch actions tied to the displayed conversation, with the tree fitting its panel and mobile branch targets remaining readable and reachable.
- Adds deterministic interaction checks and six desktop, dark-mode, and mobile captures through `test:visual:site`; captures use the ignored `apps/site/uiverify-screenshots/` path.
- Changes only the site demo and its verification, retaining the existing interactive scenario without importing the private video workspace.

**Verification**

- Root lint, type checks, and `bun run test:visual:site` pass locally; remote UI Verify upload was not run.

<sup>Written for commit 329ce1e77d577a274c956931feac48bea0598dee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an interactive thread playground with simultaneous replies, streaming progress, response status, and controls to stop individual responses.
  - Added branching conversation navigation with selectable paths, visual tree mapping, and branch creation.
  - Added controls to run three replies and reset the playground session.

- **Improvements**
  - Enhanced conversation visualization with clearer message styling, path highlighting, legends, and animated streaming indicators.
  - Added responsive layouts, mobile support, dark-mode presentation, and reduced-motion support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->