### PR TITLE
chore(chat): clean AI evaluation and parallel request lint rules

### DIFF
--- a/apps/chat/lib/ai/eval-agent.ts
+++ b/apps/chat/lib/ai/eval-agent.ts
@@ -8,19 +8,16 @@ import { systemPrompt } from "@/lib/ai/prompts";
 import type { ChatMessage, StreamWriter, ToolName } from "@/lib/ai/types";
 import { CostAccumulator } from "@/lib/credits/cost-accumulator";
 import { generateUUID } from "@/lib/utils";
-
 // No-op StreamWriter for evals - tools can write but nothing happens
-function createNoOpStreamWriter(): StreamWriter {
-  return {
-    write: () => {
-      // Intentional no-op for evaluation context
-    },
+const createNoOpStreamWriter = (): StreamWriter =>
+  ({
     merge: () => {
       // Intentional no-op for evaluation context
     },
-  } as unknown as StreamWriter;
-}
-
+    write: () => {
+      // Intentional no-op for evaluation context
+    },
+  }) as unknown as StreamWriter;
 export interface EvalAgentResult {
   assistantMessage: ChatMessage;
   finalText: string;
@@ -32,8 +29,7 @@ export interface EvalAgentResult {
   }[];
   usage: LanguageModelUsage | undefined;
 }
