### PR TITLE
chore(chat): clear db queries lint baseline

### DIFF
--- a/apps/chat/lib/db/queries.ts
+++ b/apps/chat/lib/db/queries.ts
@@ -40,14 +40,108 @@ import type { DBMessage, Part, User, UserModelPreference } from "./schema";
 
 const logger = createModuleLogger("db:queries");
 
-async function _getUserByEmail(email: string): Promise<User[]> {
+const getMessagesWithAttachments = async () => {
+  try {
+    return await db.select({ attachments: message.attachments }).from(message);
+  } catch (error) {
+    console.error(
+      "Failed to get messages with attachments from database",
+      error
+    );
+    throw error;
+  }
+};
+
+const getGeneratedImageParts = () => {
+  const toolName: ToolName = "generateImage";
+  return db
+    .select({ tool_output: part.tool_output })
+    .from(part)
+    .where(eq(part.tool_name, toolName));
+};
+
+const getFilePartUrls = (args: { messageIds?: string[] } = {}) => {
+  const { messageIds } = args;
+  let conditions: SQL<unknown> | undefined = eq(part.type, "file");
+  if (messageIds && messageIds.length > 0) {
+    conditions = and(conditions, inArray(part.messageId, messageIds));
+  }
+  return db.select({ file_url: part.file_url }).from(part).where(conditions);
+};
+
+const collectMessageAttachmentUrls = (
+  messages: { attachments: unknown }[]
+): string[] => {
+  const urls: string[] = [];
+  for (const msg of messages) {
+    if (msg.attachments && Array.isArray(msg.attachments)) {
+      for (const attachment of msg.attachments as Attachment[]) {
+        if (attachment.url) {
+          urls.push(attachment.url);
+        }
+      }
+    }
+  }
+  return urls;
+};
+
+const collectFilePartUrls = (
+  fileParts: { file_url: string | null }[]
+): string[] => {
+  const urls: string[] = [];
+  for (const p of fileParts) {
+    if (p.file_url) {
+      urls.push(p.file_url);
+    }
+  }
+  return urls;
+};
+
+const deleteAttachmentsFromMessages = async (messages: DBMessage[]) => {
+  try {
+    const attachmentUrls = collectMessageAttachmentUrls(messages);
+
+    // Collect file URLs from Part table for these messages via shared helper
+    const messageIds = messages.map((msg) => msg.id);
+    if (messageIds.length > 0) {
+      const fileParts = await getFilePartUrls({ messageIds });
+      attachmentUrls.push(...collectFilePartUrls(fileParts));
+    }
+
+    // Deduplicate in case the same file URL is referenced multiple times
+    const uniqueUrls = [...new Set(attachmentUrls)];
+    if (uniqueUrls.length > 0) {
+      await deleteFilesByUrls(uniqueUrls);
+    }
+  } catch (error) {
+    console.error("Failed to delete stored attachments:", error);
+    // Don't throw here - we still want to proceed with message deletion
+    // even if blob cleanup fails
+  }
+};
+
+const updateChatUpdatedAt = async ({ chatId }: { chatId: string }) => {
+  try {
+    return await db
+      .update(chat)
+      .set({
+        updatedAt: new Date(),
+      })
+      .where(eq(chat.id, chatId));
+  } catch (error) {
+    console.error("Failed to update chat updatedAt by id from database");
+    throw error;
+  }
+};
+
+const _getUserByEmail = async (email: string): Promise<User[]> => {
   try {
     return await db.select().from(user).where(eq(user.email, email));
   } catch (error) {
     console.error("Failed to get user from database");
     throw error;
   }
-}
+};
 
 export const saveChat = async ({
   id,
@@ -62,12 +156,12 @@ export const saveChat = async ({
 }) => {
   try {
     return await db.insert(chat).values({
-      id,
       createdAt: new Date(),
+      id,
+      projectId: projectId ?? null,
+      title,
       updatedAt: new Date(),
       userId,
-      title,
-      projectId: projectId ?? null,
     });
   } catch (error) {
     console.error("Failed to save chat in database");
@@ -90,12 +184,12 @@ export const saveChatIfNotExists = async ({
     return await db
       .insert(chat)
       .values({
-        id,
         createdAt: new Date(),
+        id,
+        projectId: projectId ?? null,
+        title,
         updatedAt: new Date(),
         userId,
-        title,
-        projectId: projectId ?? null,
       })
       .onConflictDoNothing();
   } catch (error) {
@@ -132,11 +226,11 @@ export const getChatsByUserId = async ({
   projectId?: string | null;
 }) => {
   console.log("[getChatsByUserId] Starting", {
-    userId: id,
     projectId,
-    projectIdType: typeof projectId,
     projectIdIsNull: projectId === null,
     projectIdIsUndefined: projectId === undefined,
+    projectIdType: typeof projectId,
+    userId: id,
   });
 
   try {
@@ -183,8 +277,8 @@ export const getChatsByUserId = async ({
         error,
         errorMessage: error instanceof Error ? error.message : String(error),
         errorStack: error instanceof Error ? error.stack : undefined,
-        userId: id,
         projectId,
+        userId: id,
       }
     );
     throw error;
@@ -208,14 +302,14 @@ export const createProject = async ({
 }) => {
   try {
     return await db.insert(project).values({
-      id,
-      userId,
-      name,
-      instructions,
+      createdAt: new Date(),
       ...(icon && { icon }),
       ...(iconColor && { iconColor }),
-      createdAt: new Date(),
+      id,
+      instructions,
+      name,
       updatedAt: new Date(),
+      userId,
     });
   } catch (error) {
     console.error("Failed to create project in database");
@@ -284,7 +378,7 @@ export const deleteProject = async ({ id }: { id: string }) => {
   }
 };
 
-async function _getChatsByProjectId({ projectId }: { projectId: string }) {
+const _getChatsByProjectId = async ({ projectId }: { projectId: string }) => {
   try {
     return await db
       .select()
@@ -295,31 +389,31 @@ async function _getChatsByProjectId({ projectId }: { projectId: string }) {
     console.error("Failed to get chats by project id from database");
     throw error;
   }
-}
+};
 
-async function _moveChatToProject({
+const _moveChatToProject = async ({
   chatId,
   projectId,
 }: {
   chatId: string;
   projectId: string | null;
-}) {
+}) => {
   try {
     return await db.update(chat).set({ projectId }).where(eq(chat.id, chatId));
   } catch (error) {
     console.error("Failed to move chat to project in database");
     throw error;
   }
-}
+};
 
-async function _tryGetChatById({ id }: { id: string }) {
+const _tryGetChatById = async ({ id }: { id: string }) => {
   try {
     const [selectedChat] = await db.select().from(chat).where(eq(chat.id, id));
     return selectedChat;
   } catch {
     return null;
   }
-}
+};
 
 export const getChatById = async ({ id }: { id: string }) => {
   try {
@@ -331,7 +425,7 @@ export const getChatById = async ({ id }: { id: string }) => {
   }
 };
 
-export async function saveMessage({
+export const saveMessage = async ({
   id,
   chatId,
   message: chatMessage,
@@ -339,7 +433,7 @@ export async function saveMessage({
   id: string;
   chatId: string;
   message: ChatMessage;
-}) {
+}) => {
   try {
     return await db.transaction(async (tx) => {
       // Convert ChatMessage to DBMessage (without parts)
@@ -359,12 +453,12 @@ export async function saveMessage({
       await updateChatUpdatedAt({ chatId });
     });
   } catch (error) {
-    logger.error({ error, chatId, id }, "saveMessage failed");
+    logger.error({ chatId, error, id }, "saveMessage failed");
     throw error;
   }
-}
+};
 
-export async function saveMessageIfNotExists({
+export const saveMessageIfNotExists = async ({
   id,
   chatId,
   message: chatMessage,
@@ -372,7 +466,7 @@ export async function saveMessageIfNotExists({
   id: string;
   chatId: string;
   message: ChatMessage;
-}) {
+}) => {
   try {
     return await db.transaction(async (tx) => {
       const dbMessage = chatMessageToDbMessage(chatMessage, chatId);
@@ -397,12 +491,12 @@ export async function saveMessageIfNotExists({
       return true;
     });
   } catch (error) {
-    logger.error({ error, chatId, id }, "saveMessageIfNotExists failed");
+    logger.error({ chatId, error, id }, "saveMessageIfNotExists failed");
     throw error;
   }
-}
+};
 
-export async function saveChatMessages({
+export const saveChatMessages = async ({
   messages,
 }: {
   messages: {
@@ -410,7 +504,7 @@ export async function saveChatMessages({
     chatId: string;
     message: ChatMessage;
   }[];
-}) {
+}) => {
   try {
     if (messages.length === 0) {
       return;
@@ -447,9 +541,9 @@ export async function saveChatMessages({
     );
     throw error;
   }
-}
+};
 
-export async function updateMessage({
+export const updateMessage = async ({
   id,
   chatId,
   message: chatMessage,
@@ -457,7 +551,7 @@ export async function updateMessage({
   id: string;
   chatId: string;
   message: ChatMessage;
-}) {
+}) => {
   try {
     return await db.transaction(async (tx) => {
       // Convert ChatMessage to DBMessage (without parts)
@@ -468,17 +562,17 @@ export async function updateMessage({
       const updatedMessages = await tx
         .update(message)
         .set({
+          activeStreamId: dbMessage.activeStreamId,
           annotations: dbMessage.annotations,
           attachments: dbMessage.attachments,
           createdAt: dbMessage.createdAt,
+          isPrimaryParallel: dbMessage.isPrimaryParallel,
+          lastContext: dbMessage.lastContext,
+          parallelGroupId: dbMessage.parallelGroupId,
+          parallelIndex: dbMessage.parallelIndex,
           parentMessageId: dbMessage.parentMessageId,
           selectedModel: dbMessage.selectedModel,
           selectedTool: dbMessage.selectedTool,
-          parallelGroupId: dbMessage.parallelGroupId,
-          parallelIndex: dbMessage.parallelIndex,
-          isPrimaryParallel: dbMessage.isPrimaryParallel,
-          lastContext: dbMessage.lastContext,
-          activeStreamId: dbMessage.activeStreamId,
         })
         .where(
           and(
@@ -506,26 +600,24 @@ export async function updateMessage({
       return true;
     });
   } catch (error) {
-    logger.error({ error, messageId: id, chatId }, "updateMessage failed");
+    logger.error({ chatId, error, messageId: id }, "updateMessage failed");
     throw error;
   }
-}
+};
 
-export function updateMessageActiveStreamId({
+export const updateMessageActiveStreamId = ({
   id,
   activeStreamId,
 }: {
   id: string;
   activeStreamId: string | null;
-}) {
-  return db.update(message).set({ activeStreamId }).where(eq(message.id, id));
-}
+}) => db.update(message).set({ activeStreamId }).where(eq(message.id, id));
 
-export async function getAllMessagesByChatId({
+export const getAllMessagesByChatId = async ({
   chatId,
 }: {
   chatId: string;
-}): Promise<ChatMessage[]> {
+}): Promise<ChatMessage[]> => {
   try {
     const messages = await db
       .select()
@@ -561,15 +653,13 @@ export async function getAllMessagesByChatId({
 
       return {
         id: msg.id,
-        role: msg.role as ChatMessage["role"],
-        parts,
         metadata: {
-          createdAt: msg.createdAt,
           activeStreamId: msg.activeStreamId,
-          parentMessageId: msg.parentMessageId,
+          createdAt: msg.createdAt,
+          isPrimaryParallel: msg.isPrimaryParallel,
           parallelGroupId: msg.parallelGroupId,
           parallelIndex: msg.parallelIndex,
-          isPrimaryParallel: msg.isPrimaryParallel,
+          parentMessageId: msg.parentMessageId,
           selectedModel: isSelectedModelValue(msg.selectedModel)
             ? msg.selectedModel
             : ("" as ChatMessage["metadata"]["selectedModel"]),
@@ -577,15 +667,17 @@ export async function getAllMessagesByChatId({
             undefined) as ChatMessage["metadata"]["selectedTool"],
           usage: msg.lastContext as ChatMessage["metadata"]["usage"],
         },
+        parts,
+        role: msg.role as ChatMessage["role"],
       };
     });
   } catch (error) {
     console.error("Failed to get all messages by chat ID", error);
     throw error;
   }
-}
+};
 
-export async function voteMessage({
+export const voteMessage = async ({
   chatId,
   messageId,
   type,
@@ -593,7 +685,7 @@ export async function voteMessage({
   chatId: string;
   messageId: string;
   type: "up" | "down";
-}) {
+}) => {
   try {
     const [existingVote] = await db
       .select()
@@ -608,25 +700,25 @@ export async function voteMessage({
     }
     return await db.insert(vote).values({
       chatId,
-      messageId,
       isUpvoted: type === "up",
+      messageId,
     });
   } catch (error) {
     console.error("Failed to upvote message in database", error);
     throw error;
   }
-}
+};
 
-export async function getVotesByChatId({ id }: { id: string }) {
+export const getVotesByChatId = async ({ id }: { id: string }) => {
   try {
     return await db.select().from(vote).where(eq(vote.chatId, id));
   } catch (error) {
     console.error("Failed to get votes by chat id from database", error);
     throw error;
   }
-}
+};
 
-export async function saveDocument({
+export const saveDocument = async ({
   id,
   title,
   kind,
@@ -640,24 +732,24 @@ export async function saveDocument({
   content: string;
   userId: string;
   messageId: string;
-}) {
+}) => {
   try {
     return await db.insert(document).values({
-      id,
-      title,
-      kind,
       content,
-      userId,
-      messageId,
       createdAt: new Date(),
+      id,
+      kind,
+      messageId,
+      title,
+      userId,
     });
   } catch (error) {
     console.error("Failed to save document in database", error);
     throw error;
   }
-}
+};
 
-async function _getDocumentsById({ id }: { id: string }) {
+const _getDocumentsById = async ({ id }: { id: string }) => {
   try {
     const documents = await db
       .select()
@@ -670,15 +762,15 @@ async function _getDocumentsById({ id }: { id: string }) {
     console.error("Failed to get document by id from database", error);
     throw error;
   }
-}
+};
 
-export async function getDocumentsById({
+export const getDocumentsById = async ({
   id,
   userId,
 }: {
   id: string;
   userId?: string;
-}) {
+}) => {
   try {
     // First, get the document and check ownership
     const documents = await _getDocumentsById({ id });
@@ -693,14 +785,14 @@ export async function getDocumentsById({
       // Need to check if chat is public
       const documentsWithVisibility = await db
         .select({
-          id: document.id,
-          createdAt: document.createdAt,
-          title: document.title,
-          content: document.content,
-          kind: document.kind,
-          userId: document.userId,
-          messageId: document.messageId,
           chatVisibility: chat.visibility,
+          content: document.content,
+          createdAt: document.createdAt,
+          id: document.id,
+          kind: document.kind,
+          messageId: document.messageId,
+          title: document.title,
+          userId: document.userId,
         })
         .from(document)
         .innerJoin(message, eq(document.messageId, message.id))
@@ -718,19 +810,19 @@ export async function getDocumentsById({
     );
     throw error;
   }
-}
+};
 
-export async function getPublicDocumentsById({ id }: { id: string }) {
+export const getPublicDocumentsById = async ({ id }: { id: string }) => {
   try {
     const documents = await db
       .select({
-        id: document.id,
-        createdAt: document.createdAt,
-        title: document.title,
         content: document.content,
+        createdAt: document.createdAt,
+        id: document.id,
         kind: document.kind,
-        userId: document.userId,
         messageId: document.messageId,
+        title: document.title,
+        userId: document.userId,
       })
       .from(document)
       .innerJoin(message, eq(document.messageId, message.id))
@@ -743,9 +835,9 @@ export async function getPublicDocumentsById({ id }: { id: string }) {
     console.error("Failed to get public documents by id from database");
     throw error;
   }
-}
+};
 
-export async function getDocumentById({ id }: { id: string }) {
+export const getDocumentById = async ({ id }: { id: string }) => {
   try {
     const [selectedDocument] = await db
       .select()
@@ -758,15 +850,15 @@ export async function getDocumentById({ id }: { id: string }) {
     console.error("Failed to get document by id from database");
     throw error;
   }
-}
+};
 
-async function _deleteDocumentsByIdAfterTimestamp({
+const _deleteDocumentsByIdAfterTimestamp = async ({
   id,
   timestamp,
 }: {
   id: string;
   timestamp: Date;
-}) {
+}) => {
   try {
     await db
       .delete(suggestion)
@@ -786,13 +878,13 @@ async function _deleteDocumentsByIdAfterTimestamp({
     );
     throw error;
   }
-}
+};
 
-export async function getDocumentsByMessageIds({
+export const getDocumentsByMessageIds = async ({
   messageIds,
 }: {
   messageIds: string[];
-}) {
+}) => {
   if (messageIds.length === 0) {
     return [];
   }
@@ -807,9 +899,9 @@ export async function getDocumentsByMessageIds({
     console.error("Failed to get documents by message IDs from database");
     throw error;
   }
-}
+};
 
-export async function saveDocuments({
+export const saveDocuments = async ({
   documents,
 }: {
   documents: {
@@ -821,7 +913,7 @@ export async function saveDocuments({
     messageId: string;
     createdAt: Date;
   }[];
-}) {
+}) => {
   if (documents.length === 0) {
     return;
   }
@@ -832,25 +924,25 @@ export async function saveDocuments({
     console.error("Failed to save documents in database", error);
     throw error;
   }
-}
+};
 
-export async function getMessageById({ id }: { id: string }) {
+export const getMessageById = async ({ id }: { id: string }) => {
   try {
     return await db.select().from(message).where(eq(message.id, id));
   } catch (error) {
     logger.error({ error, messageId: id }, "getMessageById failed");
     throw error;
   }
-}
+};
 
-export async function getChatMessageWithPartsById({
+export const getChatMessageWithPartsById = async ({
   id,
 }: {
   id: string;
 }): Promise<{
   chatId: string;
   message: ChatMessage;
-} | null> {
+} | null> => {
   try {
     const [dbMessage] = await db
       .select()
@@ -870,15 +962,13 @@ export async function getChatMessageWithPartsById({
       chatId: dbMessage.chatId,
       message: {
         id: dbMessage.id,
-        role: dbMessage.role as ChatMessage["role"],
-        parts: dbParts.length > 0 ? mapDBPartsToUIParts(dbParts) : [],
         metadata: {
-          createdAt: dbMessage.createdAt,
           activeStreamId: dbMessage.activeStreamId,
-          parentMessageId: dbMessage.parentMessageId,
+          createdAt: dbMessage.createdAt,
+          isPrimaryParallel: dbMessage.isPrimaryParallel,
           parallelGroupId: dbMessage.parallelGroupId,
           parallelIndex: dbMessage.parallelIndex,
-          isPrimaryParallel: dbMessage.isPrimaryParallel,
+          parentMessageId: dbMessage.parentMessageId,
           selectedModel: isSelectedModelValue(dbMessage.selectedModel)
             ? dbMessage.selectedModel
             : ("" as ChatMessage["metadata"]["selectedModel"]),
@@ -886,6 +976,8 @@ export async function getChatMessageWithPartsById({
             undefined) as ChatMessage["metadata"]["selectedTool"],
           usage: dbMessage.lastContext as ChatMessage["metadata"]["usage"],
         },
+        parts: dbParts.length > 0 ? mapDBPartsToUIParts(dbParts) : [],
+        role: dbMessage.role as ChatMessage["role"],
       },
     };
   } catch (error) {
@@ -895,15 +987,15 @@ export async function getChatMessageWithPartsById({
     );
     throw error;
   }
-}
+};
 
-async function _deleteMessagesByChatIdAfterTimestamp({
+const _deleteMessagesByChatIdAfterTimestamp = async ({
   chatId,
   timestamp,
 }: {
   chatId: string;
   timestamp: Date;
-}) {
+}) => {
   try {
     const messagesToDelete = await db
       .select()
@@ -936,15 +1028,15 @@ async function _deleteMessagesByChatIdAfterTimestamp({
     );
     throw error;
   }
-}
+};
 
-export async function deleteMessagesByChatIdAfterMessageId({
+export const deleteMessagesByChatIdAfterMessageId = async ({
   chatId,
   messageId,
 }: {
   chatId: string;
   messageId: string;
-}) {
+}) => {
   try {
     // First, get the target message to find its position in the chat
     const [targetMessage] = await db
@@ -994,30 +1086,30 @@ export async function deleteMessagesByChatIdAfterMessageId({
     );
     throw error;
   }
-}
+};
 
-export async function updateChatVisiblityById({
+export const updateChatVisiblityById = async ({
   chatId,
   visibility,
 }: {
   chatId: string;
   visibility: "private" | "public";
-}) {
+}) => {
   try {
     return await db.update(chat).set({ visibility }).where(eq(chat.id, chatId));
   } catch (error) {
     console.error("Failed to update chat visibility in database");
     throw error;
   }
-}
+};
 
-export async function updateChatTitleById({
+export const updateChatTitleById = async ({
   chatId,
   title,
 }: {
   chatId: string;
   title: string;
-}) {
+}) => {
   try {
     return await db
       .update(chat)
@@ -1029,15 +1121,15 @@ export async function updateChatTitleById({
     console.error("Failed to update chat title by id from database");
     throw error;
   }
-}
+};
 
-export async function updateChatIsPinnedById({
+export const updateChatIsPinnedById = async ({
   chatId,
   isPinned,
 }: {
   chatId: string;
   isPinned: boolean;
-}) {
+}) => {
   try {
     return await db
       .update(chat)
@@ -1049,13 +1141,13 @@ export async function updateChatIsPinnedById({
     console.error("Failed to update chat isPinned by id from database");
     throw error;
   }
-}
+};
 
-export async function getMessageCanceledAt({
+export const getMessageCanceledAt = async ({
   messageId,
 }: {
   messageId: string;
-}): Promise<Date | null> {
+}): Promise<Date | null> => {
   try {
     const [result] = await db
       .select({ canceledAt: message.canceledAt })
@@ -1066,9 +1158,9 @@ export async function getMessageCanceledAt({
     logger.error({ error, messageId }, "getMessageCanceledAt failed");
     throw error;
   }
-}
+};
 
-export async function requestGenerationCancellation({
+export const requestGenerationCancellation = async ({
   canceledAt,
   chatId,
   messageId,
@@ -1078,25 +1170,25 @@ export async function requestGenerationCancellation({
   chatId: string;
   messageId: string;
   userId: string;
-}) {
+}) => {
   try {
     await db
       .insert(generationCancellation)
       .values({ canceledAt, chatId, messageId, userId })
       .onConflictDoUpdate({
+        set: { canceledAt, chatId },
         target: [
           generationCancellation.messageId,
           generationCancellation.userId,
         ],
-        set: { canceledAt, chatId },
       });
   } catch (error) {
     logger.error({ error, messageId }, "requestGenerationCancellation failed");
     throw error;
   }
-}
+};
 
-export async function isGenerationCancellationRequested({
+export const isGenerationCancellationRequested = async ({
   chatId,
   messageId,
   userId,
@@ -1104,7 +1196,7 @@ export async function isGenerationCancellationRequested({
   chatId: string;
   messageId: string;
   userId: string;
-}) {
+}) => {
   try {
     const [cancellation] = await db
       .select({ messageId: generationCancellation.messageId })
@@ -1126,9 +1218,9 @@ export async function isGenerationCancellationRequested({
     );
     throw error;
   }
-}
+};
 
-export async function cancelActiveMessage({
+export const cancelActiveMessage = async ({
   canceledAt,
   chatId,
   messageId,
@@ -1136,7 +1228,7 @@ export async function cancelActiveMessage({
   canceledAt: Date;
   chatId: string;
   messageId: string;
-}) {
+}) => {
   try {
     const canceledMessages = await db
       .update(message)
@@ -1156,93 +1248,22 @@ export async function cancelActiveMessage({
     logger.error({ error, messageId }, "cancelActiveMessage failed");
     throw error;
   }
-}
+};
 
-async function updateChatUpdatedAt({ chatId }: { chatId: string }) {
-  try {
-    return await db
-      .update(chat)
-      .set({
-        updatedAt: new Date(),
-      })
-      .where(eq(chat.id, chatId));
-  } catch (error) {
-    console.error("Failed to update chat updatedAt by id from database");
-    throw error;
-  }
-}
-
-export async function getUserById({
+export const getUserById = async ({
   userId,
 }: {
   userId: string;
-}): Promise<User | undefined> {
+}): Promise<User | undefined> => {
   const users = await db
     .select()
     .from(user)
     .where(eq(user.id, userId))
     .limit(1);
   return users[0];
-}
+};
 
-async function getMessagesWithAttachments() {
-  try {
-    return await db.select({ attachments: message.attachments }).from(message);
-  } catch (error) {
-    console.error(
-      "Failed to get messages with attachments from database",
-      error
-    );
-    throw error;
-  }
-}
-
-function getGeneratedImageParts() {
-  const toolName: ToolName = "generateImage";
-  return db
-    .select({ tool_output: part.tool_output })
-    .from(part)
-    .where(eq(part.tool_name, toolName));
-}
-
-function getFilePartUrls(args: { messageIds?: string[] } = {}) {
-  const { messageIds } = args;
-  let conditions: SQL<unknown> | undefined = eq(part.type, "file");
-  if (messageIds && messageIds.length > 0) {
-    conditions = and(conditions, inArray(part.messageId, messageIds));
-  }
-  return db.select({ file_url: part.file_url }).from(part).where(conditions);
-}
-
-function collectMessageAttachmentUrls(
-  messages: { attachments: unknown }[]
-): string[] {
-  const urls: string[] = [];
-  for (const msg of messages) {
-    if (msg.attachments && Array.isArray(msg.attachments)) {
-      for (const attachment of msg.attachments as Attachment[]) {
-        if (attachment.url) {
-          urls.push(attachment.url);
-        }
-      }
-    }
-  }
-  return urls;
-}
-
-function collectFilePartUrls(
-  fileParts: { file_url: string | null }[]
-): string[] {
-  const urls: string[] = [];
-  for (const p of fileParts) {
-    if (p.file_url) {
-      urls.push(p.file_url);
-    }
-  }
-  return urls;
-}
-
-export async function getAllAttachmentUrls(): Promise<string[]> {
+export const getAllAttachmentUrls = async (): Promise<string[]> => {
   try {
     const [messages, generatedImageParts, fileParts] = await Promise.all([
       getMessagesWithAttachments(),
@@ -1274,36 +1295,13 @@ export async function getAllAttachmentUrls(): Promise<string[]> {
     console.error("Failed to get attachment URLs from database", error);
     throw error;
   }
-}
+};
 
-async function deleteAttachmentsFromMessages(messages: DBMessage[]) {
-  try {
-    const attachmentUrls = collectMessageAttachmentUrls(messages);
-
-    // Collect file URLs from Part table for these messages via shared helper
-    const messageIds = messages.map((msg) => msg.id);
-    if (messageIds.length > 0) {
-      const fileParts = await getFilePartUrls({ messageIds });
-      attachmentUrls.push(...collectFilePartUrls(fileParts));
-    }
-
-    // Deduplicate in case the same file URL is referenced multiple times
-    const uniqueUrls = [...new Set(attachmentUrls)];
-    if (uniqueUrls.length > 0) {
-      await deleteFilesByUrls(uniqueUrls);
-    }
-  } catch (error) {
-    console.error("Failed to delete stored attachments:", error);
-    // Don't throw here - we still want to proceed with message deletion
-    // even if blob cleanup fails
-  }
-}
-
-export async function getUserModelPreferences({
+export const getUserModelPreferences = async ({
   userId,
 }: {
   userId: string;
-}): Promise<UserModelPreference[]> {
+}): Promise<UserModelPreference[]> => {
   try {
     return await db
       .select()
@@ -1313,9 +1311,9 @@ export async function getUserModelPreferences({
     console.error("Failed to get user model preferences from database", error);
     throw error;
   }
-}
+};
 
-export async function upsertUserModelPreference({
+export const upsertUserModelPreference = async ({
   userId,
   modelId,
   enabled,
@@ -1323,26 +1321,26 @@ export async function upsertUserModelPreference({
   userId: string;
   modelId: string;
   enabled: boolean;
-}): Promise<void> {
+}): Promise<void> => {
   try {
     await db
       .insert(userModelPreference)
       .values({
-        userId,
-        modelId,
-        enabled,
         createdAt: new Date(),
+        enabled,
+        modelId,
         updatedAt: new Date(),
+        userId,
       })
       .onConflictDoUpdate({
-        target: [userModelPreference.userId, userModelPreference.modelId],
         set: {
           enabled,
           updatedAt: new Date(),
         },
+        target: [userModelPreference.userId, userModelPreference.modelId],
       });
   } catch (error) {
     console.error("Failed to upsert user model preference in database", error);
     throw error;
   }
-}
+};

--- a/apps/chat/lib/db/queries.ts
+++ b/apps/chat/lib/db/queries.ts
@@ -958,26 +958,30 @@ export const getChatMessageWithPartsById = async ({
       .where(eq(part.messageId, id))
       .orderBy(asc(part.order));
 
+    const role = dbMessage.role as ChatMessage["role"];
+    const parts = dbParts.length > 0 ? mapDBPartsToUIParts(dbParts) : [];
+    const metadata = {
+      activeStreamId: dbMessage.activeStreamId,
+      createdAt: dbMessage.createdAt,
+      isPrimaryParallel: dbMessage.isPrimaryParallel,
+      parallelGroupId: dbMessage.parallelGroupId,
+      parallelIndex: dbMessage.parallelIndex,
+      parentMessageId: dbMessage.parentMessageId,
+      selectedModel: isSelectedModelValue(dbMessage.selectedModel)
+        ? dbMessage.selectedModel
+        : ("" as ChatMessage["metadata"]["selectedModel"]),
+      selectedTool: (dbMessage.selectedTool ||
+        undefined) as ChatMessage["metadata"]["selectedTool"],
+      usage: dbMessage.lastContext as ChatMessage["metadata"]["usage"],
+    };
+
     return {
       chatId: dbMessage.chatId,
       message: {
         id: dbMessage.id,
-        metadata: {
-          activeStreamId: dbMessage.activeStreamId,
-          createdAt: dbMessage.createdAt,
-          isPrimaryParallel: dbMessage.isPrimaryParallel,
-          parallelGroupId: dbMessage.parallelGroupId,
-          parallelIndex: dbMessage.parallelIndex,
-          parentMessageId: dbMessage.parentMessageId,
-          selectedModel: isSelectedModelValue(dbMessage.selectedModel)
-            ? dbMessage.selectedModel
-            : ("" as ChatMessage["metadata"]["selectedModel"]),
-          selectedTool: (dbMessage.selectedTool ||
-            undefined) as ChatMessage["metadata"]["selectedTool"],
-          usage: dbMessage.lastContext as ChatMessage["metadata"]["usage"],
-        },
-        parts: dbParts.length > 0 ? mapDBPartsToUIParts(dbParts) : [],
-        role: dbMessage.role as ChatMessage["role"],
+        metadata,
+        parts,
+        role,
       },
     };
   } catch (error) {

--- a/apps/chat/oxlint-baseline.json
+++ b/apps/chat/oxlint-baseline.json
@@ -224,7 +224,6 @@
         "lib/clone-messages.ts",
         "lib/credits/cost-accumulator.ts",
         "lib/data-stream.test.ts",
-        "lib/db/queries.ts",
         "lib/editor/config.ts",
         "lib/files/upload-prep.ts",
         "lib/gated-chat-transport.test.ts",
@@ -568,7 +567,6 @@
         "components/ui/form.tsx",
         "components/ui/scroll-area.tsx",
         "lib/app-chat-runtime.ts",
-        "lib/db/queries.ts",
         "lib/stores/base/use-data-parts.ts",
         "lib/thread-utils.ts"
       ],
@@ -1250,7 +1248,6 @@
         "lib/credits/cost-accumulator.ts",
         "lib/data-stream.test.ts",
         "lib/db/mcp-queries.ts",
-        "lib/db/queries.ts",
         "lib/db/schema.ts",
         "lib/draft-chat-submission.ts",
         "lib/env-schema.ts",


### PR DESCRIPTION
## Summary
- convert database query helpers to const function expressions with dependency-safe ordering
- sort plain query and data object keys without changing SQL operations
- remove resolved `queries.ts` entries from the oxlint baseline

## Validation
- strict oxlint on `apps/chat/lib/db/queries.ts`: 68 → 0 diagnostics
- `bun lint`
- `bun test:types`
- `bun --filter @chatjs/chat test:unit` (47 files, 192 tests)

## Summary by Sourcery

Clear the oxlint baseline for the chat database query helpers.

Enhancements:
- Standardize database query helpers as dependency-safe const function expressions and normalize query object key ordering without changing database behavior.

Chores:
- Remove resolved `queries.ts` diagnostics from the oxlint baseline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears the oxlint baseline for `apps/chat/lib/db/queries.ts` by converting database query helpers to const function expressions with dependency-safe ordering and sorting object keys without changing SQL behavior.

- Strict oxlint on `queries.ts` now reports 0 diagnostics, down from 68.
- Extracts `role`, `parts`, and `metadata` before returning so sorted object keys don't change message reconstruction order.

<sup>Written for commit 0d3e62b8727df5061088928fa8b675b9891c7a71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized database query definitions and ordering for improved consistency.
  * Updated linting coverage so database query code follows function-style, declaration-order, and key-order rules.
  * No user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->