### PR TITLE
chore(chat): clean environment and database check lint rules

### DIFF
--- a/apps/chat/oxlint-baseline.json
+++ b/apps/chat/oxlint-baseline.json
@@ -458,8 +458,6 @@
         "lib/clone-messages.ts",
         "lib/db/backfill-parts.ts",
         "lib/files/upload-prep.ts",
-        "scripts/check-db.ts",
-        "scripts/check-env.ts",
         "tools/platform/tools.ts"
       ],
       "rules": {
@@ -774,7 +772,6 @@
         "lib/gated-chat-transport.ts",
         "lib/parallel-chat-requests.ts",
         "lib/start-provisional-chat.ts",
-        "scripts/check-db.ts",
         "tools/platform/deep-research/supervisor-agent.ts"
       ],
       "rules": {

--- a/apps/chat/scripts/check-db.ts
+++ b/apps/chat/scripts/check-db.ts
@@ -26,17 +26,19 @@ const checkDatabase = async () => {
     return;
   }
 
-  for (const purpose of ["runtime", "migration"] as const) {
+  const checkPurpose = async (purpose: "runtime" | "migration") => {
     const settings = databaseConnection(parsed.data, purpose);
     const sql = postgres(settings.url, {
       ...settings.options,
       connect_timeout: CONNECT_TIMEOUT_SECONDS,
       max: 1,
     });
-    const deadline = setTimeout(() => {
-      sql.end({ timeout: 0 }).catch(() => {
+    const deadline = setTimeout(async () => {
+      try {
+        await sql.end({ timeout: 0 });
+      } catch {
         // The timeout closes the client before the query result is relevant.
-      });
+      }
     }, CHECK_DEADLINE_MS);
     try {
       await sql`select 1`;
@@ -54,7 +56,10 @@ const checkDatabase = async () => {
       clearTimeout(deadline);
       await sql.end({ timeout: CLOSE_TIMEOUT_SECONDS });
     }
-  }
+  };
+
+  await checkPurpose("runtime");
+  await checkPurpose("migration");
 };
 
 void (async () => {

--- a/apps/chat/scripts/check-env.ts
+++ b/apps/chat/scripts/check-env.ts
@@ -152,38 +152,31 @@ const validateInstalledTools = async (
       }
       throw error;
     });
-  const errors: ValidationError[] = [];
-
-  for (const entry of entries) {
-    if (!entry.isDirectory() || entry.name.startsWith("_")) {
-      continue;
-    }
-
-    const toolPath = path.join(toolsDir, entry.name, "chatjs.json");
-    const exists = await fs
-      .access(toolPath)
-      .then(() => true)
-      .catch(() => false);
-
-    if (!exists) {
-      continue;
-    }
-
-    const toolSource = await fs.readFile(toolPath, "utf-8");
-    const mod = toolEnvironmentSchema.parse(JSON.parse(toolSource));
-
-    for (const toolEnvVar of mod.envRequirements) {
-      const missing = getMissingRequirement(toolEnvVar, env);
-      if (missing) {
-        errors.push({
-          feature: `tools.${entry.name}`,
-          missing: [missing],
-        });
+  const toolErrors = await Promise.all(
+    entries.map(async (entry): Promise<ValidationError[]> => {
+      if (!entry.isDirectory() || entry.name.startsWith("_")) {
+        return [];
       }
-    }
-  }
 
-  return errors;
+      const toolPath = path.join(toolsDir, entry.name, "chatjs.json");
+      try {
+        await fs.access(toolPath);
+      } catch {
+        return [];
+      }
+
+      const toolSource = await fs.readFile(toolPath, "utf-8");
+      const mod = toolEnvironmentSchema.parse(JSON.parse(toolSource));
+      return mod.envRequirements.flatMap((toolEnvVar) => {
+        const missing = getMissingRequirement(toolEnvVar, env);
+        return missing
+          ? [{ feature: `tools.${entry.name}`, missing: [missing] }]
+          : [];
+      });
+    })
+  );
+
+  return toolErrors.flat();
 };
 
 const validateBaseUrl = (env: NodeJS.ProcessEnv): ValidationError | null => {


### PR DESCRIPTION
Clears five strict Oxlint diagnostics from environment and database checks and removes three resolved exemptions. Database checks still run runtime then migration; independent tool manifests are validated concurrently while preserving result order.

Validation: check-db Vitest regression test passed; application lint/types and formatting passed. Independent behavior and standards review found no issues.

## Summary by Sourcery

Simplify chat environment and database checks and remove resolved lint exemptions.

Enhancements:
- Clean up environment and database validation code while preserving ordered runtime and migration checks.
- Validate independent tool manifests concurrently while maintaining deterministic error ordering.

Chores:
- Remove resolved Oxlint baseline exemptions for the chat application.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears five strict Oxlint diagnostics from `check-db` and `check-env` and removes three resolved exemptions from the lint baseline. `check-db` still runs runtime then migration; `check-env` now validates tool manifests concurrently while preserving result order.

<sup>Written for commit 89e0ec2ded0dfb22f9d349df73806142c11f7218. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

