### PR TITLE
chore(chat): clean AI error handling lint rules

### DIFF
--- a/apps/chat/lib/ai/errors.test.ts
+++ b/apps/chat/lib/ai/errors.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ChatSDKError } from "./errors";
+
+describe("ChatSDKError", () => {
+  it("preserves chat error metadata and response details", async () => {
+    const error = new ChatSDKError("not_found:chat", "missing chat");
+
+    expect(error).toMatchObject({
+      message:
+        "The requested chat was not found. Please check the chat ID and try again.",
+      name: "ChatSDKError",
+      statusCode: 404,
+      surface: "chat",
+      type: "not_found",
+    });
+
+    expect(await error.toResponse().json()).toEqual({
+      cause: "missing chat",
+      code: "not_found:chat",
+      message:
+        "The requested chat was not found. Please check the chat ID and try again.",
+    });
+  });
+
+  it("conceals database details from the response while logging them", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new ChatSDKError(
+      "not_found:database",
+      "database unavailable"
+    );
+
+    const response = error.toResponse();
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      code: "",
+      message: "Something went wrong. Please try again later.",
+    });
+    expect(errorSpy).toHaveBeenCalledWith({
+      cause: "database unavailable",
+      code: "not_found:database",
+      message: "An error occurred while executing a database query.",
+    });
+
+    errorSpy.mockRestore();
+  });
+});

