### PR TITLE
chore(chat): clean MCP client and OAuth lint rules

### DIFF
--- a/apps/chat/lib/ai/mcp/mcp-client.ts
+++ b/apps/chat/lib/ai/mcp/mcp-client.ts
@@ -62,22 +62,23 @@ export class MCPClient {
     const baseUrl = getBaseUrl();
 
     this.oauthProvider = new McpOAuthClientProvider({
-      mcpConnectorId: this.id,
-      serverUrl: this.serverConfig.url,
       clientMetadata: {
         client_name: `${config.appPrefix}-${this.name}`,
         grant_types: ["authorization_code", "refresh_token"],
-        response_types: ["code"],
-        token_endpoint_auth_method: "none", // PKCE
-        scope: "mcp:tools",
         redirect_uris: [`${baseUrl}/api/mcp/oauth/callback`],
+        response_types: ["code"],
+        scope: "mcp:tools",
         software_id: config.appPrefix,
         software_version: "1.0.0",
+        // PKCE
+        token_endpoint_auth_method: "none",
       },
+      mcpConnectorId: this.id,
       onRedirectToAuthorization: (authorizationUrl: URL) => {
         this.authorizationUrl = authorizationUrl;
         throw new OAuthAuthorizationRequiredError(authorizationUrl);
       },
+      serverUrl: this.serverConfig.url,
     });
   }
 
