### PR TITLE
Simplify useThread introduction snippets

### DIFF
--- a/apps/docs/threads.mdx
+++ b/apps/docs/threads.mdx
@@ -26,8 +26,9 @@ instance (React 18 or newer).
 
 ## Use with React
 
-You need a React app and an AI SDK chat endpoint. Keep your existing transport
-and server route. The package manages conversation state, not model hosting.
+You need a React app and an AI SDK chat endpoint at `/api/chat`.
+`useThread()` uses that endpoint by default, just like `useChat()`.
+Pass a `transport` option when you need a custom endpoint or request configuration.
 
 Replace the `useChat` import without changing your existing message list or
 composer:
@@ -36,8 +37,8 @@ composer:
 - import { useChat } from "@ai-sdk/react";
 + import { useThread } from "@chat-js/thread/react";
 
-- const chat = useChat({ transport });
-+ const chat = useThread({ transport });
+- const chat = useChat();
++ const chat = useThread();
 ```
 
 The top-level helpers remain compatible with `UseChatHelpers`, including

--- a/apps/site/app/threads/page.tsx
+++ b/apps/site/app/threads/page.tsx
@@ -171,11 +171,11 @@ export default function ThreadsPage() {
                     {"\n\n"}
                     <span className="text-muted-foreground">- </span>
                     <span className="text-foreground/55">
-                      const chat = useChat({"{ transport }"});
+                      const chat = useChat();
                     </span>
                     {"\n"}
                     <span className="text-foreground">
-                      + const chat = useThread({"{ transport }"});
+                      + const chat = useThread();
                     </span>
                     {"\n\n"}
                     <span className="text-foreground">chat.messages;</span>

--- a/apps/site/tests/thread-playground.visual.ts
+++ b/apps/site/tests/thread-playground.visual.ts
@@ -32,6 +32,15 @@ try {
   await page.getByTestId("thread-playground").waitFor();
   await page.evaluate(() => document.fonts.ready);
   await page.clock.pauseAt(new Date("2026-01-01T00:01:00Z"));
+  const intro = page.locator("main > section").first();
+  assert.match(
+    (await intro.locator("pre").textContent()) ?? "",
+    /useThread\(\)/
+  );
+  await intro.screenshot({
+    animations: "disabled",
+    path: `${output}threads-intro.png`,
+  });
   const docsLinks = page.getByRole("link", { name: "Read the docs" });
   assert.equal(await docsLinks.count(), 2);
   for (const link of await docsLinks.all()) {

--- a/packages/thread/README.md
+++ b/packages/thread/README.md
@@ -35,12 +35,9 @@ peer for the headless entry point.
 
 ```tsx
 import { useThread } from "@chat-js/thread/react";
-import { DefaultChatTransport } from "ai";
 
 function Conversation() {
-  const chat = useThread({
-    transport: new DefaultChatTransport({ api: "/api/chat" }),
-  });
+  const chat = useThread();
 
   return (
     <>
@@ -58,6 +55,9 @@ function Conversation() {
   );
 }
 ```
+
+`useThread()` uses AI SDK's default transport to call `/api/chat`. Pass a
+`transport` option for a custom endpoint or request configuration.
 
 Existing rendering and composer code can continue using:
 


### PR DESCRIPTION
Use useThread() without an explicit transport in the demo, docs introduction, and README. Explain that the default AI SDK transport calls /api/chat and custom request configuration can still use the transport option.

Validation: lint, type checks, site interaction and visual captures, and the Threads docs browser capture pass.

## Summary by Sourcery

Simplify Threads onboarding examples by using the default chat transport and clarify custom transport usage.

Enhancements:
- Simplify Threads examples by using `useThread()` with its default `/api/chat` transport and document when to provide a custom transport.

Documentation:
- Update the Threads introduction and README to explain the default transport and custom transport configuration.

Tests:
- Add visual validation and a screenshot for the Threads introduction snippet.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the introductory `useThread()` examples to use the default AI SDK chat transport instead of requiring an explicit one.

- The demo, docs, and `packages/thread/README.md` now show `useThread()` without a transport.
- The default transport calls `/api/chat`, matching `useChat()`.
- A custom `transport` option remains available for custom endpoints or request configuration.
- The thread playground visual test now covers the intro snippet and captures a screenshot.

<sup>Written for commit 41eefac45b6cf817ed82c1054ffd7020b0ddecfa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that `useThread()` and `useChat()` use the `/api/chat` endpoint by default.
  - Updated examples to omit unnecessary transport configuration.
  - Documented how to provide a custom endpoint or request settings through the `transport` option.
  - Refreshed React, site, and package usage guidance to reflect the simplified setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->