### PR TITLE
chore(chat): clean safe database query and migration lint rules

### DIFF
--- a/apps/chat/lib/db/migrate.ts
+++ b/apps/chat/lib/db/migrate.ts
@@ -24,8 +24,8 @@ const runMigrate = async () => {
 
   const settings = databaseConnection(
     {
-      DATABASE_URL: process.env.DATABASE_URL,
       DATABASE_MIGRATION_URL: process.env.DATABASE_MIGRATION_URL,
+      DATABASE_URL: process.env.DATABASE_URL,
     },
     "migration"
   );
@@ -45,8 +45,10 @@ const runMigrate = async () => {
   console.log("✅ Migrations completed in", end - start, "ms");
 };
 
-runMigrate().catch((err) => {
+try {
+  await runMigrate();
+} catch (error) {
   console.error("❌ Migration failed");
-  console.error(err);
+  console.error(error);
   process.exitCode = 1;
-});
+}

--- a/apps/chat/lib/db/migrate.ts
+++ b/apps/chat/lib/db/migrate.ts
@@ -45,10 +45,12 @@ const runMigrate = async () => {
   console.log("✅ Migrations completed in", end - start, "ms");
 };
 
-try {
-  await runMigrate();
-} catch (error) {
-  console.error("❌ Migration failed");
-  console.error(error);
-  process.exitCode = 1;
-}
+void (async () => {
+  try {
+    await runMigrate();
+  } catch (error) {
+    console.error("❌ Migration failed");
+    console.error(error);
+    process.exitCode = 1;
+  }
+})();

--- a/apps/chat/lib/db/queries.ts
+++ b/apps/chat/lib/db/queries.ts
@@ -17,9 +17,6 @@ import { isSelectedModelValue } from "@/lib/ai/types";
 import { deleteFilesByUrls } from "@/lib/file-storage";
 import { createModuleLogger } from "@/lib/logger";
 import { chatMessageToDbMessage } from "@/lib/message-conversion";
-
-const logger = createModuleLogger("db:queries");
-
 import {
   mapDBPartsToUIParts,
   mapUIMessagePartsToDBParts,
@@ -40,6 +37,8 @@ import {
   vote,
 } from "./schema";
 import type { DBMessage, Part, User, UserModelPreference } from "./schema";
+
+const logger = createModuleLogger("db:queries");
 
 async function _getUserByEmail(email: string): Promise<User[]> {
   try {
@@ -317,7 +316,7 @@ async function _tryGetChatById({ id }: { id: string }) {
   try {
     const [selectedChat] = await db.select().from(chat).where(eq(chat.id, id));
     return selectedChat;
-  } catch (_error) {
+  } catch {
     return null;
   }
 }
@@ -358,8 +357,6 @@ export async function saveMessage({
 
       // Update chat's updatedAt timestamp
       await updateChatUpdatedAt({ chatId });
-
-      return;
     });
   } catch (error) {
     logger.error({ error, chatId, id }, "saveMessage failed");
@@ -442,8 +439,6 @@ export async function saveChatMessages({
       await Promise.all(
         uniqueChatIds.map((chatId) => updateChatUpdatedAt({ chatId }))
       );
-
-      return;
     });
   } catch (error) {
     logger.error(

--- a/apps/chat/oxlint-baseline.json
+++ b/apps/chat/oxlint-baseline.json
@@ -338,7 +338,6 @@
       "files": [
         "components/part/tool-part.test.tsx",
         "lib/clone-messages.test.ts",
-        "lib/db/queries.ts",
         "lib/file-content-response.test.ts",
         "lib/file-storage.test.ts",
         "tools/chatjs/vercel-code-execution/tool.test.ts"
@@ -563,7 +562,6 @@
         "components/sidebar-chat-item.tsx",
         "components/signup-form.tsx",
         "hooks/chat-sync-hooks.ts",
-        "lib/db/queries.ts",
         "lib/stores/with-tracing.ts"
       ],
       "rules": {
@@ -605,7 +603,7 @@
       }
     },
     {
-      "files": ["components/anonymous-session-init.tsx", "lib/db/queries.ts"],
+      "files": ["components/anonymous-session-init.tsx"],
       "rules": {
         "no-useless-return": "off"
       }
@@ -728,7 +726,6 @@
         "components/chat-sync.tsx",
         "components/electron-auth-handler.tsx",
         "components/electron-auth-ui.tsx",
-        "lib/db/migrate.ts",
         "lib/gated-chat-transport.ts",
         "lib/stores/base/hooks.ts"
       ],
@@ -755,7 +752,6 @@
         "lib/anonymous-session-client.ts",
         "lib/artifacts/text/client.tsx",
         "lib/cancellation-aware-chat-transport.ts",
-        "lib/db/migrate.ts",
         "lib/gated-chat-transport.ts",
         "lib/parallel-chat-requests.ts",
         "lib/start-provisional-chat.ts",
@@ -1308,7 +1304,6 @@
         "lib/credits/cost-accumulator.ts",
         "lib/data-stream.test.ts",
         "lib/db/mcp-queries.ts",
-        "lib/db/migrate.ts",
         "lib/db/queries.ts",
         "lib/db/schema.ts",
         "lib/draft-chat-submission.ts",
@@ -1395,7 +1390,7 @@
       }
     },
     {
-      "files": ["lib/db/migrate.ts", "lib/stores/base/hooks.ts"],
+      "files": ["lib/stores/base/hooks.ts"],
       "rules": {
         "unicorn/catch-error-name": "off"
       }
@@ -1571,7 +1566,6 @@
         "components/image-modal.tsx",
         "components/multimodal-input.tsx",
         "components/sidebar-chat-item.tsx",
-        "lib/db/queries.ts",
         "lib/stores/with-tracing.ts"
       ],
       "rules": {


### PR DESCRIPTION
Removes 13 strict Oxlint diagnostics and eight resolved exemptions from database query/migration helpers. Cleans imports, unused catch bindings, and redundant returns while preserving SQL field order and sequential operations. Migration startup keeps an async IIFE so it remains compatible with the monorepo tsx/CommonJS runtime.

Validation: root lint/types passed; non-executing CommonJS transform passed. Independent review completed. No database migration was executed. Remaining query hoisting/field-order findings are retained.

## Summary by Sourcery

Clean database query and migration helpers and reduce their remaining lint exemptions without changing database behavior.

Enhancements:
- Clean up database query and migration helpers to satisfy safe lint rules while preserving query ordering and migration execution behavior.

Chores:
- Reduce the Oxlint baseline by removing resolved diagnostics and exemptions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans database query and migration helpers and reduces their lint exemptions without changing database behavior.

- Reorders connection settings and wraps migration startup in an async IIFE to stay CommonJS-compatible.
- Removes unused imports, unused catch bindings, and redundant returns from query helpers.
- Drops eight resolved entries from the Oxlint baseline.

<sup>Written for commit b57d7c57e4ac3d9cb762902e7c04f3bf06a51ce2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