-
-async function executeAgentAndGetOutput({
+const executeAgentAndGetOutput = async ({
   userMessage,
   previousMessages,
   selectedModelId,
@@ -60,118 +56,138 @@ async function executeAgentAndGetOutput({
       ReturnType<typeof createCoreChatAgent>
     >["result"]["responseMessages"]
   >;
-}> {
+}> => {
   const noOpStreamWriter = createNoOpStreamWriter();
-
+  const system = systemPrompt();
+  const costAccumulator = new CostAccumulator();
   const { result, contextForLLM } = await createCoreChatAgent({
-    system: systemPrompt(),
-    userMessage,
-    previousMessages,
-    selectedModelId,
-    explicitlyRequestedTools,
-    userId,
     abortSignal,
-    messageId,
+    // Discarded for evals
+    costAccumulator,
     dataStream: noOpStreamWriter,
+    explicitlyRequestedTools,
+    messageId,
     onError: (error) => {
       throw error;
     },
-    // Discarded for evals
-    costAccumulator: new CostAccumulator(),
+    previousMessages,
+    selectedModelId,
+    system,
+    userId,
+    userMessage,
   });
-
   await result.consumeStream();
   const responseMessages = await result.responseMessages;
   const output = await result.output;
+  return { contextForLLM, output: output || "", responseMessages, result };
+};
 
-  return { result, contextForLLM, output: output || "", responseMessages };
-}
-
-function processToolCall(
-  content: { toolCallId?: string; toolName: string; input: unknown },
+const processToolCall = (
+  content: {
+    toolCallId?: string;
+    toolName: string;
+    input: unknown;
+  },
   parts: ChatMessage["parts"],
-  toolResults: { toolName: string; type: string; state?: string }[]
-): void {
+  toolResults: {
+    toolName: string;
+    type: string;
+    state?: string;
+  }[]
+): void => {
   const toolCallId = content.toolCallId || generateUUID();
   const toolPartType = `tool-${content.toolName}` as const;
   parts.push({
-    type: toolPartType,
-    toolCallId,
-    state: "input-available",
     input: content.input,
+    state: "input-available",
+    toolCallId,
+    type: toolPartType,
   } as ChatMessage["parts"][number]);
   toolResults.push({
+    state: "input-available",
     toolName: content.toolName,
     type: toolPartType,
-    state: "input-available",
   });
-}
+};
 
-function updateExistingToolPart(
+const updateExistingToolPart = (
   parts: ChatMessage["parts"],
   toolCallId: string | undefined,
   output: unknown
-): boolean {
+): boolean => {
   const partIndex = parts.findIndex(
     (p) =>
       p.type.startsWith("tool-") &&
       "toolCallId" in p &&
       p.toolCallId === toolCallId
   );
-
   if (partIndex === -1) {
     return false;
   }
-
   const part = parts[partIndex];
   if (part.type.startsWith("tool-") && "state" in part) {
     parts[partIndex] = {
       ...part,
-      state: "output-available",
       output,
+      state: "output-available",
     } as ChatMessage["parts"][number];
   }
   return true;
-}
+};
 
-function addToolResultPart(
-  content: { toolCallId?: string; toolName: string; output: unknown },
+const addToolResultPart = (
+  content: {
+    toolCallId?: string;
+    toolName: string;
+    output: unknown;
+  },
   parts: ChatMessage["parts"]
-): void {
+): void => {
   const toolPartType = `tool-${content.toolName}` as const;
   parts.push({
-    type: toolPartType,
-    toolCallId: content.toolCallId || generateUUID(),
-    state: "output-available",
     output: content.output,
+    state: "output-available",
+    toolCallId: content.toolCallId || generateUUID(),
+    type: toolPartType,
   } as ChatMessage["parts"][number]);
-}
+};
 
-function updateToolResults(
-  toolResults: { toolName: string; type: string; state?: string }[],
+const updateToolResults = (
+  toolResults: {
+    toolName: string;
+    type: string;
+    state?: string;
+  }[],
   toolName: string
-): void {
+): void => {
   const existingIndex = toolResults.findIndex((tr) => tr.toolName === toolName);
   if (existingIndex === -1) {
     toolResults.push({
+      state: "output-available",
       toolName,
       type: `tool-${toolName}`,
-      state: "output-available",
     });
     return;
   }
-
   toolResults[existingIndex] = {
     ...toolResults[existingIndex],
     state: "output-available",
   };
-}
+};
 
-function processToolResult(
-  content: { toolCallId?: string; toolName: string; output: unknown },
+const processToolResult = (
+  content: {
+    toolCallId?: string;
+    toolName: string;
+    output: unknown;
+  },
   parts: ChatMessage["parts"],
-  toolResults: { toolName: string; type: string; state?: string }[]
-): void {
+  toolResults: {
+    toolName: string;
+    type: string;
+    state?: string;
+  }[]
+): void => {
   const updated = updateExistingToolPart(
     parts,
     content.toolCallId,
@@ -181,23 +197,26 @@ function processToolResult(
     addToolResultPart(content, parts);
   }
   updateToolResults(toolResults, content.toolName);
-}
+};
 
-function extractToolCallsAndResults(
+const extractToolCallsAndResults = (
   steps: Awaited<
     Awaited<ReturnType<typeof createCoreChatAgent>>["result"]["steps"]
   >
 ): {
   parts: ChatMessage["parts"];
-  toolResults: { toolName: string; type: string; state?: string }[];
-} {
+  toolResults: {
+    toolName: string;
+    type: string;
+    state?: string;
+  }[];
+} => {
   const toolResults: {
     toolName: string;
     type: string;
     state?: string;
   }[] = [];
   const parts: ChatMessage["parts"] = [];
-
   for (const step of steps ?? []) {
     for (const content of step.content) {
       if (content.type === "tool-call") {
@@ -207,11 +226,10 @@ function extractToolCallsAndResults(
       }
     }
   }
-
   return { parts, toolResults };
-}
+};
 
-async function generateSuggestions(
+const generateSuggestions = async (
   contextForLLM: Awaited<
     ReturnType<typeof createCoreChatAgent>
   >["contextForLLM"],
@@ -220,12 +238,11 @@ async function generateSuggestions(
       ReturnType<typeof createCoreChatAgent>
     >["result"]["responseMessages"]
   >
-): Promise<string[]> {
+): Promise<string[]> => {
   const followupSuggestionsResult = generateFollowupSuggestions([
     ...contextForLLM,
     ...responseMessages,
   ]);
-
   const result = await followupSuggestionsResult;
   let lastSuggestions: string[] = [];
   for await (const chunk of result.partialOutputStream) {
@@ -235,11 +252,10 @@ async function generateSuggestions(
       );
     }
   }
-
   return lastSuggestions.length > 0 ? lastSuggestions.slice(-5) : [];
-}
+};
 
-export async function runCoreChatAgentEval({
+export const runCoreChatAgentEval = async ({
   userMessage,
   previousMessages = [],
   selectedModelId,
@@ -255,58 +271,52 @@ export async function runCoreChatAgentEval({
   userId?: string | null;
   activeTools: ToolName[];
   abortSignal?: AbortSignal;
-}): Promise<EvalAgentResult> {
+}): Promise<EvalAgentResult> => {
   const messageId = generateUUID();
   const requestedTools = determineExplicitlyRequestedTools(selectedTool);
   const explicitlyRequestedTools =
     requestedTools === null
       ? activeTools
       : requestedTools.filter((tool) => activeTools.includes(tool));
-
   const { result, contextForLLM, output, responseMessages } =
     await executeAgentAndGetOutput({
-      userMessage,
+      abortSignal,
+      explicitlyRequestedTools,
+      messageId,
       previousMessages,
       selectedModelId,
-      explicitlyRequestedTools,
       userId,
-      abortSignal,
-      messageId,
+      userMessage,
     });
-
   const steps = (await result.steps) ?? [];
   const { parts, toolResults } = extractToolCallsAndResults(steps);
-
   if (output) {
     parts.unshift({
-      type: "text",
       text: output,
+      type: "text",
     });
   }
-
   const assistantMessage: ChatMessage = {
     id: messageId,
-    role: "assistant",
-    parts,
     metadata: {
+      activeStreamId: null,
       createdAt: new Date(),
       parentMessageId: userMessage.id,
       selectedModel: selectedModelId,
-      activeStreamId: null,
     },
+    parts,
+    role: "assistant",
   };
-
   const followupSuggestions = await generateSuggestions(
     contextForLLM,
     responseMessages
   );
   const usage = await result.usage;
-
   return {
-    finalText: output,
     assistantMessage,
-    usage,
-    toolResults,
+    finalText: output,
     followupSuggestions,
+    toolResults,
+    usage,
   };
-}
+};

--- a/apps/chat/lib/ai/eval-agent.ts
+++ b/apps/chat/lib/ai/eval-agent.ts
@@ -8,16 +8,18 @@ import { systemPrompt } from "@/lib/ai/prompts";
 import type { ChatMessage, StreamWriter, ToolName } from "@/lib/ai/types";
 import { CostAccumulator } from "@/lib/credits/cost-accumulator";
 import { generateUUID } from "@/lib/utils";
+
 // No-op StreamWriter for evals - tools can write but nothing happens
-const createNoOpStreamWriter = (): StreamWriter =>
-  ({
-    merge: () => {
-      // Intentional no-op for evaluation context
-    },
-    write: () => {
-      // Intentional no-op for evaluation context
-    },
-  }) as unknown as StreamWriter;
+const createNoOpStreamWriter = (): StreamWriter => ({
+  merge: () => {
+    // Intentional no-op for evaluation context
+  },
+  onError: undefined,
+  write: () => {
+    // Intentional no-op for evaluation context
+  },
+});
+
 export interface EvalAgentResult {
   assistantMessage: ChatMessage;
   finalText: string;

--- a/apps/chat/lib/parallel-chat-requests.test.ts
+++ b/apps/chat/lib/parallel-chat-requests.test.ts
@@ -55,7 +55,7 @@ const message: ChatMessage = {
     parentMessageId: null,
     selectedModel: gatewayModelDefaults.workflows.chat,
   },
-  parts: [{ type: "text", text: "Compare both approaches" }],
+  parts: [{ text: "Compare both approaches", type: "text" }],
   role: "user",
 };
 
@@ -83,6 +83,38 @@ afterEach(() => {
 });
 
 describe("runParallelThreadRequestSpecs", () => {
+  it("fails a blocked secondary run when the primary ends without persistence", async () => {
+    const transport = new ControlledTransport();
+    const chat = new Thread<ChatMessage>({
+      transport: createGatedChatTransport(transport),
+    });
+    const result = runParallelThreadRequestSpecs({
+      chatId: "unconfirmed-chat",
+      isAuthenticated: true,
+      message,
+      onRunStarted: vi.fn(),
+      projectId: null,
+      requestSpecs,
+      startRun: chat.startRun,
+    });
+
+    await vi.waitFor(() => {
+      assert.equal(chat.getSnapshot().runs.length, 2);
+    });
+    transport.finish(0, "primary-without-ack");
+
+    assert.deepEqual(await result, [requestSpecs[1]]);
+    assert.equal(transport.requests.length, 1);
+    assert.equal(
+      acknowledgeParallelUserMessagePersistence({
+        chatId: "unconfirmed-chat",
+        parallelGroupId: "response-group-1",
+        userMessageId: message.id,
+      }),
+      false
+    );
+  });
+
   it("creates every run immediately and gates only secondary transport", async () => {
     const underlyingTransport = new ControlledTransport();
     const startedRuns: {

--- a/apps/chat/lib/parallel-chat-requests.ts
+++ b/apps/chat/lib/parallel-chat-requests.ts
@@ -13,44 +13,49 @@ export interface ParallelRequestBody {
   requestId: string;
   selectedModelId: AppModelId;
 }
-
 interface UserMessagePersistenceAcknowledgment {
   chatId: string;
   parallelGroupId: string | null;
   userMessageId: string;
 }
-
 interface PersistenceGate {
   readonly promise: Promise<void>;
   reject: (error: unknown) => void;
   resolve: () => void;
   readonly settled: boolean;
 }
-
 const persistenceGates = new Map<
   string,
-  { gate: PersistenceGate; parallelGroupId: string | null }
+  {
+    gate: PersistenceGate;
+    parallelGroupId: string | null;
+  }
 >();
+const persistenceGateKey = (chatId: string, userMessageId: string) =>
+  `${chatId}:${userMessageId}`;
+const observeRejection = async (promise: Promise<unknown>) => {
+  try {
+    await promise;
+  } catch {
+    // The secondary transport receives the original gate rejection.
+  }
+};
 
-function persistenceGateKey(chatId: string, userMessageId: string) {
-  return `${chatId}:${userMessageId}`;
-}
+const noop = () => {
+  // Replaced synchronously by the promise executor.
+};
 
-function createPersistenceGate(): PersistenceGate {
-  let rejectPromise: (error: unknown) => void = () => undefined;
-  let resolvePromise: () => void = () => undefined;
+const createPersistenceGate = (): PersistenceGate => {
+  let rejectPromise: (error: unknown) => void = noop;
+  let resolvePromise: () => void = noop;
   let settled = false;
   const promise = new Promise<void>((resolve, reject) => {
     rejectPromise = reject;
     resolvePromise = resolve;
   });
-  promise.catch(() => undefined);
-
+  void observeRejection(promise);
   return {
     promise,
-    get settled() {
-      return settled;
-    },
     reject(error) {
       if (settled) {
         return;
@@ -65,29 +70,31 @@ function createPersistenceGate(): PersistenceGate {
       settled = true;
       resolvePromise();
     },
+    get settled() {
+      return settled;
+    },
   };
-}
+};
 
-function registerPersistenceGate({
+const registerPersistenceGate = ({
   chatId,
   message,
 }: {
   chatId: string;
   message: ChatMessage;
-}) {
+}) => {
   const key = persistenceGateKey(chatId, message.id);
   const previous = persistenceGates.get(key);
   previous?.gate.reject(new Error("Persistence gate replaced"));
-
   const gate = createPersistenceGate();
   persistenceGates.set(key, {
     gate,
     parallelGroupId: message.metadata.parallelGroupId ?? null,
   });
   return gate;
-}
+};
 
-function rejectPersistenceGate({
+const rejectPersistenceGate = ({
   chatId,
   error,
   gate,
@@ -97,17 +104,44 @@ function rejectPersistenceGate({
   error: unknown;
   gate: PersistenceGate;
   userMessageId: string;
-}) {
+}) => {
   const key = persistenceGateKey(chatId, userMessageId);
   if (persistenceGates.get(key)?.gate === gate) {
     persistenceGates.delete(key);
   }
   gate.reject(error);
-}
+};
 
-export function acknowledgeParallelUserMessagePersistence(
+const rejectWhenPrimaryFinishes = async ({
+  chatId,
+  gate,
+  primaryFinished,
+  userMessageId,
+}: {
+  chatId: string;
+  gate: PersistenceGate;
+  primaryFinished: Promise<unknown>;
+  userMessageId: string;
+}) => {
+  try {
+    await primaryFinished;
+  } catch {
+    // The caller handles a failed primary run separately.
+    return;
+  }
+  if (!gate.settled) {
+    rejectPersistenceGate({
+      chatId,
+      error: new Error("Primary response ended before user persistence"),
+      gate,
+      userMessageId,
+    });
+  }
+};
+
+export const acknowledgeParallelUserMessagePersistence = (
   acknowledgment: UserMessagePersistenceAcknowledgment
-) {
+) => {
   const key = persistenceGateKey(
     acknowledgment.chatId,
     acknowledgment.userMessageId
@@ -116,33 +150,29 @@ export function acknowledgeParallelUserMessagePersistence(
   if (!entry || entry.parallelGroupId !== acknowledgment.parallelGroupId) {
     return false;
   }
-
   persistenceGates.delete(key);
   entry.gate.resolve();
   return true;
-}
+};
 
-export function clearParallelPersistenceGates() {
+export const clearParallelPersistenceGates = () => {
   for (const { gate } of persistenceGates.values()) {
     gate.reject(new Error("Persistence gates cleared"));
   }
   persistenceGates.clear();
-}
+};
 
-export function createParallelRequestBody(
+export const createParallelRequestBody = (
   requestSpec: ParallelRequestSpec,
   isPrimaryParallel = requestSpec.isPrimary
-): ParallelRequestBody {
-  return {
-    selectedModelId: requestSpec.modelId,
-    parallelGroupId: requestSpec.parallelGroupId,
-    parallelIndex: requestSpec.parallelIndex,
-    requestId: requestSpec.requestId,
-    isPrimaryParallel,
-  };
-}
-
-export async function runParallelThreadRequestSpecs({
+): ParallelRequestBody => ({
+  isPrimaryParallel,
+  parallelGroupId: requestSpec.parallelGroupId,
+  parallelIndex: requestSpec.parallelIndex,
+  requestId: requestSpec.requestId,
+  selectedModelId: requestSpec.modelId,
+});
+export const runParallelThreadRequestSpecs = async ({
   chatId,
   isAuthenticated,
   message,
@@ -162,17 +192,15 @@ export async function runParallelThreadRequestSpecs({
     runId: string;
   }) => void;
   startRun: TreeHelpers<ChatMessage>["startRun"];
-}) {
-  const primaryRequest = requestSpecs[0];
+}) => {
+  const [primaryRequest] = requestSpecs;
   if (!primaryRequest) {
     return [];
   }
-
   const persistenceGate =
     isAuthenticated && requestSpecs.length > 1
       ? registerPersistenceGate({ chatId, message })
       : null;
-
   try {
     const primaryRun = await startRun({
       message,
@@ -190,7 +218,6 @@ export async function runParallelThreadRequestSpecs({
         runId: primaryRun.id,
       });
     }
-
     const secondaryRuns = await Promise.all(
       requestSpecs.slice(1).map(async (requestSpec) => {
         const run = await startRun({
@@ -216,25 +243,14 @@ export async function runParallelThreadRequestSpecs({
         return { requestSpec, run };
       })
     );
-
     const rejectUnconfirmedPersistence = persistenceGate
-      ? primaryRun.finished.then(
-          () => {
-            if (!persistenceGate.settled) {
-              rejectPersistenceGate({
-                chatId,
-                error: new Error(
-                  "Primary response ended before user persistence"
-                ),
-                gate: persistenceGate,
-                userMessageId: message.id,
-              });
-            }
-          },
-          () => undefined
-        )
+      ? rejectWhenPrimaryFinishes({
+          chatId,
+          gate: persistenceGate,
+          primaryFinished: primaryRun.finished,
+          userMessageId: message.id,
+        })
       : Promise.resolve();
-
     const runs = [
       { requestSpec: primaryRequest, run: primaryRun },
       ...secondaryRuns,
@@ -243,7 +259,6 @@ export async function runParallelThreadRequestSpecs({
       ...runs.map(({ run }) => run.finished),
       rejectUnconfirmedPersistence,
     ]);
-
     return runs
       .filter(({ run }) => run.getSnapshot()?.status === "error")
       .map(({ requestSpec }) => requestSpec);
@@ -258,4 +273,4 @@ export async function runParallelThreadRequestSpecs({
     }
     throw error;
   }
-}
+};

--- a/apps/chat/oxlint-baseline.json
+++ b/apps/chat/oxlint-baseline.json
@@ -15,11 +15,13 @@
       }
     },
     {
-      "files": [
-        "lib/ai/gateway.ts",
-        "lib/ai/text-splitter.ts",
-        "lib/parallel-chat-requests.test.ts"
-      ],
+      "files": ["lib/ai/gateway.ts", "lib/ai/text-splitter.ts"],
+      "rules": {
+        "class-methods-use-this": "off"
+      }
+    },
+    {
+      "files": ["lib/parallel-chat-requests.test.ts"],
       "rules": {
         "class-methods-use-this": "off"
       }
@@ -212,7 +214,6 @@
         "hooks/use-artifact.tsx",
         "lib/ai/active-gateway.ts",
         "lib/ai/core-chat-agent.ts",
-        "lib/ai/eval-agent.ts",
         "lib/anonymous-session-client.ts",
         "lib/app-chat-runtime.ts",
         "lib/artifacts/code/client.tsx",
@@ -229,7 +230,6 @@
         "lib/files/upload-prep.ts",
         "lib/gated-chat-transport.test.ts",
         "lib/message-conversion.ts",
-        "lib/parallel-chat-requests.ts",
         "lib/runtime-registry/runtime-api.ts",
         "lib/runtime-registry/runtime-registry-provider.tsx",
         "lib/start-provisional-chat.ts",
@@ -642,7 +642,6 @@
         "lib/draft-chat-submission.ts",
         "lib/files/upload-prep.ts",
         "lib/message-conversion.ts",
-        "lib/parallel-chat-requests.ts",
         "lib/start-provisional-chat.ts",
         "lib/stores/with-tracing.ts"
       ],
@@ -668,11 +667,16 @@
         "lib/cancellation-aware-chat-transport.test.ts",
         "lib/gated-chat-transport.test.ts",
         "lib/gated-chat-transport.ts",
-        "lib/parallel-chat-requests.ts",
         "lib/redis/client.test.ts",
         "lib/redis/client.ts",
         "scripts/check-redis.ts"
       ],
+      "rules": {
+        "promise/avoid-new": "off"
+      }
+    },
+    {
+      "files": ["lib/parallel-chat-requests.ts"],
       "rules": {
         "promise/avoid-new": "off"
       }
@@ -727,7 +731,6 @@
         "lib/artifacts/text/client.tsx",
         "lib/cancellation-aware-chat-transport.ts",
         "lib/gated-chat-transport.ts",
-        "lib/parallel-chat-requests.ts",
         "lib/start-provisional-chat.ts",
         "tools/platform/deep-research/supervisor-agent.ts"
       ],
@@ -1239,7 +1242,6 @@
         "hooks/use-artifact.tsx",
         "lib/ai/active-gateway.ts",
         "lib/ai/core-chat-agent.ts",
-        "lib/ai/eval-agent.ts",
         "lib/ai/gateway-model-defaults.ts",
         "lib/ai/gateways/fallback-models.ts",
         "lib/ai/markdown-joiner-transform.ts",
@@ -1270,8 +1272,6 @@
         "lib/files/upload-prep.ts",
         "lib/logger.ts",
         "lib/message-conversion.ts",
-        "lib/parallel-chat-requests.test.ts",
-        "lib/parallel-chat-requests.ts",
         "lib/redis/client.test.ts",
         "lib/stores/base/hooks.ts",
         "lib/stores/with-data-stream.test.ts",
@@ -1367,8 +1367,7 @@
       "files": [
         "components/ai-elements/prompt-input.tsx",
         "components/sheet-editor.tsx",
-        "lib/gated-chat-transport.test.ts",
-        "lib/parallel-chat-requests.ts"
+        "lib/gated-chat-transport.test.ts"
       ],
       "rules": {
         "unicorn/consistent-function-scoping": "off"
@@ -1429,7 +1428,6 @@
         "components/data-stream-handler.tsx",
         "lib/cancellation-aware-chat-transport.ts",
         "lib/gated-chat-transport.ts",
-        "lib/parallel-chat-requests.ts",
         "lib/redis/client.test.ts",
         "lib/social-auth.test.ts",
         "providers/session-provider.tsx"


### PR DESCRIPTION
Removes 43 strict lint violations and nine resolved file/rule exemptions across AI evaluation, parallel request helpers, and their test. Converts helpers to function expressions, sorts object keys, and expresses persistence rejection handling with async/await while preserving failure propagation.

Adds a regression test proving that a primary run finishing without persistence acknowledgment fails its blocked secondary run and clears the persistence gate. Keeps the existing deferred-promise exemption because this gate requires external resolution.

Validation: root bun lint and bun test:types passed; six parallel-request and gated-transport tests passed. Independent behavior review found no regressions.

## Summary by Sourcery

Harden parallel request persistence handling and clean up lint compliance across evaluation and request helpers.

Bug Fixes:
- Ensure blocked secondary parallel runs fail when the primary run completes without user-message persistence acknowledgment, while clearing the persistence gate.

Enhancements:
- Clean up AI evaluation and parallel-request code to satisfy lint rules and standardize function, object, and asynchronous error-handling patterns.

Tests:
- Add regression coverage for secondary-run failure and persistence-gate cleanup when primary persistence is not acknowledged.

Chores:
- Remove resolved oxlint violations and associated baseline exemptions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up lint violations in AI evaluation and parallel request helpers by converting to arrow functions, sorting object keys, and using async/await for persistence rejection. The eval stream writer now satisfies its contract with the missing `onError` field, and a regression test confirms a primary run ending without persistence acknowledgment fails its blocked secondary run and clears the gate.

<sup>Written for commit ce5323ad2a4503beb3a6e1efde321d5fffc049b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved parallel chat request handling when the primary response completes before persistence is acknowledged.
  - Secondary requests now remain appropriately blocked, and the system accurately reports the affected request and acknowledgment status.

- **Refactor**
  - Internal request-processing logic was reorganized without changing expected functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->