### PR TITLE
chore(chat): clear utility lint baseline

### DIFF
--- a/apps/chat/lib/clone-messages.test.ts
+++ b/apps/chat/lib/clone-messages.test.ts
@@ -5,6 +5,10 @@ import { describe, it, vi } from "vitest";
 import { gatewayModelDefaults } from "@/lib/ai/gateway-model-defaults";
 
 import type { ChatMessage } from "./ai/types";
+import {
+  cloneAttachmentsInMessages,
+  cloneMessagesWithDocuments,
+} from "./clone-messages";
 
 const fileStorage = vi.hoisted(() => ({
   downloadFile: vi.fn(),
@@ -17,11 +21,6 @@ vi.mock("@/lib/config", () => ({
 
 vi.mock("./file-storage", () => fileStorage);
 
-import {
-  cloneAttachmentsInMessages,
-  cloneMessagesWithDocuments,
-} from "./clone-messages";
-
 function createMessage({
   id,
   parentMessageId = null,
@@ -32,16 +31,16 @@ function createMessage({
   chatId: string;
 }): ChatMessage & { chatId: string } {
   return {
+    chatId,
     id,
-    role: "user",
-    parts: [],
     metadata: {
+      activeStreamId: null,
       createdAt: new Date("2024-01-01T00:00:00.000Z"),
       parentMessageId,
       selectedModel: gatewayModelDefaults.workflows.chat,
-      activeStreamId: null,
     },
-    chatId,
+    parts: [],
+    role: "user",
   };
 }
 
@@ -52,19 +51,19 @@ describe("cloneMessagesWithDocuments", () => {
     const userId = "user-1";
 
     const m1 = createMessage({
+      chatId: sourceChatId,
       id: "m1",
       parentMessageId: null,
-      chatId: sourceChatId,
     });
     const m2 = createMessage({
+      chatId: sourceChatId,
       id: "m2",
       parentMessageId: "m1",
-      chatId: sourceChatId,
     });
     const m3 = createMessage({
+      chatId: sourceChatId,
       id: "m3",
       parentMessageId: "m2",
-      chatId: sourceChatId,
     });
 
     const { clonedMessages, messageIdMap } = cloneMessagesWithDocuments(
@@ -79,9 +78,9 @@ describe("cloneMessagesWithDocuments", () => {
     // IDs should all be new and unique
     const newIds = clonedMessages.map((m) => m.id);
     assert.equal(new Set(newIds).size, 3);
-    assert(!newIds.includes("m1"));
-    assert(!newIds.includes("m2"));
-    assert(!newIds.includes("m3"));
+    assert.ok(!newIds.includes("m1"));
+    assert.ok(!newIds.includes("m2"));
+    assert.ok(!newIds.includes("m3"));
 
     // All messages should belong to the new chat
     for (const msg of clonedMessages) {
@@ -92,17 +91,17 @@ describe("cloneMessagesWithDocuments", () => {
     const newM2Id = messageIdMap.get("m2");
     const newM3Id = messageIdMap.get("m3");
 
-    assert(newM1Id);
-    assert(newM2Id);
-    assert(newM3Id);
+    assert.ok(newM1Id);
+    assert.ok(newM2Id);
+    assert.ok(newM3Id);
 
     const clonedM1 = clonedMessages.find((m) => m.id === newM1Id);
     const clonedM2 = clonedMessages.find((m) => m.id === newM2Id);
     const clonedM3 = clonedMessages.find((m) => m.id === newM3Id);
 
-    assert(clonedM1);
-    assert(clonedM2);
-    assert(clonedM3);
+    assert.ok(clonedM1);
+    assert.ok(clonedM2);
+    assert.ok(clonedM3);
 
     // Root has no parent
     assert.equal(clonedM1.metadata.parentMessageId, null);
@@ -120,69 +119,69 @@ describe("cloneMessagesWithDocuments", () => {
     const userId = "user-1";
 
     const messageWithDoc = createMessage({
+      chatId: sourceChatId,
       id: "m-doc",
       parentMessageId: null,
-      chatId: sourceChatId,
     });
 
     // Minimal tool parts that reference a document id.
     // Shapes match the actual tool output types so the test type-checks.
     messageWithDoc.parts = [
       {
-        type: "tool-createTextDocument",
-        toolCallId: "call-create",
-        state: "output-available",
         input: {
-          title: "Doc title",
           content: "The document content",
+          title: "Doc title",
         },
         output: {
-          status: "success",
+          date: "2024-01-01T00:00:00.000Z",
           documentId: "doc-1",
           result: "A document was created and is now visible to the user.",
-          date: "2024-01-01T00:00:00.000Z",
+          status: "success",
         },
+        state: "output-available",
+        toolCallId: "call-create",
+        type: "tool-createTextDocument",
       },
       {
-        type: "tool-editTextDocument",
-        toolCallId: "call-update",
-        state: "output-available",
         input: {
+          content: "Updated content",
           documentId: "doc-1",
           title: "Doc title",
-          content: "Updated content",
         },
         output: {
-          status: "success",
+          date: "2024-01-01T00:00:00.000Z",
           documentId: "doc-1",
           result: "The document was updated and is now visible to the user.",
-          date: "2024-01-01T00:00:00.000Z",
+          status: "success",
         },
+        state: "output-available",
+        toolCallId: "call-update",
+        type: "tool-editTextDocument",
       },
       {
-        type: "tool-deepResearch",
-        toolCallId: "call-deep",
-        state: "output-available",
         input: {},
         output: {
-          format: "report",
-          status: "success",
-          documentId: "doc-1",
-          result: "Deep research report content",
           date: "2024-01-01T00:00:00.000Z",
+          documentId: "doc-1",
+          format: "report",
+          result: "Deep research report content",
+          status: "success",
         },
+        state: "output-available",
+        toolCallId: "call-deep",
+        type: "tool-deepResearch",
       },
     ];
 
     const sourceDocuments = [
       {
-        id: "doc-1",
-        messageId: "m-doc",
-        userId: "source-user",
-        title: "Doc title",
-        kind: "text",
         content: "hello",
         createdAt: new Date("2024-01-01T00:00:00.000Z"),
+        id: "doc-1",
+        kind: "text",
+        messageId: "m-doc",
+        title: "Doc title",
+        userId: "source-user",
       },
     ];
 
@@ -200,11 +199,11 @@ describe("cloneMessagesWithDocuments", () => {
     const newMessageId = messageIdMap.get("m-doc");
     const newDocumentId = documentIdMap.get("doc-1");
 
-    assert(newMessageId);
-    assert(newDocumentId);
+    assert.ok(newMessageId);
+    assert.ok(newDocumentId);
 
-    const clonedMessage = clonedMessages[0];
-    const clonedDocument = clonedDocuments[0];
+    const [clonedMessage] = clonedMessages;
+    const [clonedDocument] = clonedDocuments;
 
     // Document should point to cloned message and new user
     assert.equal(clonedDocument.messageId, newMessageId);
@@ -234,7 +233,8 @@ describe("cloneMessagesWithDocuments", () => {
 describe("cloneAttachmentsInMessages", () => {
   it("copies managed files through the configured storage provider", async () => {
     fileStorage.downloadFile.mockResolvedValue({
-      arrayBuffer: async () => new TextEncoder().encode("contents").buffer,
+      arrayBuffer: () =>
+        Promise.resolve(new TextEncoder().encode("contents").buffer),
       type: "text/plain",
     });
     fileStorage.uploadFile.mockResolvedValue({
@@ -245,9 +245,9 @@ describe("cloneAttachmentsInMessages", () => {
       {
         parts: [
           {
-            type: "file",
             filename: "attachment.txt",
             mediaType: "text/plain",
+            type: "file",
             url: "https://old-chat.example/api/files/content?key=l_u0a2bkphKLFKsBI4q5Tue9.png",
           },
         ],

--- a/apps/chat/lib/clone-messages.ts
+++ b/apps/chat/lib/clone-messages.ts
@@ -36,8 +36,8 @@ function cloneMessages<
 
     const clonedMessage: T = {
       ...message,
-      id: newId,
       chatId: newChatId,
+      id: newId,
       parentMessageId: newParentId,
     };
     clonedMessages.push(clonedMessage);
@@ -188,7 +188,7 @@ function updateDocumentReferencesInMessageParts<
   T extends { parts: ChatMessage["parts"] },
 >(messages: T[], documentIdMap: Map<string, string>): T[] {
   return messages.map((message) => {
-    const parts = message.parts;
+    const { parts } = message;
     let updatedParts: ChatMessage["parts"] = [];
 
     if (Array.isArray(parts)) {
@@ -352,8 +352,13 @@ export function cloneMessagesWithDocuments<
 
   // Step 2: Create message ID mapping for later use
   const messageIdMap = new Map<string, string>();
-  for (let i = 0; i < sourceMessages.length; i++) {
-    messageIdMap.set(sourceMessages[i].id, clonedMessagesBase[i].id);
+  for (let i = 0; i < sourceMessages.length; i += 1) {
+    const sourceMessage = sourceMessages[i];
+    const clonedMessage = clonedMessagesBase[i];
+    if (!sourceMessage || !clonedMessage) {
+      throw new Error(`Message at index ${i} not found while cloning`);
+    }
+    messageIdMap.set(sourceMessage.id, clonedMessage.id);
   }
 
   // Step 2b: If messages have metadata.parentMessageId (ChatMessage),
@@ -419,9 +424,9 @@ export function cloneMessagesWithDocuments<
   );
 
   return {
-    clonedMessages: messagesWithUpdatedDocRefs,
     clonedDocuments,
-    messageIdMap,
+    clonedMessages: messagesWithUpdatedDocRefs,
     documentIdMap,
+    messageIdMap,
   };
 }

--- a/apps/chat/lib/utils/download-assets.test.ts
+++ b/apps/chat/lib/utils/download-assets.test.ts
@@ -22,24 +22,24 @@ describe("replaceFilePartUrlByBinaryDataInMessages", () => {
       {
         content: [
           {
-            type: "file",
-            mediaType: "application/pdf",
             data: { openai: "file-123" },
-          },
-          {
-            type: "file",
             mediaType: "application/pdf",
-            data: { type: "reference", reference: { openai: "file-456" } },
+            type: "file",
           },
           {
+            data: { reference: { openai: "file-456" }, type: "reference" },
+            mediaType: "application/pdf",
             type: "file",
+          },
+          {
+            data: { text: "document", type: "text" },
             mediaType: "text/plain",
-            data: { type: "text", text: "document" },
+            type: "file",
           },
           {
-            type: "file",
+            data: { data: new Uint8Array([1, 2]), type: "data" },
             mediaType: "application/pdf",
-            data: { type: "data", data: new Uint8Array([1, 2]) },
+            type: "file",
           },
         ],
         role: "user",
@@ -64,9 +64,9 @@ describe("replaceFilePartUrlByBinaryDataInMessages", () => {
         {
           content: [
             {
-              type: "file",
-              mediaType: "application/pdf",
               data: { type: "url", url },
+              mediaType: "application/pdf",
+              type: "file",
             },
           ],
           role: "user",
@@ -79,9 +79,9 @@ describe("replaceFilePartUrlByBinaryDataInMessages", () => {
       {
         content: [
           {
-            type: "file",
-            mediaType: "application/pdf",
             data: new Uint8Array([7]),
+            mediaType: "application/pdf",
+            type: "file",
           },
         ],
         role: "user",
@@ -106,9 +106,9 @@ describe("replaceFilePartUrlByBinaryDataInMessages", () => {
       {
         content: [
           {
-            type: "file",
             data: "/api/files/content?key=l_u0a2bkphKLFKsBI4q5Tue9.png",
             mediaType: "image/png",
+            type: "file",
           },
         ],
         role: "user",
@@ -135,11 +135,11 @@ describe("replaceFilePartUrlByBinaryDataInMessages", () => {
     const result = await replaceFilePartUrlByBinaryDataInMessages([
       {
         content: [
-          { type: "text", text: "Describe the earlier context" },
+          { text: "Describe the earlier context", type: "text" },
           {
-            type: "file",
             data: "/api/files/content?key=l_u0a2bkphKLFKsBI4q5Tue9.png",
             mediaType: "image/png",
+            type: "file",
           },
         ],
         role: "user",
@@ -148,7 +148,7 @@ describe("replaceFilePartUrlByBinaryDataInMessages", () => {
 
     assert.deepEqual(result, [
       {
-        content: [{ type: "text", text: "Describe the earlier context" }],
+        content: [{ text: "Describe the earlier context", type: "text" }],
         role: "user",
       },
     ]);
@@ -163,11 +163,11 @@ describe("replaceFilePartUrlByBinaryDataInMessages", () => {
     const result = await replaceFilePartUrlByBinaryDataInMessages([
       {
         content: [
-          { type: "text", text: "Continue this conversation" },
+          { text: "Continue this conversation", type: "text" },
           {
-            type: "file",
             data: "https://legacy.public.blob.vercel-storage.com/missing.png",
             mediaType: "image/png",
+            type: "file",
           },
         ],
         role: "user",
@@ -176,7 +176,7 @@ describe("replaceFilePartUrlByBinaryDataInMessages", () => {
 
     assert.deepEqual(result, [
       {
-        content: [{ type: "text", text: "Continue this conversation" }],
+        content: [{ text: "Continue this conversation", type: "text" }],
         role: "user",
       },
     ]);
@@ -191,9 +191,9 @@ describe("replaceFilePartUrlByBinaryDataInMessages", () => {
       {
         content: [
           {
-            type: "file",
             data: "/api/files/content?key=l_u0a2bkphKLFKsBI4q5Tue9.png",
             mediaType: "image/png",
+            type: "file",
           },
         ],
         role: "user",
@@ -212,26 +212,26 @@ describe("replaceFilePartUrlByBinaryDataInMessages", () => {
       {
         content: [
           {
-            type: "file",
             data: "/api/files/content?key=l_u0a2bkphKLFKsBI4q5Tue9.png",
             mediaType: "image/png",
+            type: "file",
           },
         ],
         role: "user",
       },
       {
-        content: [{ type: "text", text: "Earlier response" }],
+        content: [{ text: "Earlier response", type: "text" }],
         role: "assistant",
       },
       {
-        content: [{ type: "text", text: "Continue this conversation" }],
+        content: [{ text: "Continue this conversation", type: "text" }],
         role: "user",
       },
     ]);
 
     assert.deepEqual(result, [
       {
-        content: [{ type: "text", text: "Continue this conversation" }],
+        content: [{ text: "Continue this conversation", type: "text" }],
         role: "user",
       },
     ]);
@@ -246,12 +246,12 @@ describe("replaceFilePartUrlByBinaryDataInMessages", () => {
     const result = await replaceFilePartUrlByBinaryDataInMessages([
       {
         content: [
-          { type: "text", text: "Continue this conversation" },
+          { text: "Continue this conversation", type: "text" },
           {
-            type: "image",
             image: new URL(
               "https://legacy.public.blob.vercel-storage.com/missing.png"
             ),
+            type: "image",
           },
         ],
         role: "user",
@@ -260,7 +260,7 @@ describe("replaceFilePartUrlByBinaryDataInMessages", () => {
 
     assert.deepEqual(result, [
       {
-        content: [{ type: "text", text: "Continue this conversation" }],
+        content: [{ text: "Continue this conversation", type: "text" }],
         role: "user",
       },
     ]);
@@ -278,9 +278,9 @@ describe("replaceFilePartUrlByBinaryDataInMessages", () => {
         {
           content: [
             {
-              type: "file",
               data: "/api/files/content?key=l_u0a2bkphKLFKsBI4q5Tue9.png",
               mediaType: "image/png",
+              type: "file",
             },
           ],
           role: "user",
@@ -301,9 +301,9 @@ describe("replaceFilePartUrlByBinaryDataInMessages", () => {
         {
           content: [
             {
-              type: "file",
               data: "https://files.example/unavailable.png",
               mediaType: "image/png",
+              type: "file",
             },
           ],
           role: "user",
@@ -329,9 +329,9 @@ describe("replaceFilePartUrlByBinaryDataInMessages", () => {
       {
         content: [
           {
-            type: "file",
             data: "https://files.example/api/files/content?key=l_u0a2bkphKLFKsBI4q5Tue9.png",
             mediaType: "image/png",
+            type: "file",
           },
         ],
         role: "user",
@@ -353,14 +353,14 @@ describe("replaceFilePartUrlByBinaryDataInMessages", () => {
       {
         content: [
           {
-            type: "file",
             data: "/api/files/content?key=l_u0a2bkphKLFKsBI4q5Tue9.png",
             mediaType: "image/png",
+            type: "file",
           },
           {
-            type: "file",
             data: "aGVsbG8=",
             mediaType: "text/plain",
+            type: "file",
           },
         ],
         role: "user",

--- a/apps/chat/oxlint-baseline.json
+++ b/apps/chat/oxlint-baseline.json
@@ -322,7 +322,6 @@
     {
       "files": [
         "components/part/tool-part.test.tsx",
-        "lib/clone-messages.test.ts",
         "lib/file-content-response.test.ts",
         "lib/file-storage.test.ts",
         "tools/chatjs/vercel-code-execution/tool.test.ts"
@@ -498,10 +497,7 @@
       }
     },
     {
-      "files": [
-        "components/ai-elements/prompt-input.tsx",
-        "lib/clone-messages.ts"
-      ],
+      "files": ["components/ai-elements/prompt-input.tsx"],
       "rules": {
         "no-plusplus": "off"
       }
@@ -637,8 +633,6 @@
         "components/settings/mcp-details-page.tsx",
         "components/share-button.tsx",
         "components/suggested-actions.tsx",
-        "lib/clone-messages.test.ts",
-        "lib/clone-messages.ts",
         "lib/draft-chat-submission.ts",
         "lib/files/upload-prep.ts",
         "lib/message-conversion.ts",
@@ -1139,7 +1133,6 @@
       "files": [
         "app/layout.tsx",
         "components/create-artifact.tsx",
-        "lib/clone-messages.test.ts",
         "lib/gated-chat-transport.test.ts",
         "lib/stores/base/hooks.ts"
       ],
@@ -1251,8 +1244,6 @@
         "lib/artifacts/text/client.tsx",
         "lib/auth.ts",
         "lib/chat-tree-actions.test.ts",
-        "lib/clone-messages.test.ts",
-        "lib/clone-messages.ts",
         "lib/config-requirements.ts",
         "lib/config-schema.ts",
         "lib/create-anonymous-session.ts",
@@ -1279,7 +1270,6 @@
         "lib/thread-utils.test.ts",
         "lib/types/anonymous.ts",
         "lib/utils.ts",
-        "lib/utils/download-assets.test.ts",
         "lib/utils/message-mapping.ts",
         "providers/chat-input-provider.tsx",
         "providers/chat-models-provider.tsx",
@@ -1352,7 +1342,7 @@
       }
     },
     {
-      "files": ["lib/clone-messages.test.ts", "lib/file-storage.test.ts"],
+      "files": ["lib/file-storage.test.ts"],
       "rules": {
         "unicorn/consistent-assert": "off"
       }


### PR DESCRIPTION
## Summary

- clear resolved lint baseline entries for message cloning and asset download utilities
- normalize import ordering, object key ordering, and assertion usage in focused tests
- preserve sequential attachment cloning while removing safe loop, destructuring, and assertion exemptions

## Validation

- `bun lint`
- `bun test:types` (apps/chat)
- `bun test:unit lib/clone-messages.test.ts lib/utils/download-assets.test.ts` (apps/chat)

## Summary by Sourcery

Clear the resolved lint baseline for chat message cloning and asset download utilities.

Enhancements:
- Align message cloning and asset download utilities with lint rules while preserving existing cloning behavior.
- Improve message cloning safety with explicit validation of source and cloned message mappings.

Tests:
- Normalize focused cloning and asset-download tests to satisfy import, object ordering, destructuring, and assertion lint rules.

Chores:
- Remove resolved utility lint baseline entries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears the lint baseline for chat message cloning and asset download utilities by aligning code and tests with lint rules.

- Normalizes import ordering, object key ordering, destructuring, and assertion usage across `clone-messages.ts`, `clone-messages.test.ts`, and `download-assets.test.ts`, including switching loops from `++` to `+= 1`.
- Adds explicit validation that source and cloned messages exist at each index when building the message ID map, throwing an error if either is missing.

<sup>Written for commit 09283838c7d0a3265404fc180ae50d6aac9895ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling during message cloning when expected source or cloned messages are unavailable.

- **Refactor**
  - Reorganized message and attachment cloning logic without changing its intended behavior.
  - Updated message content handling for compatibility with the latest SDK conventions.

- **Tests**
  - Refreshed cloning and asset-download test coverage and fixtures.

- **Chores**
  - Cleaned up lint configuration associated with removed test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->