### PR TITLE
Simplify thread installation and refresh architecture docs

### DIFF
--- a/.changeset/simple-thread-install.md
+++ b/.changeset/simple-thread-install.md
@@ -1,0 +1,5 @@
+---
+"@chat-js/thread": patch
+---
+
+Install AI SDK dependencies with the thread package so consumers only need `bun add @chat-js/thread`. Keep React as a shared peer and clarify architecture, editing, and controller ownership.

--- a/apps/docs/blume.config.ts
+++ b/apps/docs/blume.config.ts
@@ -73,6 +73,7 @@ export default defineConfig({
     ],
   },
   redirects: [
+    { from: "/core/use-thread", to: "/threads" },
     { from: "/core/file-storage", to: "/storage" },
     { from: "/core/registry", to: "/registry" },
     { from: "/core/tool-registry", to: "/tools/overview" },
@@ -97,11 +98,11 @@ export default defineConfig({
         "/",
         "/quickstart",
         "/changelog",
+        "/threads",
         {
           label: "Core Concepts",
           items: [
             "/core/architecture",
-            "/core/use-thread",
             "/core/configuration",
             "/core/authentication",
             "/core/multi-model",

--- a/apps/docs/core/use-thread.mdx
+++ b/apps/docs/core/use-thread.mdx
@@ -14,8 +14,11 @@ move between branches while responses continue streaming.
 ## Install
 
 ```bash
-bun add @chat-js/thread ai @ai-sdk/react react
+bun add @chat-js/thread
 ```
+
+The package manages its AI SDK dependencies and uses your app's existing React
+instance (React 18 or newer).
 
 Replace the `useChat` import without changing your existing message list or
 composer:

--- a/apps/docs/e2e/docs-visual.browser.test.ts
+++ b/apps/docs/e2e/docs-visual.browser.test.ts
@@ -2,6 +2,7 @@ import { takeSnapshot } from "@uiverify/vitest";
 import { expect, test } from "vitest";
 
 const pages = [
+	{ name: "threads", path: "/docs/threads" },
   { name: "database", path: "/docs/reference/database" },
   { name: "redis", path: "/docs/reference/redis" },
   { name: "storage", path: "/docs/storage" },

--- a/apps/docs/features/branching.mdx
+++ b/apps/docs/features/branching.mdx
@@ -52,7 +52,7 @@ Messages are persisted with a parent message ID. Root messages have no parent.
 The client uses `useThread` to project the selected path and to keep each active
 assistant response attached to its own reserved node.
 
-See [useThread](../core/use-thread) for the tree, cursor, active-path, and run
+See [useThread](../threads) for the tree, cursor, active-path, and run
 model.
 
 ## Related

--- a/apps/docs/features/parallel-responses.mdx
+++ b/apps/docs/features/parallel-responses.mdx
@@ -66,6 +66,6 @@ responses remain available, including any that are still generating.
 
 ## Related
 
-- [useThread](../core/use-thread)
+- [useThread](../threads)
 - [Branching](./branching)
 - [Multi-Model Support](../core/multi-model)

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -112,4 +112,4 @@ npx @chat-js/cli@latest create my-app
 - [Streamdown](https://streamdown.ai/) - Markdown for AI streaming
 - [AI Elements](https://ai-sdk.dev/elements/overview) - AI-native Components
 - [AI SDK Tools](https://ai-sdk-tools.dev/) - Developer tools for AI SDK
-- [`@chat-js/thread`](./core/use-thread) - Branching conversations with a `useChat`-compatible interface
+- [`@chat-js/thread`](./threads) - Branching conversations with a `useChat`-compatible interface

--- a/apps/docs/threads.mdx
+++ b/apps/docs/threads.mdx
@@ -1,15 +1,19 @@
 ---
-title: "useThread"
-description: "Build branching AI conversations with a useChat-compatible interface"
+title: "Threads"
+description: "Add branching conversations and parallel responses to your AI SDK app with @chat-js/thread"
 ---
 
-`useThread` is the React interface to the `Thread` controller behind branching
-conversations in ChatJS. You keep the familiar AI SDK `useChat` interface for
-the selected conversation, while every message and response branch lives in a
-complete tree.
+`@chat-js/thread` is a standalone package for branching AI conversations.
+Use it in your existing app without installing the ChatJS starter.
+
+The React hook, `useThread`, keeps the familiar AI SDK `useChat` interface for
+the selected conversation and stores every branch in a complete message tree.
+The `Thread` controller provides the same tree and run controls outside React.
 
 Use it when you need to edit earlier messages, compare alternative replies, or
 move between branches while responses continue streaming.
+
+[Try the interactive demo](https://www.chatjs.dev/threads).
 
 ## Install
 
@@ -19,6 +23,11 @@ bun add @chat-js/thread
 
 The package manages its AI SDK dependencies and uses your app's existing React
 instance (React 18 or newer).
+
+## Use with React
+
+You need a React app and an AI SDK chat endpoint. Keep your existing transport
+and server route. The package manages conversation state, not model hosting.
 
 Replace the `useChat` import without changing your existing message list or
 composer:
@@ -76,7 +85,7 @@ await chat.sendMessage({
 });
 ```
 
-See [Branching](../features/branching) for the ChatJS user experience.
+See [Branching](./features/branching) for the ChatJS user experience.
 
 ## Run parallel responses
 
@@ -109,7 +118,7 @@ await Promise.all([
 stream write arrives. ChatJS uses this model for multiple replies from the same
 model and for comparisons across different models.
 
-See [Parallel Responses](../features/parallel-responses) for the product flow.
+See [Parallel Responses](./features/parallel-responses) for the product flow.
 
 ## Status and controls
 
@@ -157,5 +166,26 @@ const chat = useThread({
 The snapshot is `{ version: 1, cursorId, nodes }`. Runtime indexes, active
 requests, and run adapters are not persisted.
 
-The package README documents the complete interface, transport metadata, and
-`Thread` exports.
+## Use without React
+
+Import the controller from the core entry point:
+
+```ts
+import { Thread } from "@chat-js/thread";
+import { DefaultChatTransport } from "ai";
+
+const thread = new Thread({
+  transport: new DefaultChatTransport({ api: "/api/chat" }),
+});
+
+await thread.sendMessage({ text: "Plan a weekend in Lisbon" });
+const snapshot = thread.getSnapshot();
+```
+
+Use `subscribe()` to observe state changes and `stopAll()` to cancel active
+requests when your application no longer needs the controller.
+
+## Package reference
+
+The [package README](https://github.com/FranciscoMoretti/chat-js/tree/main/packages/thread)
+covers the full interface, transport metadata, and custom state adapters.

--- a/apps/site/app/threads/page.tsx
+++ b/apps/site/app/threads/page.tsx
@@ -140,9 +140,9 @@ export default function ThreadsPage() {
                   </a>
                   <a
                     className="inline-flex min-h-11 items-center gap-2 border-border border-b text-foreground/75 text-sm transition-colors hover:text-foreground"
-                    href={`${siteLinks.github}/tree/main/packages/thread`}
+                    href={`${siteLinks.docs}/threads`}
                   >
-                    Read the package
+                    Read the docs
                     <ArrowRight className="size-3.5" />
                   </a>
                 </div>
@@ -342,9 +342,9 @@ export default function ThreadsPage() {
             </div>
             <a
               className="inline-flex min-h-11 shrink-0 items-center gap-2 bg-primary px-5 font-medium text-primary-foreground text-sm transition-opacity hover:opacity-85"
-              href={`${siteLinks.github}/blob/main/packages/thread/ARCHITECTURE.md`}
+              href={`${siteLinks.docs}/threads`}
             >
-              Read the architecture
+              Read the docs
               <ArrowRight className="size-4" />
             </a>
           </div>

--- a/apps/site/components/thread-showcase.tsx
+++ b/apps/site/components/thread-showcase.tsx
@@ -26,8 +26,7 @@ import {
 
 import styles from "./thread-showcase.module.css";
 
-const INSTALL_COMMAND =
-  "bun add @chat-js/thread ai@^7.0.93 @ai-sdk/react@^4.0.96 react";
+const INSTALL_COMMAND = "bun add @chat-js/thread";
 const MAX_ACTIVE_RUNS = 8;
 
 type PlaygroundChat = ThreadChat & { stoppedIds: ReadonlySet<string> };

--- a/apps/site/tests/thread-playground.visual.ts
+++ b/apps/site/tests/thread-playground.visual.ts
@@ -32,6 +32,17 @@ try {
   await page.getByTestId("thread-playground").waitFor();
   await page.evaluate(() => document.fonts.ready);
   await page.clock.pauseAt(new Date("2026-01-01T00:01:00Z"));
+  const installCommand = page
+    .getByRole("button", { name: "Copy installation command" })
+    .locator("../..");
+  assert.equal(
+    await installCommand.locator("code").textContent(),
+    "$ bun add @chat-js/thread"
+  );
+  await installCommand.screenshot({
+    animations: "disabled",
+    path: `${output}threads-install.png`,
+  });
   const initialHeight = await page
     .getByTestId("thread-playground")
     .evaluate((element) => element.clientHeight);
@@ -212,7 +223,7 @@ try {
   await capture(page, "threads-mobile-live");
   assert.deepEqual(errors, [], "No browser runtime errors");
   console.log(
-    `Threads interaction checks passed; six deterministic captures in ${output}`
+    `Threads interaction checks passed; deterministic captures in ${output}`
   );
 } finally {
   await browser.close();

--- a/apps/site/tests/thread-playground.visual.ts
+++ b/apps/site/tests/thread-playground.visual.ts
@@ -32,6 +32,21 @@ try {
   await page.getByTestId("thread-playground").waitFor();
   await page.evaluate(() => document.fonts.ready);
   await page.clock.pauseAt(new Date("2026-01-01T00:01:00Z"));
+  const docsLinks = page.getByRole("link", { name: "Read the docs" });
+  assert.equal(await docsLinks.count(), 2);
+  for (const link of await docsLinks.all()) {
+    assert.equal(
+      await link.getAttribute("href"),
+      "https://chatjs.dev/docs/threads"
+    );
+  }
+  await docsLinks
+    .last()
+    .locator("..")
+    .screenshot({
+      animations: "disabled",
+      path: `${output}threads-docs-link.png`,
+    });
   const installCommand = page
     .getByRole("button", { name: "Copy installation command" })
     .locator("../..");

--- a/bun.lock
+++ b/bun.lock
@@ -313,23 +313,22 @@
     "packages/thread": {
       "name": "@chat-js/thread",
       "version": "0.1.0",
+      "dependencies": {
+        "@ai-sdk/react": "^4.0.96",
+        "ai": "^7.0.93",
+      },
       "devDependencies": {
-        "@ai-sdk/react": "4.0.96",
         "@types/bun": "^1.3.12",
         "@types/react": "19.2.7",
         "@types/react-test-renderer": "19.1.0",
-        "ai": "7.0.93",
         "react": "19.2.3",
         "react-test-renderer": "19.2.3",
         "typescript": "6.0.2",
       },
       "peerDependencies": {
-        "@ai-sdk/react": "^4.0.96",
-        "ai": "^7.0.93",
         "react": ">=18",
       },
       "optionalPeers": [
-        "@ai-sdk/react",
         "react",
       ],
     },

--- a/packages/thread/ARCHITECTURE.md
+++ b/packages/thread/ARCHITECTURE.md
@@ -133,9 +133,11 @@ if (threadRef.current === null) {
 
 The same `Thread` is retained while its identity inputs remain unchanged.
 Supplying a different external `thread` or a different defined `id` replaces
-the controller, including its state and active runs. Otherwise, callback
-wrappers read the latest React callbacks without replacing the retained
-controller.
+the controller, so the hook observes the replacement state and runs. This does
+not stop the previous controller's requests. Call `stopAll()` explicitly when abandoning an
+active controller. Otherwise, callback wrappers read the latest React callbacks without replacing the retained
+controller. Construction options such as transport and initial tree are retained.
+Changing those hook options alone does not recreate the controller.
 
 An existing `AbstractThread` can also be supplied. This includes both the
 default `Thread` and custom subclasses:
@@ -273,7 +275,9 @@ Tree mutations enforce these invariants:
 role as AI SDK's `Chat.id`, remains stable as messages are added, and is sent to
 the transport as `chatId` on every request.
 
-Within that conversation, each `message.id` identifies one immutable tree node.
+Within that conversation, each `message.id` identifies a stable tree node.
+Its content can change as streaming and tool updates arrive, while its identity
+and parent remain stable.
 Each run has a separate stable ID identifying its request lifecycle. A run is
 present while submitted even though no assistant message exists yet, then binds
 to the assistant ID produced by AI SDK's stream reducer. A message ID identifies
@@ -305,7 +309,6 @@ Every assistant response lifecycle has one `RunRecord`:
 
 ```ts
 type RunRecord<TMessage extends UIMessage> = {
-  aborted: boolean;
   chat: ThreadRunChat<TMessage>;
   error: Error | undefined;
   finished: Promise<void>;
@@ -384,7 +387,8 @@ The package does not define another transport protocol or manually parse
 `UIMessageChunk` values. A delegating transport ensures new and reconnected
 runs use the latest transport configured on `Thread`.
 
-Each request receives the selected linear path. `ChatRequestOptions` are passed
+Each request receives its owning run's linear path, even when the cursor selects
+a different branch. `ChatRequestOptions` are passed
 to the configured transport unchanged; tree controls never leak into the
 application request body.
 
@@ -435,7 +439,7 @@ another root. The cursor follows the replacement on its first write only when
 it still points to the regeneration target, so navigation during submission or
 streaming is not overwritten.
 
-AI SDK 6.0.244 and later initialize fresh response state for regeneration.
+The supported AI SDK 7 runtime initializes fresh response state for regeneration.
 This allows a response whose parent is also an assistant to regenerate without
 mutating that shared parent. For `[user, assistant A, assistant B]`, regenerating
 `assistant B` preserves both existing messages and creates a replacement sibling
@@ -550,6 +554,33 @@ useThread({
 `maxActiveRuns` limits the complete conversation. `maxActiveRunsPerMessage`
 limits assistant siblings generated from one user message. A rejected run does
 not leave an extra user message behind.
+
+## Editing Earlier Messages
+
+To preserve an original message and its descendants, select its parent and
+send the edited content with a new message ID. This creates a sibling user
+message and a new response branch. Passing an existing user message ID updates
+that node in place instead, preserving its original parent. Editing controls
+and the choice between replacing content and creating a branch belong to the UI.
+
+## Dependencies and Entry Points
+
+Install with `bun add @chat-js/thread`. The package declares `ai` and
+`@ai-sdk/react` as dependencies, so consumers do not need to repeat the supported
+SDK versions in their install command. `ai` supplies the runtime request engine.
+`@ai-sdk/react` supplies the `UseChatHelpers` type contract used by the adapter.
+The supported ranges live in `package.json`.
+
+React remains an optional peer dependency (React 18 or newer), so the React
+adapter shares the application's React instance. The core entry point has no
+React runtime imports. Dependency installation may still include React through
+the SDK adapter's peer requirements; runtime independence does not mean an
+installation without React-related packages.
+
+The build emits external-package ESM and TypeScript declarations for the core
+and `/react` entry points. The React entry includes `"use client"`. Bun and
+development export conditions point to source; ordinary Node and bundler
+consumers use `dist`.
 
 ## Package Boundary
 

--- a/packages/thread/README.md
+++ b/packages/thread/README.md
@@ -23,17 +23,13 @@ the core.
 
 ## Install
 
-For the headless core:
-
 ```bash
-bun add @chat-js/thread ai@^7.0.93
+bun add @chat-js/thread
 ```
 
-For React:
-
-```bash
-bun add @chat-js/thread ai@^7.0.93 @ai-sdk/react@^4.0.96 react
-```
+The package installs its AI SDK dependencies. In a React app, `useThread`
+uses your existing React instance (React 18 or newer). React is an optional
+peer for the headless entry point.
 
 ## Use
 

--- a/packages/thread/package.json
+++ b/packages/thread/package.json
@@ -54,29 +54,26 @@
 		"test:types": "tsc -p tsconfig.json --noEmit && bun run build"
 	},
 	"peerDependencies": {
-		"@ai-sdk/react": "^4.0.96",
-		"ai": "^7.0.93",
 		"react": ">=18"
 	},
 	"peerDependenciesMeta": {
-		"@ai-sdk/react": {
-			"optional": true
-		},
 		"react": {
 			"optional": true
 		}
 	},
 	"devDependencies": {
-		"@ai-sdk/react": "4.0.96",
 		"@types/bun": "^1.3.12",
 		"@types/react": "19.2.7",
 		"@types/react-test-renderer": "19.1.0",
-		"ai": "7.0.93",
 		"react": "19.2.3",
 		"react-test-renderer": "19.2.3",
 		"typescript": "6.0.2"
 	},
 	"engines": {
 		"node": ">=22"
+	},
+	"dependencies": {
+		"ai": "^7.0.93",
+		"@ai-sdk/react": "^4.0.96"
 	}
 }

--- a/packages/thread/test/package-smoke.test.ts
+++ b/packages/thread/test/package-smoke.test.ts
@@ -130,7 +130,6 @@ assert.throws(() => import.meta.resolve("@ai-sdk/react"), { code: "ERR_MODULE_NO
 			const reactChunk = reactSource.match(/from "(\.\/chunk-[^"]+\.js)"/)?.[1];
 
 			expect(packageMetadata.peerDependenciesMeta).toEqual({
-				"@ai-sdk/react": { optional: true },
 				react: { optional: true },
 			});
 			expect(reactSource.startsWith('"use client";')).toBeTrue();


### PR DESCRIPTION
Consumers currently have to copy versioned AI SDK dependencies into their install command. Declare `ai` and `@ai-sdk/react` as package dependencies so installation is simply `bun add @chat-js/thread`. React remains a shared optional peer. Update the demo, docs, README, and add a patch changeset.

Refresh the architecture document against the implementation: controller replacement does not cancel previous requests, requests retain their owning branch path, message content can change, and editing with a new ID creates a sibling branch. Remove the obsolete run field and document dependency and export boundaries.

Validation:
- `bun lint` and `bun test:types` pass.
- All 65 package tests pass in an isolated package copy.
- Packed tarball installs into an empty consumer with a single `bun add`; core and React imports resolve along with both SDK dependencies.
- Site interaction checks pass with no browser errors; reviewed the new installation command capture.

The initial workspace package test run encountered a local React/test-renderer hoisting mismatch. The isolated suite and clean consumer verification avoid that workspace resolution mismatch.

## Summary by Sourcery

Simplify @chat-js/thread installation and align its documentation with the current thread architecture.

Enhancements:
- Make @chat-js/thread installable with a single command by declaring the AI SDK packages as dependencies while keeping React optional.
- Refresh thread architecture and package documentation to reflect controller ownership, request paths, editable messages, branching behavior, dependency boundaries, and entry points.

Documentation:
- Update the docs site navigation, links, installation guidance, and standalone Threads documentation.

Tests:
- Extend package and site validation to cover the updated dependency metadata, installation command, documentation links, and thread showcase.

Chores:
- Add a patch changeset for the package installation and architecture documentation updates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consumers previously had to copy versioned AI SDK dependencies into their install command. Now `ai` and `@ai-sdk/react` are package dependencies, so installation is simply `bun add @chat-js/thread`. React remains an optional shared peer.

- Adds a dedicated Threads docs guide and redirects the old `useThread` page to it.
- Updates install commands in README, docs, and site showcase; site links now point to the docs guide instead of GitHub.
- Refreshes architecture doc: controller replacement does not cancel previous requests, requests retain their owning branch path, message content can change, editing with a new ID creates a sibling branch.
- Removes the obsolete `aborted` run field and documents dependency and export boundaries.
- Adds a patch changeset and updates package smoke test expectations.

<sup>Written for commit cde31cbf1524100ef8a8ddbb906dde6c5f77ea71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Install the thread package with a single `bun add `@chat-js/thread`` command.
  - Use thread functionality without React through the headless package entry point.
  - React remains optional for headless usage and supports existing React 18+ applications.

- **Documentation**
  - Added a dedicated Threads documentation section with updated navigation and redirects.
  - Expanded guidance on editing messages, architecture, dependencies, and entry points.
  - Updated the marketing site to link directly to the Threads documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->