@@ -115,10 +116,10 @@ export class MCPClient {
       // AI SDK handles 401 internally and calls auth() with the provider
       this.client = await createMCPClient({
         transport: {
+          authProvider: this.oauthProvider,
+          headers: this.serverConfig.headers,
           type: this.serverConfig.type,
           url: this.serverConfig.url,
-          headers: this.serverConfig.headers,
-          authProvider: this.oauthProvider,
         },
       });
 
@@ -129,7 +130,7 @@ export class MCPClient {
       if (error instanceof OAuthAuthorizationRequiredError) {
         this._status = "authorizing";
         log.info(
-          { connectorId: this.id, authUrl: error.authorizationUrl.toString() },
+          { authUrl: error.authorizationUrl.toString(), connectorId: this.id },
           "OAuth authorization required"
         );
         return;
@@ -151,23 +152,23 @@ export class MCPClient {
   }> {
     // If already connected, return current status
     if (this.status === "connected" && this.client) {
-      return { status: "connected", needsAuth: false };
+      return { needsAuth: false, status: "connected" };
     }
 
     // If already in authorizing state, return that
     if (this.authorizationUrl) {
-      return { status: "authorizing", needsAuth: true };
+      return { needsAuth: true, status: "authorizing" };
     }
 
     try {
       await this.connect();
       // Check if OAuth is required (authorizationUrl gets set during connect)
       if (this.authorizationUrl) {
-        return { status: "authorizing", needsAuth: true };
+        return { needsAuth: true, status: "authorizing" };
       }
       return {
-        status: this.client ? "connected" : "disconnected",
         needsAuth: false,
+        status: this.client ? "connected" : "disconnected",
       };
     } catch (error) {
       const errorMessage =
@@ -187,14 +188,14 @@ export class MCPClient {
       ) {
         this._status = "incompatible";
         return {
-          status: "incompatible",
-          needsAuth: false,
           error:
             "Server requires pre-configured OAuth credentials (does not support dynamic client registration)",
+          needsAuth: false,
+          status: "incompatible",
         };
       }
 
-      return { status: "disconnected", needsAuth: false, error: errorMessage };
+      return { error: errorMessage, needsAuth: false, status: "disconnected" };
     }
   }
 
@@ -207,8 +208,8 @@ export class MCPClient {
 
     // Use the auth function from @ai-sdk/mcp to complete the OAuth flow
     await auth(this.oauthProvider, {
-      serverUrl: this.serverConfig.url,
       authorizationCode: code,
+      serverUrl: this.serverConfig.url,
     });
 
     this.authorizationUrl = undefined;
@@ -272,7 +273,7 @@ export class MCPClient {
     try {
       await this.client?.close();
     } catch (error) {
-      log.error({ error, connectorId: this.id }, "Error closing MCP client");
+      log.error({ connectorId: this.id, error }, "Error closing MCP client");
     }
     this.client = undefined;
     this._status = "disconnected";
@@ -308,7 +309,7 @@ const clientsMap = new Map<string, MCPClient>();
 /**
  * Get or create an MCP client for a connector.
  */
-export function getOrCreateMcpClient({
+export const getOrCreateMcpClient = ({
   id,
   name,
   url,
@@ -320,40 +321,38 @@ export function getOrCreateMcpClient({
   url: string;
   type: "http" | "sse";
   headers?: Record<string, string>;
-}): MCPClient {
+}): MCPClient => {
   let client = clientsMap.get(id);
 
   if (!client) {
-    client = new MCPClient(id, name, { url, type, headers });
+    client = new MCPClient(id, name, { headers, type, url });
     clientsMap.set(id, client);
   }
 
   return client;
-}
+};
 
 /**
  * Remove an MCP client from the cache and close it.
  */
-export async function removeMcpClient(id: string): Promise<void> {
+export const removeMcpClient = async (id: string): Promise<void> => {
   const client = clientsMap.get(id);
   if (client) {
     await client.close();
     clientsMap.delete(id);
   }
-}
+};
 
 /**
  * Get an existing MCP client by ID.
  */
-function _getMcpClient(id: string): MCPClient | undefined {
-  return clientsMap.get(id);
-}
+const _getMcpClient = (id: string): MCPClient | undefined => clientsMap.get(id);
 
 /**
  * Create a fresh MCP client for OAuth callback handling.
  * Does NOT use the cache - creates a new instance to avoid state conflicts.
  */
-export function createMcpClientForCallback({
+export const createMcpClientForCallback = ({
   id,
   name,
   url,
@@ -365,6 +364,4 @@ export function createMcpClientForCallback({
   url: string;
   type: "http" | "sse";
   headers?: Record<string, string>;
-}): MCPClient {
-  return new MCPClient(id, name, { url, type, headers });
-}
+}): MCPClient => new MCPClient(id, name, { headers, type, url });

--- a/apps/chat/lib/ai/mcp/mcp-client.ts
+++ b/apps/chat/lib/ai/mcp/mcp-client.ts
@@ -13,10 +13,8 @@ import { createModuleLogger } from "@/lib/logger";
 import { getBaseUrl } from "@/lib/url";
 
 import { invalidateAllMcpCaches } from "./cache";
-import {
-  McpOAuthClientProvider,
-  OAuthAuthorizationRequiredError,
-} from "./mcp-oauth-provider";
+import { McpOAuthClientProvider } from "./mcp-oauth-provider";
+import { OAuthAuthorizationRequiredError } from "./oauth-authorization-required-error";
 
 const log = createModuleLogger("mcp-client");
 

--- a/apps/chat/lib/ai/mcp/mcp-oauth-provider.ts
+++ b/apps/chat/lib/ai/mcp/mcp-oauth-provider.ts
@@ -20,8 +20,6 @@ import type { OAuthClientInformationFull } from "@/lib/db/mcp-queries";
 import type { McpOAuthSession } from "@/lib/db/schema";
 import { createModuleLogger } from "@/lib/logger";
 
-export { OAuthAuthorizationRequiredError } from "./oauth-authorization-required-error";
-
 const log = createModuleLogger("mcp-oauth-provider");
 
 /**

--- a/apps/chat/lib/ai/mcp/mcp-oauth-provider.ts
+++ b/apps/chat/lib/ai/mcp/mcp-oauth-provider.ts
@@ -20,21 +20,9 @@ import type { OAuthClientInformationFull } from "@/lib/db/mcp-queries";
 import type { McpOAuthSession } from "@/lib/db/schema";
 import { createModuleLogger } from "@/lib/logger";
 
+export { OAuthAuthorizationRequiredError } from "./oauth-authorization-required-error";
+
 const log = createModuleLogger("mcp-oauth-provider");
-
-/**
- * Custom error thrown when OAuth authorization is required.
- * The client should catch this and redirect the user to the authorization URL.
- */
-export class OAuthAuthorizationRequiredError extends Error {
-  authorizationUrl: URL;
-
-  constructor(authorizationUrl: URL) {
-    super("OAuth user authorization required");
-    this.name = "OAuthAuthorizationRequiredError";
-    this.authorizationUrl = authorizationUrl;
-  }
-}
 
 /**
  * PostgreSQL-backed OAuth client provider for MCP.
@@ -52,7 +40,8 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
     serverUrl: string;
     clientMetadata: OAuthClientMetadata;
     onRedirectToAuthorization: (authUrl: URL) => Promise<void>;
-    state?: string; // Optional: adopt existing state (for callback reconciliation)
+    // Optional: adopt existing state for callback reconciliation.
+    state?: string;
   };
   private saveClientInformationPromise: Promise<void> | null = null;
 
@@ -61,7 +50,8 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
     serverUrl: string;
     clientMetadata: OAuthClientMetadata;
     onRedirectToAuthorization: (authUrl: URL) => Promise<void>;
-    state?: string; // Optional: adopt existing state (for callback reconciliation)
+    // Optional: adopt existing state for callback reconciliation.
+    state?: string;
   }) {
     this.config = config;
   }
@@ -164,9 +154,9 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
       ) {
         log.warn(
           {
-            state: authData.state,
-            savedRedirectUri: clientInfo.redirect_uris[0],
             currentRedirectUri: this.redirectUrl,
+            savedRedirectUri: clientInfo.redirect_uris[0],
+            state: authData.state,
           },
           "clientInformation: redirect URI mismatch, invalidating session"
         );
@@ -175,11 +165,10 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
         }
         this.cachedAuthData = undefined;
         this.initialized = false;
-        return;
+      } else {
+        return clientInfo;
       }
-      return clientInfo;
     }
-    return;
   }
 
   async saveClientInformation(
@@ -204,16 +193,17 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
       };
     }
 
-    this.saveClientInformationPromise = setOAuthClientInfoOnceByState({
-      state: this.currentOAuthState,
-      clientInfo: clientCredentials,
-    })
-      .then((session) => {
+    this.saveClientInformationPromise = (async () => {
+      try {
+        const session = await setOAuthClientInfoOnceByState({
+          clientInfo: clientCredentials,
+          state: this.currentOAuthState,
+        });
         this.cachedAuthData = session;
-      })
-      .finally(() => {
+      } finally {
         this.saveClientInformationPromise = null;
-      });
+      }
+    })();
     await this.saveClientInformationPromise;
   }
 
@@ -224,8 +214,8 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
 
   async saveTokens(tokens: OAuthTokens): Promise<void> {
     this.cachedAuthData = await saveTokensAndCleanup({
-      state: this.currentOAuthState,
       mcpConnectorId: this.config.mcpConnectorId,
+      state: this.currentOAuthState,
       tokens,
     });
   }
@@ -258,9 +248,9 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
     if (existingVerifier) {
       log.info(
         {
-          state: this.currentOAuthState,
           existingVerifierPrefix: existingVerifier.slice(0, 10),
           newVerifierPrefix: pkceVerifier.slice(0, 10),
+          state: this.currentOAuthState,
         },
         "saveCodeVerifier: SKIPPING - verifier already exists"
       );
@@ -270,8 +260,8 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
 
     log.info(
       {
-        state: this.currentOAuthState,
         codeVerifierPrefix: pkceVerifier.slice(0, 10),
+        state: this.currentOAuthState,
       },
       "saveCodeVerifier: saving first verifier"
     );
@@ -285,16 +275,17 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
     }
 
     // Serialize and make the DB write immutable (DB-side also guards against overwrite).
-    this.saveCodeVerifierPromise = setOAuthCodeVerifierOnceByState({
-      state: this.currentOAuthState,
-      codeVerifier: pkceVerifier,
-    })
-      .then((session) => {
+    this.saveCodeVerifierPromise = (async () => {
+      try {
+        const session = await setOAuthCodeVerifierOnceByState({
+          codeVerifier: pkceVerifier,
+          state: this.currentOAuthState,
+        });
         this.cachedAuthData = session;
-      })
-      .finally(() => {
+      } finally {
         this.saveCodeVerifierPromise = null;
-      });
+      }
+    })();
     await this.saveCodeVerifierPromise;
   }
 
@@ -302,9 +293,9 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
     const authData = await this.getAuthData();
     log.info(
       {
-        state: this.currentOAuthState,
-        hasCodeVerifier: !!authData?.codeVerifier,
         codeVerifierPrefix: authData?.codeVerifier?.slice(0, 10),
+        hasCodeVerifier: !!authData?.codeVerifier,
+        state: this.currentOAuthState,
       },
       "codeVerifier called"
     );
@@ -338,9 +329,9 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
     if (session.mcpConnectorId !== this.config.mcpConnectorId) {
       log.warn(
         {
-          state,
-          sessionConnectorId: session.mcpConnectorId,
           expectedConnectorId: this.config.mcpConnectorId,
+          sessionConnectorId: session.mcpConnectorId,
+          state,
         },
         "adoptState: connector ID mismatch"
       );
@@ -348,12 +339,12 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
     }
     log.info(
       {
-        state,
-        previousState: this.currentOAuthState,
-        wasInitialized: this.initialized,
-        hasCodeVerifier: !!session.codeVerifier,
         hasClientInfo: !!session.clientInfo,
+        hasCodeVerifier: !!session.codeVerifier,
         hasTokens: !!session.tokens,
+        previousState: this.currentOAuthState,
+        state,
+        wasInitialized: this.initialized,
       },
       "adoptState: adopting session (overriding previous state if any)"
     );

--- a/apps/chat/lib/ai/mcp/oauth-authorization-required-error.ts
+++ b/apps/chat/lib/ai/mcp/oauth-authorization-required-error.ts
@@ -1,0 +1,12 @@
+/**
+ * Signals that OAuth authorization must be completed before the MCP client can continue.
+ */
+export class OAuthAuthorizationRequiredError extends Error {
+  authorizationUrl: URL;
+
+  constructor(authorizationUrl: URL) {
+    super("OAuth user authorization required");
+    this.name = "OAuthAuthorizationRequiredError";
+    this.authorizationUrl = authorizationUrl;
+  }
+}

--- a/apps/chat/oxlint-baseline.json
+++ b/apps/chat/oxlint-baseline.json
@@ -225,7 +225,6 @@
         "lib/ai/core-chat-agent.ts",
         "lib/ai/errors.ts",
         "lib/ai/eval-agent.ts",
-        "lib/ai/mcp/mcp-client.ts",
         "lib/anonymous-session-client.ts",
         "lib/app-chat-runtime.ts",
         "lib/artifacts/code/client.tsx",
@@ -427,7 +426,7 @@
       }
     },
     {
-      "files": ["lib/ai/mcp/mcp-oauth-provider.ts", "lib/ai/text-splitter.ts"],
+      "files": ["lib/ai/text-splitter.ts"],
       "rules": {
         "max-classes-per-file": "off"
       }
@@ -492,8 +491,6 @@
         "components/multimodal-input.tsx",
         "components/part/text-message-part.tsx",
         "lib/ai/eval-agent.ts",
-        "lib/ai/mcp/mcp-client.ts",
-        "lib/ai/mcp/mcp-oauth-provider.ts",
         "lib/ai/token-utils.test.ts",
         "lib/auth.ts",
         "lib/credits/cost-accumulator.ts",
@@ -613,11 +610,7 @@
       }
     },
     {
-      "files": [
-        "components/anonymous-session-init.tsx",
-        "lib/ai/mcp/mcp-oauth-provider.ts",
-        "lib/db/queries.ts"
-      ],
+      "files": ["components/anonymous-session-init.tsx", "lib/db/queries.ts"],
       "rules": {
         "no-useless-return": "off"
       }
@@ -765,7 +758,6 @@
         "components/retry-button.tsx",
         "components/suggested-actions.tsx",
         "lib/ai/completion-queue.ts",
-        "lib/ai/mcp/mcp-oauth-provider.ts",
         "lib/anonymous-session-client.ts",
         "lib/artifacts/text/client.tsx",
         "lib/cancellation-aware-chat-transport.ts",
@@ -1305,8 +1297,6 @@
         "lib/ai/gateway-model-defaults.ts",
         "lib/ai/gateways/fallback-models.ts",
         "lib/ai/markdown-joiner-transform.ts",
-        "lib/ai/mcp/mcp-client.ts",
-        "lib/ai/mcp/mcp-oauth-provider.ts",
         "lib/ai/text-splitter.ts",
         "lib/ai/token-utils.test.ts",
         "lib/ai/usage-token-details.test.ts",


### PR DESCRIPTION
Clears all 36 remaining strict Oxlint diagnostics in the MCP client/provider scope and removes resolved exemptions. Extracts the authorization error with direct imports, orders fields, and simplifies async handling while preserving OAuth single-flight writes and request timing.

Validation: root `bun lint` and `bun test:types` passed, application lint passed, independent behavior and standards review completed. No live external OAuth flow was exercised.

## Summary by Sourcery

Clean up MCP client and OAuth provider lint issues while preserving existing OAuth behavior.

Enhancements:
- Clean up MCP client and OAuth provider code to satisfy strict Oxlint rules while preserving OAuth session handling and single-flight persistence behavior.
- Extract the OAuth authorization-required error into its own module and standardize MCP client/provider exports, field ordering, and async control flow.

Chores:
- Remove resolved Oxlint baseline exemptions in the chat application.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up all remaining strict Oxlint diagnostics in the MCP client and OAuth provider scope and removes the resolved baseline exemptions, with no behavior changes to OAuth flows.

- Extracts `OAuthAuthorizationRequiredError` into its own module so `mcp-client.ts` can import it directly.
- Reorders fields and object properties, converts exported functions to arrow functions, and simplifies async promise handling while preserving single-flight persistence and request timing.
- Removes `mcp-client.ts` and `mcp-oauth-provider.ts` from the Oxlint baseline exclusions now that all rules pass.

<sup>Written for commit f53511440be353b763f83ace2d3f309090b5eb5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Reorganized authentication error handling and internal client configuration without changing user-facing behavior.
  - Simplified asynchronous processing while preserving existing results and control flow.
  - Updated internal code quality configuration to reflect the revised implementation.

- **Bug Fixes**
  - No user-visible bug fixes were included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->