--- a/apps/chat/lib/ai/errors.ts
+++ b/apps/chat/lib/ai/errors.ts
@@ -23,31 +23,113 @@ export type ErrorCode = `${ErrorType}:${Surface}`;
 type ErrorVisibility = "response" | "log" | "none";
 
 const visibilityBySurface: Record<Surface, ErrorVisibility> = {
-  database: "log",
-  chat: "response",
-  auth: "response",
-  stream: "response",
   api: "response",
-  history: "response",
-  vote: "response",
+  auth: "response",
+  chat: "response",
+  database: "log",
   document: "response",
+  history: "response",
+  stream: "response",
   suggestions: "response",
+  vote: "response",
+};
+
+const getMessageByErrorCode = (errorCode: ErrorCode): string => {
+  if (errorCode.includes("database")) {
+    return "An error occurred while executing a database query.";
+  }
+
+  switch (errorCode) {
+    case "bad_request:api": {
+      return "The request couldn't be processed. Please check your input and try again.";
+    }
+
+    case "unauthorized:auth": {
+      return "You need to sign in before continuing.";
+    }
+    case "forbidden:auth": {
+      return "Your account does not have access to this feature.";
+    }
+
+    case "rate_limit:chat": {
+      return "You have exceeded your maximum number of messages for the day. Please try again later.";
+    }
+    case "input_too_long:chat": {
+      return "Your message input is too long. Please shorten your message and try again.";
+    }
+    case "not_found:chat": {
+      return "The requested chat was not found. Please check the chat ID and try again.";
+    }
+    case "forbidden:chat": {
+      return "This chat belongs to another user. Please check the chat ID and try again.";
+    }
+    case "unauthorized:chat": {
+      return "You need to sign in to view this chat. Please sign in and try again.";
+    }
+    case "offline:chat": {
+      return "We're having trouble sending your message. Please check your internet connection and try again.";
+    }
+
+    case "not_found:document": {
+      return "The requested document was not found. Please check the document ID and try again.";
+    }
+    case "forbidden:document": {
+      return "This document belongs to another user. Please check the document ID and try again.";
+    }
+    case "unauthorized:document": {
+      return "You need to sign in to view this document. Please sign in and try again.";
+    }
+    case "bad_request:document": {
+      return "The request to create or update the document was invalid. Please check your input and try again.";
+    }
+
+    default: {
+      return "Something went wrong. Please try again later.";
+    }
+  }
+};
+
+const getStatusCodeByType = (type: ErrorType): number => {
+  switch (type) {
+    case "bad_request":
+    case "input_too_long": {
+      return 400;
+    }
+    case "unauthorized": {
+      return 401;
+    }
+    case "forbidden": {
+      return 403;
+    }
+    case "not_found": {
+      return 404;
+    }
+    case "rate_limit": {
+      return 429;
+    }
+    case "offline": {
+      return 503;
+    }
+    default: {
+      return 500;
+    }
+  }
 };
 
 export class ChatSDKError extends Error {
+  name = "ChatSDKError";
   type: ErrorType;
   surface: Surface;
   statusCode: number;
 
   constructor(errorCode: ErrorCode, cause?: string) {
-    super();
+    super(getMessageByErrorCode(errorCode));
 
     const [type, surface] = errorCode.split(":");
 
     this.type = type as ErrorType;
     this.cause = cause;
     this.surface = surface as Surface;
-    this.message = getMessageByErrorCode(errorCode);
     this.statusCode = getStatusCodeByType(this.type);
   }
 
@@ -59,9 +141,9 @@ export class ChatSDKError extends Error {
 
     if (visibility === "log") {
       console.error({
+        cause,
         code,
         message,
-        cause,
       });
 
       return Response.json(
@@ -70,67 +152,6 @@ export class ChatSDKError extends Error {
       );
     }
 
-    return Response.json({ code, message, cause }, { status: statusCode });
-  }
-}
-
-function getMessageByErrorCode(errorCode: ErrorCode): string {
-  if (errorCode.includes("database")) {
-    return "An error occurred while executing a database query.";
-  }
-
-  switch (errorCode) {
-    case "bad_request:api":
-      return "The request couldn't be processed. Please check your input and try again.";
-
-    case "unauthorized:auth":
-      return "You need to sign in before continuing.";
-    case "forbidden:auth":
-      return "Your account does not have access to this feature.";
-
-    case "rate_limit:chat":
-      return "You have exceeded your maximum number of messages for the day. Please try again later.";
-    case "input_too_long:chat":
-      return "Your message input is too long. Please shorten your message and try again.";
-    case "not_found:chat":
-      return "The requested chat was not found. Please check the chat ID and try again.";
-    case "forbidden:chat":
-      return "This chat belongs to another user. Please check the chat ID and try again.";
-    case "unauthorized:chat":
-      return "You need to sign in to view this chat. Please sign in and try again.";
-    case "offline:chat":
-      return "We're having trouble sending your message. Please check your internet connection and try again.";
-
-    case "not_found:document":
-      return "The requested document was not found. Please check the document ID and try again.";
-    case "forbidden:document":
-      return "This document belongs to another user. Please check the document ID and try again.";
-    case "unauthorized:document":
-      return "You need to sign in to view this document. Please sign in and try again.";
-    case "bad_request:document":
-      return "The request to create or update the document was invalid. Please check your input and try again.";
-
-    default:
-      return "Something went wrong. Please try again later.";
-  }
-}
-
-function getStatusCodeByType(type: ErrorType) {
-  switch (type) {
-    case "bad_request":
-    case "input_too_long":
-      return 400;
-    case "unauthorized":
-      return 401;
-    case "forbidden":
-      return 403;
-    case "not_found":
-      return 404;
-    case "rate_limit":
-      return 429;
-    case "offline":
-      return 503;
-    default:
-      return 500;
+    return Response.json({ cause, code, message }, { status: statusCode });
   }
 }

--- a/apps/chat/lib/ai/eval-agent.ts
+++ b/apps/chat/lib/ai/eval-agent.ts
@@ -76,7 +76,8 @@ async function executeAgentAndGetOutput({
     onError: (error) => {
       throw error;
     },
-    costAccumulator: new CostAccumulator(), // Discarded for evals
+    // Discarded for evals
+    costAccumulator: new CostAccumulator(),
   });
 
   await result.consumeStream();
@@ -118,19 +119,19 @@ function updateExistingToolPart(
       p.toolCallId === toolCallId
   );
 
-  if (partIndex >= 0) {
-    const part = parts[partIndex];
-    if (part.type.startsWith("tool-") && "state" in part) {
-      parts[partIndex] = {
-        ...part,
-        state: "output-available",
-        output,
-      } as ChatMessage["parts"][number];
-    }
-    return true;
+  if (partIndex === -1) {
+    return false;
   }
 
-  return false;
+  const part = parts[partIndex];
+  if (part.type.startsWith("tool-") && "state" in part) {
+    parts[partIndex] = {
+      ...part,
+      state: "output-available",
+      output,
+    } as ChatMessage["parts"][number];
+  }
+  return true;
 }
 
 function addToolResultPart(
@@ -151,18 +152,19 @@ function updateToolResults(
   toolName: string
 ): void {
   const existingIndex = toolResults.findIndex((tr) => tr.toolName === toolName);
-  if (existingIndex >= 0) {
-    toolResults[existingIndex] = {
-      ...toolResults[existingIndex],
-      state: "output-available",
-    };
-  } else {
+  if (existingIndex === -1) {
     toolResults.push({
       toolName,
       type: `tool-${toolName}`,
       state: "output-available",
     });
+    return;
   }
+
+  toolResults[existingIndex] = {
+    ...toolResults[existingIndex],
+    state: "output-available",
+  };
 }
 
 function processToolResult(

--- a/apps/chat/oxlint-baseline.json
+++ b/apps/chat/oxlint-baseline.json
@@ -223,7 +223,6 @@
         "lib/ai/complete-data-part.test.ts",
         "lib/ai/completion-queue.test.ts",
         "lib/ai/core-chat-agent.ts",
-        "lib/ai/errors.ts",
         "lib/ai/eval-agent.ts",
         "lib/anonymous-session-client.ts",
         "lib/app-chat-runtime.ts",
@@ -490,7 +489,6 @@
         "components/keyboard-shortcuts.tsx",
         "components/multimodal-input.tsx",
         "components/part/text-message-part.tsx",
-        "lib/ai/eval-agent.ts",
         "lib/ai/token-utils.test.ts",
         "lib/auth.ts",
         "lib/credits/cost-accumulator.ts",
@@ -598,7 +596,6 @@
         "components/settings/mcp-details-page.tsx",
         "components/ui/form.tsx",
         "components/ui/scroll-area.tsx",
-        "lib/ai/errors.ts",
         "lib/app-chat-runtime.ts",
         "lib/db/queries.ts",
         "lib/db/schema.ts",
@@ -1292,7 +1289,6 @@
         "lib/ai/active-gateway.ts",
         "lib/ai/complete-data-part.test.ts",
         "lib/ai/core-chat-agent.ts",
-        "lib/ai/errors.ts",
         "lib/ai/eval-agent.ts",
         "lib/ai/gateway-model-defaults.ts",
         "lib/ai/gateways/fallback-models.ts",
@@ -1420,7 +1416,7 @@
       }
     },
     {
-      "files": ["components/settings/models-table.tsx", "lib/ai/eval-agent.ts"],
+      "files": ["components/settings/models-table.tsx"],
       "rules": {
         "unicorn/consistent-existence-index-check": "off"
       }
@@ -1435,12 +1431,6 @@
       ],
       "rules": {
         "unicorn/consistent-function-scoping": "off"
-      }
-    },
-    {
-      "files": ["lib/ai/errors.ts"],
-      "rules": {
-        "unicorn/custom-error-definition": "off"
       }
     },
     {
@@ -1628,8 +1618,7 @@
         "components/diffview.tsx",
         "components/model-selector.tsx",
         "components/part/document-common.tsx",
-        "components/part/document-preview.tsx",
-        "lib/ai/errors.ts"
+        "components/part/document-preview.tsx"
       ],
       "rules": {
         "unicorn/switch-case-braces": "off"


### PR DESCRIPTION
Clears 33 strict Oxlint diagnostics from AI error handling and safe eval-agent expressions, removing the resolved exemptions. Initializes ChatSDKError with its mapped message and explicit diagnostic name; response metadata and database-detail redaction remain unchanged.

Validation: focused error response/privacy tests, root lint/types, and independent standards/behavior review passed. The remaining eval-agent hoisting and payload-order findings are retained for focused follow-up.

## Summary by Sourcery

Clean up AI error handling and eval-agent lint issues while preserving response behavior and privacy guarantees.

Bug Fixes:
- Preserve chat error metadata and response behavior while ensuring database error details remain concealed from clients and available in logs.

Enhancements:
- Strengthen AI error handling and eval-agent code quality by resolving strict Oxlint diagnostics and removing obsolete lint exemptions.

Tests:
- Add focused tests covering chat error metadata, response details, status codes, and database-detail redaction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves 33 strict Oxlint diagnostics in AI error handling and eval-agent expressions, removing the resolved lint exemptions. `ChatSDKError` now initializes its message via the parent constructor and sets an explicit `name`, while response metadata and database-detail redaction remain unchanged. Adds focused tests covering error metadata, response status, and database-detail redaction.

<sup>Written for commit 7d18888f759b4da7cb66abf497aa1090ff2b9e7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

