### PR TITLE
chore(site): clear straightforward lint debt

### DIFF
--- a/apps/site/app/layout.tsx
+++ b/apps/site/app/layout.tsx
@@ -8,109 +8,109 @@ import { siteConfig } from "@/lib/site-config";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  metadataBase: new URL(siteConfig.url),
-  applicationName: siteConfig.name,
-  title: {
-    default: `${siteConfig.title} — The Prod-Ready AI Chat App`,
-    template: `%s | ${siteConfig.title}`,
-  },
-  description: siteConfig.description,
-  keywords: [...siteConfig.keywords],
-  authors: [{ name: "Francisco Moretti" }],
-  creator: "Francisco Moretti",
-  publisher: siteConfig.name,
-  category: "technology",
   alternates: {
     types: {
       "application/rss+xml": `${siteConfig.docsUrl}/rss.xml`,
     },
   },
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "default",
+    title: siteConfig.shortName,
+  },
+  applicationName: siteConfig.name,
+  authors: [{ name: "Francisco Moretti" }],
+  category: "technology",
+  creator: "Francisco Moretti",
+  description: siteConfig.description,
   formatDetection: {
-    email: false,
     address: false,
+    email: false,
     telephone: false,
   },
+  keywords: [...siteConfig.keywords],
+  metadataBase: new URL(siteConfig.url),
   openGraph: {
-    type: "website",
-    locale: "en_US",
-    siteName: siteConfig.name,
-    url: siteConfig.url,
-    title: `${siteConfig.title} — The Prod-Ready AI Chat App`,
     description: siteConfig.description,
     images: [
       {
+        alt: "ChatJS AI chat application interface preview",
+        height: 630,
         url: siteConfig.ogImage,
         width: 1200,
-        height: 630,
-        alt: "ChatJS AI chat application interface preview",
       },
     ],
+    locale: "en_US",
+    siteName: siteConfig.name,
+    title: `${siteConfig.title} — The Prod-Ready AI Chat App`,
+    type: "website",
+    url: siteConfig.url,
+  },
+  publisher: siteConfig.name,
+  title: {
+    default: `${siteConfig.title} — The Prod-Ready AI Chat App`,
+    template: `%s | ${siteConfig.title}`,
   },
   twitter: {
     card: "summary_large_image",
     creator: siteConfig.creator,
-    title: `${siteConfig.title} — The Prod-Ready AI Chat App`,
     description: siteConfig.description,
     images: [siteConfig.ogImage],
-  },
-  appleWebApp: {
-    capable: true,
-    title: siteConfig.shortName,
-    statusBarStyle: "default",
+    title: `${siteConfig.title} — The Prod-Ready AI Chat App`,
   },
 };
 
 export const viewport: Viewport = {
-  width: "device-width",
   initialScale: 1,
   themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "#f8f7f4" },
-    { media: "(prefers-color-scheme: dark)", color: "#09090b" },
+    { color: "#f8f7f4", media: "(prefers-color-scheme: light)" },
+    { color: "#09090b", media: "(prefers-color-scheme: dark)" },
   ],
+  width: "device-width",
 };
 
 const geist = Geist({
-  subsets: ["latin"],
   display: "swap",
+  subsets: ["latin"],
   variable: "--font-geist",
 });
 
 const geistMono = Geist_Mono({
-  subsets: ["latin"],
   display: "swap",
+  subsets: ["latin"],
   variable: "--font-geist-mono",
 });
 
 const instrumentSerif = Instrument_Serif({
-  subsets: ["latin"],
-  weight: "400",
-  style: ["normal", "italic"],
   display: "swap",
+  style: ["normal", "italic"],
+  subsets: ["latin"],
   variable: "--font-instrument-serif",
+  weight: "400",
 });
 
-export default function RootLayout({
+const RootLayout = ({
   children,
 }: Readonly<{
   children: React.ReactNode;
-}>) {
-  return (
-    <html
-      className={`${geist.variable} ${geistMono.variable} ${instrumentSerif.variable}`}
-      lang="en"
-      suppressHydrationWarning
-    >
-      <body className="antialiased">
-        <ThemeProvider
-          attribute="class"
-          defaultTheme="system"
-          disableTransitionOnChange
-          enableSystem
-        >
-          {children}
-        </ThemeProvider>
-        <Analytics />
-      </body>
-    </html>
-  );
-}
+}>) => (
+  <html
+    className={`${geist.variable} ${geistMono.variable} ${instrumentSerif.variable}`}
+    lang="en"
+    suppressHydrationWarning
+  >
+    <body className="antialiased">
+      <ThemeProvider
+        attribute="class"
+        defaultTheme="system"
+        disableTransitionOnChange
+        enableSystem
+      >
+        {children}
+      </ThemeProvider>
+      <Analytics />
+    </body>
+  </html>
+);
+
+export default RootLayout;

--- a/apps/site/app/page.tsx
+++ b/apps/site/app/page.tsx
@@ -13,18 +13,18 @@ import { UseCases } from "@/components/use-cases";
 import { siteConfig, siteLinks } from "@/lib/site-config";
 
 export const metadata: Metadata = {
-  title: "The Prod-Ready AI Chat App",
-  description:
-    "Stop rebuilding the same AI chat infrastructure. ChatJS gives you a production-ready foundation with auth, streaming, tool calling, and 120+ models.",
   alternates: {
     canonical: siteLinks.home,
   },
+  description:
+    "Stop rebuilding the same AI chat infrastructure. ChatJS gives you a production-ready foundation with auth, streaming, tool calling, and 120+ models.",
   openGraph: {
-    url: siteLinks.home,
-    title: "ChatJS - Stop Rebuilding the Same AI Chat Infrastructure",
     description:
       "A production-ready foundation with auth, streaming, tool calling, and 120+ models. Scaffold it, customize it, ship it.",
+    title: "ChatJS - Stop Rebuilding the Same AI Chat Infrastructure",
+    url: siteLinks.home,
   },
+  title: "The Prod-Ready AI Chat App",
 };
 
 const structuredData = {
@@ -32,55 +32,53 @@ const structuredData = {
   "@graph": [
     {
       "@type": "SoftwareApplication",
-      name: siteConfig.name,
       applicationCategory: "DeveloperApplication",
-      operatingSystem: "Web, macOS, Windows, Linux",
-      url: siteLinks.home,
+      codeRepository: siteLinks.github,
       description: siteConfig.description,
       image: `${siteConfig.url}${siteConfig.ogImage}`,
+      name: siteConfig.name,
       offers: {
         "@type": "Offer",
         price: "0",
         priceCurrency: "USD",
       },
-      softwareHelp: siteLinks.docs,
-      codeRepository: siteLinks.github,
+      operatingSystem: "Web, macOS, Windows, Linux",
       screenshot: `${siteConfig.url}${siteConfig.ogImage}`,
+      softwareHelp: siteLinks.docs,
+      url: siteLinks.home,
     },
     {
       "@type": "Organization",
-      name: siteConfig.name,
-      url: siteLinks.home,
       logo: `${siteConfig.url}/logo.svg`,
+      name: siteConfig.name,
       sameAs: [siteLinks.github],
+      url: siteLinks.home,
     },
     {
       "@type": "WebSite",
+      description: siteConfig.description,
       name: siteConfig.name,
       url: siteLinks.home,
-      description: siteConfig.description,
     },
   ],
 };
 
-export default function HomePage() {
-  return (
-    <div className="flex min-h-screen flex-col">
-      <script type="application/ld+json">
-        {JSON.stringify(structuredData)}
-      </script>
-      <Navbar />
-      <main className="flex-1">
-        <Hero />
-        <LogoCloud />
-        <Features />
-        <TechStack />
-        <Platforms />
-        <UseCases />
-        <Faq />
-        <GetStarted />
-      </main>
-      <Footer />
-    </div>
-  );
-}
+const HomePage = () => (
+  <div className="flex min-h-screen flex-col">
+    <script type="application/ld+json">{JSON.stringify(structuredData)}</script>
+    <Navbar />
+    <main className="flex-1">
+      <Hero />
+      <LogoCloud />
+      <Features />
+      <TechStack />
+      <Platforms />
+      <UseCases />
+      <Faq />
+      <GetStarted />
+    </main>
+    <Footer />
+  </div>
+);
+
+export default HomePage;

--- a/apps/site/app/threads/page.tsx
+++ b/apps/site/app/threads/page.tsx
@@ -26,23 +26,23 @@ const THREADS_DESCRIPTION =
   "Keep the useChat interface and add message trees, branch navigation, and concurrent AI SDK response streams.";
 
 export const metadata: Metadata = {
-  title: THREADS_TITLE,
-  description: THREADS_DESCRIPTION,
   alternates: {
     canonical: siteLinks.threads,
   },
+  description: THREADS_DESCRIPTION,
   openGraph: {
-    url: siteLinks.threads,
-    title: THREADS_TITLE,
     description:
       "A useChat-compatible active path backed by a complete message tree.",
+    title: THREADS_TITLE,
+    url: siteLinks.threads,
   },
+  title: THREADS_TITLE,
   twitter: {
     card: "summary_large_image",
     creator: siteConfig.creator,
-    title: THREADS_TITLE,
     description: THREADS_DESCRIPTION,
     images: [siteConfig.ogImage],
+    title: THREADS_TITLE,
   },
 };
 
@@ -59,298 +59,296 @@ const compatibility = [
 
 const additions = [
   {
-    icon: Route,
-    title: "Cursor navigation",
     description:
       "Select any message and expose its root-to-node path as chat.messages.",
+    icon: Route,
+    title: "Cursor navigation",
   },
   {
-    icon: GitFork,
-    title: "Message topology",
     description:
       "Read parents, children, siblings, leaves, and complete tree snapshots.",
+    icon: GitFork,
+    title: "Message topology",
   },
   {
-    icon: Radio,
-    title: "Independent runs",
     description:
       "Stream, stop, and resume responses without coupling them to the visible path.",
+    icon: Radio,
+    title: "Independent runs",
   },
   {
-    icon: Layers3,
-    title: "Parallel responses",
     description:
       "Start multiple assistant runs from one user message and follow only the one you choose.",
+    icon: Layers3,
+    title: "Parallel responses",
   },
 ] as const;
 
 const architectureRows = [
   {
-    label: "Tree",
     detail: "Canonical messages, parent-child edges, and the selected cursor.",
+    label: "Tree",
   },
   {
-    label: "Active path",
     detail: "A useChat-compatible projection from the root to the cursor.",
+    label: "Active path",
   },
   {
-    label: "Branch runs",
     detail:
       "One isolated AI SDK request lifecycle and abort controller per response.",
+    label: "Branch runs",
   },
   {
-    label: "Transport",
     detail:
       "Your existing AI SDK ChatTransport, shared without a new wire protocol.",
+    label: "Transport",
   },
 ] as const;
 
-export default function ThreadsPage() {
-  return (
-    <div className="flex min-h-screen flex-col">
-      <Navbar />
-      <main className="flex-1">
-        <section className="border-border/50 border-b">
-          <div className="mx-auto max-w-6xl px-6 pt-16 pb-14 sm:pt-24 sm:pb-20">
-            <div className="grid gap-12 lg:grid-cols-[minmax(0,1.12fr)_minmax(23rem,0.88fr)] lg:items-end">
-              <div className="min-w-0">
-                <div className="text-muted-foreground flex items-center gap-2 font-mono text-xs tracking-[0.18em] uppercase">
-                  <GitBranch className="size-4" />
-                  useThread for AI SDK
-                </div>
-                <h1 className="font-display mt-7 max-w-4xl text-4xl leading-[0.98] tracking-tight sm:text-7xl">
-                  Branching conversations for AI SDK.
-                </h1>
-                <p className="text-foreground/72 mt-7 max-w-2xl text-lg leading-8 sm:text-xl">
-                  Keep the{" "}
-                  <code className="text-foreground font-mono text-[0.9em]">
-                    useChat
-                  </code>{" "}
-                  interface. Add a complete message tree, branch navigation, and
-                  concurrent responses that keep streaming when users move
-                  elsewhere.
-                </p>
-                <div className="mt-8 flex flex-wrap items-center gap-5">
-                  <a
-                    className="bg-primary text-primary-foreground inline-flex min-h-11 items-center gap-2 px-5 text-sm font-medium transition-opacity hover:opacity-85"
-                    href="#playground"
-                  >
-                    Try the playground
-                    <ArrowRight className="size-4" />
-                  </a>
-                  <a
-                    className="border-border text-foreground/75 hover:text-foreground inline-flex min-h-11 items-center gap-2 border-b text-sm transition-colors"
-                    href={`${siteLinks.docs}/threads`}
-                  >
-                    Read the docs
-                    <ArrowRight className="size-3.5" />
-                  </a>
-                </div>
+const ThreadsPage = () => (
+  <div className="flex min-h-screen flex-col">
+    <Navbar />
+    <main className="flex-1">
+      <section className="border-border/50 border-b">
+        <div className="mx-auto max-w-6xl px-6 pt-16 pb-14 sm:pt-24 sm:pb-20">
+          <div className="grid gap-12 lg:grid-cols-[minmax(0,1.12fr)_minmax(23rem,0.88fr)] lg:items-end">
+            <div className="min-w-0">
+              <div className="text-muted-foreground flex items-center gap-2 font-mono text-xs tracking-[0.18em] uppercase">
+                <GitBranch className="size-4" />
+                useThread for AI SDK
               </div>
-
-              <div className="border-border bg-card min-w-0 border-y">
-                <div className="border-border flex items-center justify-between border-b px-4 py-3">
-                  <span className="text-muted-foreground font-mono text-xs">
-                    Chat.tsx
-                  </span>
-                  <span className="text-muted-foreground flex items-center gap-1.5 font-mono text-[10px] uppercase">
-                    <Check className="size-3" /> useChat compatible
-                  </span>
-                </div>
-                <pre className="overflow-x-auto px-4 py-5 font-mono text-[13px] leading-7">
-                  <code>
-                    <span className="text-muted-foreground">- </span>
-                    <span className="text-foreground/55">
-                      import {"{ useChat }"} from &quot;@ai-sdk/react&quot;;
-                    </span>
-                    {"\n"}
-                    <span className="text-foreground">
-                      + import {"{ useThread }"} from
-                      &quot;@chat-js/thread/react&quot;;
-                    </span>
-                    {"\n\n"}
-                    <span className="text-muted-foreground">- </span>
-                    <span className="text-foreground/55">
-                      const chat = useChat();
-                    </span>
-                    {"\n"}
-                    <span className="text-foreground">
-                      + const chat = useThread();
-                    </span>
-                    {"\n\n"}
-                    <span className="text-foreground">chat.messages;</span>
-                    <span className="text-muted-foreground">
-                      {" "}
-                      {"// selected path"}
-                    </span>
-                    {"\n"}
-                    <span className="text-foreground">chat.tree;</span>
-                    <span className="text-muted-foreground">
-                      {" "}
-                      {"// complete tree"}
-                    </span>
-                  </code>
-                </pre>
+              <h1 className="font-display mt-7 max-w-4xl text-4xl leading-[0.98] tracking-tight sm:text-7xl">
+                Branching conversations for AI SDK.
+              </h1>
+              <p className="text-foreground/72 mt-7 max-w-2xl text-lg leading-8 sm:text-xl">
+                Keep the{" "}
+                <code className="text-foreground font-mono text-[0.9em]">
+                  useChat
+                </code>{" "}
+                interface. Add a complete message tree, branch navigation, and
+                concurrent responses that keep streaming when users move
+                elsewhere.
+              </p>
+              <div className="mt-8 flex flex-wrap items-center gap-5">
+                <a
+                  className="bg-primary text-primary-foreground inline-flex min-h-11 items-center gap-2 px-5 text-sm font-medium transition-opacity hover:opacity-85"
+                  href="#playground"
+                >
+                  Try the playground
+                  <ArrowRight className="size-4" />
+                </a>
+                <a
+                  className="border-border text-foreground/75 hover:text-foreground inline-flex min-h-11 items-center gap-2 border-b text-sm transition-colors"
+                  href={`${siteLinks.docs}/threads`}
+                >
+                  Read the docs
+                  <ArrowRight className="size-3.5" />
+                </a>
               </div>
             </div>
 
-            <ThreadInstallCommand />
-          </div>
-        </section>
-
-        <section className="scroll-mt-20 py-16 sm:py-20" id="playground">
-          <div className="mx-auto max-w-6xl px-6">
-            <div className="mb-8 flex flex-col justify-between gap-5 sm:flex-row sm:items-end">
-              <div className="max-w-2xl">
-                <p className="text-muted-foreground font-mono text-xs tracking-[0.18em] uppercase">
-                  The package, not a mockup
-                </p>
-                <h2 className="font-display mt-4 text-3xl tracking-tight sm:text-5xl">
-                  Move through the tree while it streams.
-                </h2>
+            <div className="border-border bg-card min-w-0 border-y">
+              <div className="border-border flex items-center justify-between border-b px-4 py-3">
+                <span className="text-muted-foreground font-mono text-xs">
+                  Chat.tsx
+                </span>
+                <span className="text-muted-foreground flex items-center gap-1.5 font-mono text-[10px] uppercase">
+                  <Check className="size-3" /> useChat compatible
+                </span>
               </div>
-              <p className="text-foreground/65 max-w-sm text-sm leading-6">
-                Branch from any message, request parallel replies, switch paths
-                mid-stream, and stop individual runs. The canvas reads directly
-                from useThread state.
+              <pre className="overflow-x-auto px-4 py-5 font-mono text-[13px] leading-7">
+                <code>
+                  <span className="text-muted-foreground">- </span>
+                  <span className="text-foreground/55">
+                    import {"{ useChat }"} from &quot;@ai-sdk/react&quot;;
+                  </span>
+                  {"\n"}
+                  <span className="text-foreground">
+                    + import {"{ useThread }"} from
+                    &quot;@chat-js/thread/react&quot;;
+                  </span>
+                  {"\n\n"}
+                  <span className="text-muted-foreground">- </span>
+                  <span className="text-foreground/55">
+                    const chat = useChat();
+                  </span>
+                  {"\n"}
+                  <span className="text-foreground">
+                    + const chat = useThread();
+                  </span>
+                  {"\n\n"}
+                  <span className="text-foreground">chat.messages;</span>
+                  <span className="text-muted-foreground">
+                    {" "}
+                    {"// selected path"}
+                  </span>
+                  {"\n"}
+                  <span className="text-foreground">chat.tree;</span>
+                  <span className="text-muted-foreground">
+                    {" "}
+                    {"// complete tree"}
+                  </span>
+                </code>
+              </pre>
+            </div>
+          </div>
+
+          <ThreadInstallCommand />
+        </div>
+      </section>
+
+      <section className="scroll-mt-20 py-16 sm:py-20" id="playground">
+        <div className="mx-auto max-w-6xl px-6">
+          <div className="mb-8 flex flex-col justify-between gap-5 sm:flex-row sm:items-end">
+            <div className="max-w-2xl">
+              <p className="text-muted-foreground font-mono text-xs tracking-[0.18em] uppercase">
+                The package, not a mockup
+              </p>
+              <h2 className="font-display mt-4 text-3xl tracking-tight sm:text-5xl">
+                Move through the tree while it streams.
+              </h2>
+            </div>
+            <p className="text-foreground/65 max-w-sm text-sm leading-6">
+              Branch from any message, request parallel replies, switch paths
+              mid-stream, and stop individual runs. The canvas reads directly
+              from useThread state.
+            </p>
+          </div>
+          <ThreadPlayground />
+        </div>
+      </section>
+
+      <section className="border-border/50 bg-card border-y py-20 sm:py-28">
+        <div className="mx-auto max-w-6xl px-6">
+          <div className="grid gap-12 lg:grid-cols-[0.8fr_1.2fr] lg:gap-20">
+            <div>
+              <p className="text-muted-foreground font-mono text-xs tracking-[0.18em] uppercase">
+                A strict extension
+              </p>
+              <h2 className="font-display mt-5 text-3xl tracking-tight sm:text-5xl">
+                Your chat stays linear. Its history does not.
+              </h2>
+              <p className="text-foreground/68 mt-5 leading-7">
+                Existing message lists and composers keep using the selected
+                path. Tree-specific state is additive and namespaced under{" "}
+                <code className="text-foreground font-mono text-sm">
+                  chat.tree
+                </code>
+                .
               </p>
             </div>
-            <ThreadPlayground />
-          </div>
-        </section>
 
-        <section className="border-border/50 bg-card border-y py-20 sm:py-28">
-          <div className="mx-auto max-w-6xl px-6">
-            <div className="grid gap-12 lg:grid-cols-[0.8fr_1.2fr] lg:gap-20">
-              <div>
-                <p className="text-muted-foreground font-mono text-xs tracking-[0.18em] uppercase">
-                  A strict extension
-                </p>
-                <h2 className="font-display mt-5 text-3xl tracking-tight sm:text-5xl">
-                  Your chat stays linear. Its history does not.
-                </h2>
-                <p className="text-foreground/68 mt-5 leading-7">
-                  Existing message lists and composers keep using the selected
-                  path. Tree-specific state is additive and namespaced under{" "}
-                  <code className="text-foreground font-mono text-sm">
-                    chat.tree
-                  </code>
-                  .
-                </p>
+            <div>
+              <div className="border-border flex items-center gap-2 border-b pb-4">
+                <Braces className="text-muted-foreground size-4" />
+                <h3 className="text-sm font-medium">Same AI SDK surface</h3>
               </div>
-
-              <div>
-                <div className="border-border flex items-center gap-2 border-b pb-4">
-                  <Braces className="text-muted-foreground size-4" />
-                  <h3 className="text-sm font-medium">Same AI SDK surface</h3>
-                </div>
-                <div className="border-border grid grid-cols-2 border-b sm:grid-cols-4">
-                  {compatibility.map((item) => (
-                    <div
-                      className="border-border flex min-h-14 items-center gap-2 border-r px-3 font-mono text-xs last:border-r-0 max-sm:[&:nth-child(2n)]:border-r-0 sm:[&:nth-child(4n)]:border-r-0"
-                      key={item}
-                    >
-                      <Check className="text-muted-foreground size-3.5 shrink-0" />
-                      {item}
-                    </div>
-                  ))}
-                </div>
-
-                <div className="mt-10 grid sm:grid-cols-2">
-                  {additions.map((item) => (
-                    <article
-                      className="border-border border-b py-6 sm:odd:pr-7 sm:even:border-l sm:even:pl-7"
-                      key={item.title}
-                    >
-                      <item.icon className="text-muted-foreground size-4" />
-                      <h3 className="mt-4 font-medium">{item.title}</h3>
-                      <p className="text-foreground/65 mt-2 text-sm leading-6">
-                        {item.description}
-                      </p>
-                    </article>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section className="py-20 sm:py-28">
-          <div className="mx-auto max-w-6xl px-6">
-            <div className="grid gap-14 lg:grid-cols-[0.92fr_1.08fr] lg:items-start lg:gap-20">
-              <div>
-                <p className="text-muted-foreground font-mono text-xs tracking-[0.18em] uppercase">
-                  Why it keeps working
-                </p>
-                <h2 className="font-display mt-5 text-3xl tracking-tight sm:text-5xl">
-                  One tree. One AI SDK lifecycle per response.
-                </h2>
-                <p className="text-foreground/68 mt-5 max-w-xl leading-7">
-                  A single linear chat engine cannot safely own several branch
-                  streams. useThread isolates each response while routing every
-                  update into its own assistant node once streaming begins.
-                </p>
-                <div className="text-foreground/65 mt-8 flex flex-wrap gap-x-6 gap-y-3 text-sm">
-                  <span className="flex items-center gap-2">
-                    <RefreshCw className="size-3.5" /> Resume per run
-                  </span>
-                  <span className="flex items-center gap-2">
-                    <CircleStop className="size-3.5" /> Stop per run
-                  </span>
-                  <span className="flex items-center gap-2">
-                    <Workflow className="size-3.5" /> Navigate independently
-                  </span>
-                </div>
-              </div>
-
-              <div className="border-border border-t">
-                {architectureRows.map((row, index) => (
+              <div className="border-border grid grid-cols-2 border-b sm:grid-cols-4">
+                {compatibility.map((item) => (
                   <div
-                    className="border-border grid gap-2 border-b py-5 sm:grid-cols-[8rem_1fr] sm:gap-6"
-                    key={row.label}
+                    className="border-border flex min-h-14 items-center gap-2 border-r px-3 font-mono text-xs last:border-r-0 max-sm:[&:nth-child(2n)]:border-r-0 sm:[&:nth-child(4n)]:border-r-0"
+                    key={item}
                   >
-                    <div className="flex items-center gap-3 font-mono text-xs">
-                      <span className="text-muted-foreground">
-                        0{index + 1}
-                      </span>
-                      {row.label}
-                    </div>
-                    <p className="text-foreground/68 text-sm leading-6">
-                      {row.detail}
-                    </p>
+                    <Check className="text-muted-foreground size-3.5 shrink-0" />
+                    {item}
                   </div>
+                ))}
+              </div>
+
+              <div className="mt-10 grid sm:grid-cols-2">
+                {additions.map((item) => (
+                  <article
+                    className="border-border border-b py-6 sm:odd:pr-7 sm:even:border-l sm:even:pl-7"
+                    key={item.title}
+                  >
+                    <item.icon className="text-muted-foreground size-4" />
+                    <h3 className="mt-4 font-medium">{item.title}</h3>
+                    <p className="text-foreground/65 mt-2 text-sm leading-6">
+                      {item.description}
+                    </p>
+                  </article>
                 ))}
               </div>
             </div>
           </div>
-        </section>
+        </div>
+      </section>
 
-        <section className="border-border/50 bg-card border-y py-20 sm:py-24">
-          <div className="mx-auto flex max-w-6xl flex-col items-start justify-between gap-10 px-6 lg:flex-row lg:items-end">
-            <div className="max-w-2xl">
+      <section className="py-20 sm:py-28">
+        <div className="mx-auto max-w-6xl px-6">
+          <div className="grid gap-14 lg:grid-cols-[0.92fr_1.08fr] lg:items-start lg:gap-20">
+            <div>
               <p className="text-muted-foreground font-mono text-xs tracking-[0.18em] uppercase">
-                Headless by design
+                Why it keeps working
               </p>
               <h2 className="font-display mt-5 text-3xl tracking-tight sm:text-5xl">
-                Own the experience. Choose how you integrate it.
+                One tree. One AI SDK lifecycle per response.
               </h2>
-              <p className="text-foreground/68 mt-5 leading-7">
-                Install the versioned package alongside AI SDK. Your
-                conversation UI, branch controls, persistence, and server routes
-                remain application-owned.
+              <p className="text-foreground/68 mt-5 max-w-xl leading-7">
+                A single linear chat engine cannot safely own several branch
+                streams. useThread isolates each response while routing every
+                update into its own assistant node once streaming begins.
               </p>
+              <div className="text-foreground/65 mt-8 flex flex-wrap gap-x-6 gap-y-3 text-sm">
+                <span className="flex items-center gap-2">
+                  <RefreshCw className="size-3.5" /> Resume per run
+                </span>
+                <span className="flex items-center gap-2">
+                  <CircleStop className="size-3.5" /> Stop per run
+                </span>
+                <span className="flex items-center gap-2">
+                  <Workflow className="size-3.5" /> Navigate independently
+                </span>
+              </div>
             </div>
-            <a
-              className="bg-primary text-primary-foreground inline-flex min-h-11 shrink-0 items-center gap-2 px-5 text-sm font-medium transition-opacity hover:opacity-85"
-              href={`${siteLinks.docs}/threads`}
-            >
-              Read the docs
-              <ArrowRight className="size-4" />
-            </a>
+
+            <div className="border-border border-t">
+              {architectureRows.map((row, index) => (
+                <div
+                  className="border-border grid gap-2 border-b py-5 sm:grid-cols-[8rem_1fr] sm:gap-6"
+                  key={row.label}
+                >
+                  <div className="flex items-center gap-3 font-mono text-xs">
+                    <span className="text-muted-foreground">0{index + 1}</span>
+                    {row.label}
+                  </div>
+                  <p className="text-foreground/68 text-sm leading-6">
+                    {row.detail}
+                  </p>
+                </div>
+              ))}
+            </div>
           </div>
-        </section>
-      </main>
-      <Footer />
-    </div>
-  );
-}
+        </div>
+      </section>
+
+      <section className="border-border/50 bg-card border-y py-20 sm:py-24">
+        <div className="mx-auto flex max-w-6xl flex-col items-start justify-between gap-10 px-6 lg:flex-row lg:items-end">
+          <div className="max-w-2xl">
+            <p className="text-muted-foreground font-mono text-xs tracking-[0.18em] uppercase">
+              Headless by design
+            </p>
+            <h2 className="font-display mt-5 text-3xl tracking-tight sm:text-5xl">
+              Own the experience. Choose how you integrate it.
+            </h2>
+            <p className="text-foreground/68 mt-5 leading-7">
+              Install the versioned package alongside AI SDK. Your conversation
+              UI, branch controls, persistence, and server routes remain
+              application-owned.
+            </p>
+          </div>
+          <a
+            className="bg-primary text-primary-foreground inline-flex min-h-11 shrink-0 items-center gap-2 px-5 text-sm font-medium transition-opacity hover:opacity-85"
+            href={`${siteLinks.docs}/threads`}
+          >
+            Read the docs
+            <ArrowRight className="size-4" />
+          </a>
+        </div>
+      </section>
+    </main>
+    <Footer />
+  </div>
+);
+
+export default ThreadsPage;

--- a/apps/site/components/get-started.tsx
+++ b/apps/site/components/get-started.tsx
@@ -7,10 +7,10 @@ import { siteLinks } from "@/lib/site-config";
 
 const command = "npx @chat-js/cli@latest create my-app";
 
-export function GetStarted() {
+export const GetStarted = () => {
   const [copied, setCopied] = useState(false);
 
-  async function handleCopy() {
+  const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(command);
       setCopied(true);
@@ -21,7 +21,7 @@ export function GetStarted() {
     } catch {
       // Ignore clipboard permission failures.
     }
-  }
+  };
 
   return (
     <section className="relative overflow-hidden py-24 sm:py-32">
@@ -101,4 +101,4 @@ export function GetStarted() {
       </div>
     </section>
   );
-}
+};

--- a/apps/site/components/hero.tsx
+++ b/apps/site/components/hero.tsx
@@ -3,154 +3,150 @@ import Image from "next/image";
 
 import { siteLinks } from "@/lib/site-config";
 
-function Sparkle({
+const Sparkle = ({
   className,
   size = 24,
 }: {
   className?: string;
   size?: number;
-}) {
-  return (
-    <svg
-      aria-hidden="true"
-      className={className}
-      fill="currentColor"
-      height={size}
-      viewBox="0 0 24 24"
-      width={size}
-    >
-      <path d="M12 0L14.2 9.8L24 12L14.2 14.2L12 24L9.8 14.2L0 12L9.8 9.8Z" />
-    </svg>
-  );
-}
+}) => (
+  <svg
+    aria-hidden="true"
+    className={className}
+    fill="currentColor"
+    height={size}
+    viewBox="0 0 24 24"
+    width={size}
+  >
+    <path d="M12 0L14.2 9.8L24 12L14.2 14.2L12 24L9.8 14.2L0 12L9.8 9.8Z" />
+  </svg>
+);
 
-export function Hero() {
-  return (
-    <section className="relative overflow-hidden">
-      {/* Background atmosphere — layered organic gradients */}
-      <div className="pointer-events-none absolute inset-0">
-        {/* Top fade from card into bg */}
-        <div className="from-card/40 absolute inset-x-0 top-0 h-[500px] bg-gradient-to-b via-transparent to-transparent" />
-        {/* Warm accent blob — left */}
-        <div className="absolute top-[25%] left-[15%] h-[500px] w-[600px] -rotate-12 rounded-full bg-amber-500/2.5 blur-[120px] dark:bg-amber-400/3" />
-        {/* Cool accent blob — right */}
-        <div className="absolute top-[35%] right-[10%] h-[450px] w-[550px] rotate-12 rounded-full bg-indigo-500/2 blur-[120px] dark:bg-indigo-400/2.5" />
-        {/* Center glow behind mockup */}
-        <div className="bg-foreground/2 absolute bottom-[5%] left-1/2 h-[500px] w-[800px] -translate-x-1/2 rounded-full blur-[120px]" />
+export const Hero = () => (
+  <section className="relative overflow-hidden">
+    {/* Background atmosphere — layered organic gradients */}
+    <div className="pointer-events-none absolute inset-0">
+      {/* Top fade from card into bg */}
+      <div className="from-card/40 absolute inset-x-0 top-0 h-[500px] bg-gradient-to-b via-transparent to-transparent" />
+      {/* Warm accent blob — left */}
+      <div className="absolute top-[25%] left-[15%] h-[500px] w-[600px] -rotate-12 rounded-full bg-amber-500/2.5 blur-[120px] dark:bg-amber-400/3" />
+      {/* Cool accent blob — right */}
+      <div className="absolute top-[35%] right-[10%] h-[450px] w-[550px] rotate-12 rounded-full bg-indigo-500/2 blur-[120px] dark:bg-indigo-400/2.5" />
+      {/* Center glow behind mockup */}
+      <div className="bg-foreground/2 absolute bottom-[5%] left-1/2 h-[500px] w-[800px] -translate-x-1/2 rounded-full blur-[120px]" />
+    </div>
+
+    {/* Decorative sparkles */}
+    <Sparkle
+      className="animate-sparkle text-foreground/7 pointer-events-none absolute top-32 left-[12%] hidden sm:block"
+      size={20}
+    />
+    <Sparkle
+      className="animate-sparkle text-foreground/5 pointer-events-none absolute top-48 right-[18%] hidden sm:block"
+      size={14}
+    />
+    <Sparkle
+      className="animate-sparkle text-foreground/6 pointer-events-none absolute bottom-[30%] left-[8%] hidden lg:block"
+      size={10}
+    />
+    <Sparkle
+      className="animate-sparkle text-foreground/4 pointer-events-none absolute top-[60%] right-[8%] hidden lg:block"
+      size={16}
+    />
+
+    <div className="relative mx-auto max-w-6xl px-6 pt-20 pb-20 sm:pt-28 sm:pb-28">
+      {/* Badge */}
+      <div className="animate-fade-in-up flex justify-center">
+        <a
+          className="border-border/60 bg-card/70 text-foreground/75 hover:border-foreground/20 hover:text-foreground inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm backdrop-blur-sm transition-colors"
+          href="https://github.com/franciscomoretti/chat-js"
+          rel="noreferrer"
+          target="_blank"
+        >
+          <svg
+            aria-hidden="true"
+            className="h-3.5 w-3.5"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <title>GitHub</title>
+            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+          </svg>
+          Open Source — Apache 2.0
+          <ArrowRight className="h-3 w-3" />
+        </a>
       </div>
 
-      {/* Decorative sparkles */}
-      <Sparkle
-        className="animate-sparkle text-foreground/7 pointer-events-none absolute top-32 left-[12%] hidden sm:block"
-        size={20}
-      />
-      <Sparkle
-        className="animate-sparkle text-foreground/5 pointer-events-none absolute top-48 right-[18%] hidden sm:block"
-        size={14}
-      />
-      <Sparkle
-        className="animate-sparkle text-foreground/6 pointer-events-none absolute bottom-[30%] left-[8%] hidden lg:block"
-        size={10}
-      />
-      <Sparkle
-        className="animate-sparkle text-foreground/4 pointer-events-none absolute top-[60%] right-[8%] hidden lg:block"
-        size={16}
-      />
+      {/* Headline */}
+      <h1
+        className="animate-fade-in-up font-display text-foreground mx-auto mt-8 max-w-4xl text-center text-5xl tracking-tight sm:text-7xl lg:text-8xl"
+        style={{ animationDelay: "0.1s" }}
+      >
+        Ship AI chat in <span className="italic">minutes</span>, not months
+      </h1>
 
-      <div className="relative mx-auto max-w-6xl px-6 pt-20 pb-20 sm:pt-28 sm:pb-28">
-        {/* Badge */}
-        <div className="animate-fade-in-up flex justify-center">
-          <a
-            className="border-border/60 bg-card/70 text-foreground/75 hover:border-foreground/20 hover:text-foreground inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm backdrop-blur-sm transition-colors"
-            href="https://github.com/franciscomoretti/chat-js"
-            rel="noreferrer"
-            target="_blank"
-          >
-            <svg
-              aria-hidden="true"
-              className="h-3.5 w-3.5"
-              fill="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <title>GitHub</title>
-              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-            </svg>
-            Open Source — Apache 2.0
-            <ArrowRight className="h-3 w-3" />
-          </a>
-        </div>
+      {/* Subhead */}
+      <p
+        className="animate-fade-in-up text-foreground/75 mx-auto mt-8 max-w-2xl text-center text-lg leading-relaxed sm:text-xl"
+        style={{ animationDelay: "0.2s" }}
+      >
+        An open-source, production-ready AI chat foundation. Authentication,
+        120+ models, streaming, tool calling — everything you need to launch.
+      </p>
 
-        {/* Headline */}
-        <h1
-          className="animate-fade-in-up font-display text-foreground mx-auto mt-8 max-w-4xl text-center text-5xl tracking-tight sm:text-7xl lg:text-8xl"
-          style={{ animationDelay: "0.1s" }}
+      {/* CTA */}
+      <div
+        className="animate-fade-in-up mt-10 flex flex-col items-center gap-6 sm:flex-row sm:justify-center"
+        style={{ animationDelay: "0.3s" }}
+      >
+        <a
+          className="bg-primary text-primary-foreground shadow-primary/15 hover:shadow-primary/20 inline-flex items-center gap-2 rounded-xl px-8 py-3.5 text-sm font-medium shadow-lg transition-all hover:-translate-y-0.5 hover:shadow-xl"
+          href={siteLinks.docsGettingStarted}
         >
-          Ship AI chat in <span className="italic">minutes</span>, not months
-        </h1>
-
-        {/* Subhead */}
-        <p
-          className="animate-fade-in-up text-foreground/75 mx-auto mt-8 max-w-2xl text-center text-lg leading-relaxed sm:text-xl"
-          style={{ animationDelay: "0.2s" }}
+          Get Started
+          <ArrowRight className="h-4 w-4" />
+        </a>
+        <a
+          className="border-foreground/15 text-foreground/70 hover:border-foreground/25 hover:text-foreground/90 inline-flex items-center gap-2 rounded-xl border px-8 py-3.5 text-sm font-medium transition-all hover:-translate-y-0.5"
+          href={siteLinks.demo}
         >
-          An open-source, production-ready AI chat foundation. Authentication,
-          120+ models, streaming, tool calling — everything you need to launch.
-        </p>
+          Live Demo
+          <ArrowRight className="h-4 w-4" />
+        </a>
+      </div>
 
-        {/* CTA */}
-        <div
-          className="animate-fade-in-up mt-10 flex flex-col items-center gap-6 sm:flex-row sm:justify-center"
-          style={{ animationDelay: "0.3s" }}
-        >
-          <a
-            className="bg-primary text-primary-foreground shadow-primary/15 hover:shadow-primary/20 inline-flex items-center gap-2 rounded-xl px-8 py-3.5 text-sm font-medium shadow-lg transition-all hover:-translate-y-0.5 hover:shadow-xl"
-            href={siteLinks.docsGettingStarted}
-          >
-            Get Started
-            <ArrowRight className="h-4 w-4" />
-          </a>
-          <a
-            className="border-foreground/15 text-foreground/70 hover:border-foreground/25 hover:text-foreground/90 inline-flex items-center gap-2 rounded-xl border px-8 py-3.5 text-sm font-medium transition-all hover:-translate-y-0.5"
-            href={siteLinks.demo}
-          >
-            Live Demo
-            <ArrowRight className="h-4 w-4" />
-          </a>
-        </div>
+      {/* Chat Preview */}
+      <div
+        className="animate-fade-in-up relative mx-auto mt-20 max-w-3xl perspective-distant"
+        style={{ animationDelay: "0.5s" }}
+      >
+        {/* Layered ambient glow */}
+        <div className="bg-foreground/[0.07] pointer-events-none absolute -inset-8 rounded-3xl blur-3xl" />
+        <div className="bg-foreground/4 pointer-events-none absolute -inset-16 rounded-4xl blur-[80px]" />
 
-        {/* Chat Preview */}
-        <div
-          className="animate-fade-in-up relative mx-auto mt-20 max-w-3xl perspective-distant"
-          style={{ animationDelay: "0.5s" }}
-        >
-          {/* Layered ambient glow */}
-          <div className="bg-foreground/[0.07] pointer-events-none absolute -inset-8 rounded-3xl blur-3xl" />
-          <div className="bg-foreground/4 pointer-events-none absolute -inset-16 rounded-4xl blur-[80px]" />
-
-          {/* Screenshot with depth */}
-          <div className="animate-float ring-foreground/[0.08] relative [transform:rotateX(2deg)] rounded-2xl shadow-[0_20px_70px_-10px_rgba(0,0,0,0.35)] ring-1 transition-transform duration-700 hover:[transform:rotateX(0deg)] dark:shadow-[0_20px_70px_-10px_rgba(0,0,0,0.7)]">
-            <div className="overflow-hidden rounded-2xl">
-              <Image
-                alt="ChatJS — AI chat interface"
-                className="block h-auto w-full dark:hidden"
-                fetchPriority="high"
-                height={1536}
-                sizes="(max-width: 768px) 100vw, (max-width: 1280px) 90vw, 1024px"
-                src="/chatjs_preview_light.png"
-                width={2048}
-              />
-              <Image
-                alt="ChatJS — AI chat interface"
-                className="hidden h-auto w-full dark:block"
-                height={1536}
-                sizes="(max-width: 768px) 100vw, (max-width: 1280px) 90vw, 1024px"
-                src="/chatjs_preview_dark.png"
-                width={2048}
-              />
-            </div>
+        {/* Screenshot with depth */}
+        <div className="animate-float ring-foreground/[0.08] relative [transform:rotateX(2deg)] rounded-2xl shadow-[0_20px_70px_-10px_rgba(0,0,0,0.35)] ring-1 transition-transform duration-700 hover:[transform:rotateX(0deg)] dark:shadow-[0_20px_70px_-10px_rgba(0,0,0,0.7)]">
+          <div className="overflow-hidden rounded-2xl">
+            <Image
+              alt="ChatJS — AI chat interface"
+              className="block h-auto w-full dark:hidden"
+              fetchPriority="high"
+              height={1536}
+              sizes="(max-width: 768px) 100vw, (max-width: 1280px) 90vw, 1024px"
+              src="/chatjs_preview_light.png"
+              width={2048}
+            />
+            <Image
+              alt="ChatJS — AI chat interface"
+              className="hidden h-auto w-full dark:block"
+              height={1536}
+              sizes="(max-width: 768px) 100vw, (max-width: 1280px) 90vw, 1024px"
+              src="/chatjs_preview_dark.png"
+              width={2048}
+            />
           </div>
         </div>
       </div>
-    </section>
-  );
-}
+    </div>
+  </section>
+);

--- a/apps/site/components/logo-cloud.tsx
+++ b/apps/site/components/logo-cloud.tsx
@@ -1,23 +1,21 @@
 const PROVIDERS = ["OpenAI", "Anthropic", "Google", "xAI", "Meta"];
 
-export function LogoCloud() {
-  return (
-    <section className="border-border/30 border-y py-12">
-      <div className="mx-auto max-w-6xl px-6">
-        <p className="text-foreground/75 text-center text-sm tracking-wide uppercase">
-          Access 120+ models from leading AI providers
-        </p>
-        <div className="mt-8 flex flex-wrap items-center justify-center gap-x-14 gap-y-4">
-          {PROVIDERS.map((name) => (
-            <span
-              className="text-foreground/75 hover:text-foreground text-xl font-medium tracking-tight transition-colors"
-              key={name}
-            >
-              {name}
-            </span>
-          ))}
-        </div>
+export const LogoCloud = () => (
+  <section className="border-border/30 border-y py-12">
+    <div className="mx-auto max-w-6xl px-6">
+      <p className="text-foreground/75 text-center text-sm tracking-wide uppercase">
+        Access 120+ models from leading AI providers
+      </p>
+      <div className="mt-8 flex flex-wrap items-center justify-center gap-x-14 gap-y-4">
+        {PROVIDERS.map((name) => (
+          <span
+            className="text-foreground/75 hover:text-foreground text-xl font-medium tracking-tight transition-colors"
+            key={name}
+          >
+            {name}
+          </span>
+        ))}
       </div>
-    </section>
-  );
-}
+    </div>
+  </section>
+);

--- a/apps/site/components/thread-showcase.tsx
+++ b/apps/site/components/thread-showcase.tsx
@@ -35,7 +35,7 @@ const MAX_ACTIVE_RUNS = 8;
 
 type PlaygroundChat = ThreadChat & { stoppedIds: ReadonlySet<string> };
 
-function responseState(chat: PlaygroundChat, message: PlaygroundMessage) {
+const responseState = (chat: PlaygroundChat, message: PlaygroundMessage) => {
   if (message.role !== "assistant") {
     return "complete";
   }
@@ -50,15 +50,15 @@ function responseState(chat: PlaygroundChat, message: PlaygroundMessage) {
     return "stopped";
   }
   return "complete";
-}
+};
 
-function ResponseStatus({
+const ResponseStatus = ({
   chat,
   message,
 }: {
   chat: PlaygroundChat;
   message: PlaygroundMessage;
-}) {
+}) => {
   const state = responseState(chat, message);
   const live = state === "streaming" || state === "submitted";
   const tokens = Math.ceil(getMessageText(message).length / 4);
@@ -83,12 +83,12 @@ function ResponseStatus({
       )}
     </span>
   );
-}
+};
 
-export function ThreadInstallCommand() {
+export const ThreadInstallCommand = () => {
   const [copied, setCopied] = useState(false);
 
-  async function copyCommand() {
+  const copyCommand = async () => {
     try {
       await navigator.clipboard.writeText(INSTALL_COMMAND);
       setCopied(true);
@@ -96,7 +96,7 @@ export function ThreadInstallCommand() {
     } catch {
       setCopied(false);
     }
-  }
+  };
 
   return (
     <div className="border-border bg-card mt-8 max-w-3xl border">
@@ -122,9 +122,9 @@ export function ThreadInstallCommand() {
       </div>
     </div>
   );
-}
+};
 
-function Conversation({
+const Conversation = ({
   chat,
   draft,
   onBranch,
@@ -142,7 +142,7 @@ function Conversation({
   onSend: () => Promise<void>;
   playgroundError: string | null;
   responseCount: number;
-}) {
+}) => {
   const transcript = useRef<HTMLDivElement>(null);
   const followTranscript = useRef(true);
   useEffect(() => {
@@ -158,7 +158,7 @@ function Conversation({
     observer.observe(element);
     return () => observer.disconnect();
   }, []);
-  const cursorId = chat.tree.cursorId;
+  const { cursorId } = chat.tree;
   const textLength = chat.messages.reduce(
     (length, message) => length + getMessageText(message).length,
     0
@@ -166,8 +166,8 @@ function Conversation({
   useEffect(() => {
     if (textLength && followTranscript.current) {
       transcript.current?.scrollTo({
-        top: transcript.current.scrollHeight,
         behavior: "instant",
+        top: transcript.current.scrollHeight,
       });
     }
   }, [textLength]);
@@ -175,8 +175,8 @@ function Conversation({
     followTranscript.current = true;
     if (cursorId) {
       transcript.current?.scrollTo({
-        top: transcript.current.scrollHeight,
         behavior: "instant",
+        top: transcript.current.scrollHeight,
       });
     }
   }, [cursorId]);
@@ -212,16 +212,16 @@ function Conversation({
           const siblingIndex = siblings.findIndex(
             (sibling) => sibling.id === message.id
           );
-          const hasSiblings = siblings.length > 1 && siblingIndex >= 0;
+          const hasSiblings = siblings.length > 1 && siblingIndex !== -1;
 
-          function navigateToSibling(nextIndex: number) {
+          const navigateToSibling = (nextIndex: number) => {
             const sibling = siblings[nextIndex];
             if (!sibling) {
               return;
             }
             const leaf = chat.tree.getLeaves(sibling.id).at(-1);
             chat.tree.setCursor(leaf?.id ?? sibling.id);
-          }
+          };
 
           return (
             <article
@@ -385,9 +385,9 @@ function Conversation({
       </form>
     </section>
   );
-}
+};
 
-function TreeCanvas({ chat }: { chat: PlaygroundChat }) {
+const TreeCanvas = ({ chat }: { chat: PlaygroundChat }) => {
   const layout = useMemo(
     () =>
       buildTreeLayout({
@@ -398,7 +398,7 @@ function TreeCanvas({ chat }: { chat: PlaygroundChat }) {
   );
   const activeIds = new Set(chat.messages.map((message) => message.id));
   const canvas = useRef<HTMLDivElement>(null);
-  const [viewportSize, setViewportSize] = useState({ width: 0, height: 0 });
+  const [viewportSize, setViewportSize] = useState({ height: 0, width: 0 });
   useEffect(() => {
     const viewport = canvas.current;
     if (!viewport) {
@@ -406,8 +406,8 @@ function TreeCanvas({ chat }: { chat: PlaygroundChat }) {
     }
     const observer = new ResizeObserver(() =>
       setViewportSize({
-        width: viewport.clientWidth,
         height: viewport.clientHeight,
+        width: viewport.clientWidth,
       })
     );
     observer.observe(viewport);
@@ -428,20 +428,20 @@ function TreeCanvas({ chat }: { chat: PlaygroundChat }) {
     <div className={styles.treeScroll} ref={canvas}>
       <div
         style={{
+          height: layout.height * scale + 24,
           position: "relative",
           width: Math.max(viewportSize.width, layout.width * scale + 24),
-          height: layout.height * scale + 24,
         }}
       >
         <div
           className="absolute"
           style={{
             height: layout.height,
-            width: layout.width,
-            transform: `scale(${scale})`,
-            transformOrigin: "top left",
             left: Math.max(12, (viewportSize.width - layout.width * scale) / 2),
             top: 12,
+            transform: `scale(${scale})`,
+            transformOrigin: "top left",
+            width: layout.width,
           }}
         >
           <svg
@@ -523,18 +523,18 @@ function TreeCanvas({ chat }: { chat: PlaygroundChat }) {
       </div>
     </div>
   );
-}
+};
 
-function PlaygroundSession() {
+const PlaygroundSession = () => {
   const [draft, setDraft] = useState("");
   const [playgroundError, setPlaygroundError] = useState<string | null>(null);
   const [responseCount, setResponseCount] = useState(1);
   const idCounter = useRef(100);
 
-  function generateMessageId() {
+  const generateMessageId = () => {
     idCounter.current += 1;
     return `msg_${idCounter.current}`;
-  }
+  };
 
   const [stoppedIds, setStoppedIds] = useState<ReadonlySet<string>>(new Set());
   const thread = useThread<PlaygroundMessage>({
@@ -550,19 +550,17 @@ function PlaygroundSession() {
   });
   const chat: PlaygroundChat = { ...thread, stoppedIds };
 
-  function messageInput(text: string, title: string, messageId?: string) {
-    return {
-      messageId,
-      metadata: {
-        activeStreamId: null,
-        createdAt: new Date().toISOString(),
-        title,
-      },
-      text,
-    };
-  }
+  const messageInput = (text: string, title: string, messageId?: string) => ({
+    messageId,
+    metadata: {
+      activeStreamId: null,
+      createdAt: new Date().toISOString(),
+      title,
+    },
+    text,
+  });
 
-  async function sendDraft(text = draft.trim(), count = responseCount) {
+  const sendDraft = async (text = draft.trim(), count = responseCount) => {
     if (!text) {
       return;
     }
@@ -602,9 +600,9 @@ function PlaygroundSession() {
         error instanceof Error ? error.message : "Unable to start this response"
       );
     }
-  }
+  };
 
-  async function branchFrom(messageId: string) {
+  const branchFrom = async (messageId: string) => {
     setPlaygroundError(null);
     try {
       const message = chat.tree.messagesById[messageId];
@@ -630,7 +628,7 @@ function PlaygroundSession() {
         error instanceof Error ? error.message : "Unable to create this branch"
       );
     }
-  }
+  };
 
   return (
     <div className={styles.playground} data-testid="thread-playground">
@@ -697,9 +695,9 @@ function PlaygroundSession() {
       </div>
     </div>
   );
-}
+};
 
-export function ThreadPlayground() {
+export const ThreadPlayground = () => {
   const [session, setSession] = useState(0);
   return (
     <div>
@@ -714,13 +712,11 @@ export function ThreadPlayground() {
       </div>
     </div>
   );
-}
+};
 
-export function ThreadShowcase() {
-  return (
-    <>
-      <ThreadPlayground />
-      <ThreadInstallCommand />
-    </>
-  );
-}
+export const ThreadShowcase = () => (
+  <>
+    <ThreadPlayground />
+    <ThreadInstallCommand />
+  </>
+);

--- a/apps/site/tests/thread-playground.visual.ts
+++ b/apps/site/tests/thread-playground.visual.ts
@@ -14,19 +14,19 @@ const output = fileURLToPath(
 await mkdir(output, { recursive: true });
 const errors: string[] = [];
 
-async function capture(page: Page, name: string) {
+const capture = async (page: Page, name: string) => {
   await page.getByTestId("thread-playground").screenshot({
     animations: "disabled",
+    path: `${output}${name}.png`,
     style:
       "header:has(> nav), nextjs-portal { visibility: hidden !important; }",
-    path: `${output}${name}.png`,
   });
-}
+};
 
 try {
   const page = await browser.newPage({
-    viewport: { width: 1440, height: 1200 },
     reducedMotion: "reduce",
+    viewport: { height: 1200, width: 1440 },
   });
   page.on("pageerror", (error) => errors.push(error.message));
   await page.clock.install({ time: new Date("2026-01-01T00:00:00Z") });
@@ -190,7 +190,7 @@ try {
   // Branch creation must preserve the original branch and select the new reply.
   const originalCount = await page.locator("[data-node-id]").count();
   await page
-    .getByRole("button", { name: "Branch from here", exact: true })
+    .getByRole("button", { exact: true, name: "Branch from here" })
     .last()
     .click();
   await page.waitForFunction(
@@ -221,7 +221,7 @@ try {
   await page.clock.runFor(1800);
   await page.evaluate(() => document.documentElement.classList.add("dark"));
   await capture(page, "threads-dark-live");
-  await page.setViewportSize({ width: 390, height: 844 });
+  await page.setViewportSize({ height: 844, width: 390 });
   await page.evaluate(() => document.documentElement.classList.remove("dark"));
   assert.equal(
     await page.evaluate(

--- a/oxlint-baseline.json
+++ b/oxlint-baseline.json
@@ -24,12 +24,7 @@
     },
     {
       "files": [
-        "apps/site/components/get-started.tsx",
-        "apps/site/components/hero.tsx",
-        "apps/site/components/logo-cloud.tsx",
         "apps/site/components/thread-playground-model.ts",
-        "apps/site/components/thread-showcase.tsx",
-        "apps/site/tests/thread-playground.visual.ts",
         "apps/videos/src/ThreadsLaunch.tsx",
         "packages/cli/src/utils/run-command.ts"
       ],
@@ -81,12 +76,6 @@
       }
     },
     {
-      "files": ["apps/site/components/thread-showcase.tsx"],
-      "rules": {
-        "prefer-destructuring": "off"
-      }
-    },
-    {
       "files": [
         "apps/docs/e2e/docs-visual.browser.test.ts",
         "apps/site/components/thread-playground-model.ts",
@@ -121,16 +110,7 @@
       }
     },
     {
-      "files": [
-        "apps/site/app/layout.tsx",
-        "apps/site/app/page.tsx",
-        "apps/site/app/threads/page.tsx",
-        "apps/site/components/get-started.tsx",
-        "apps/site/components/hero.tsx",
-        "apps/site/components/logo-cloud.tsx",
-        "apps/site/components/thread-showcase.tsx",
-        "apps/videos/src/ThreadsLaunch.tsx"
-      ],
+      "files": ["apps/videos/src/ThreadsLaunch.tsx"],
       "rules": {
         "react/function-component-definition": "off"
       }
@@ -167,11 +147,7 @@
     },
     {
       "files": [
-        "apps/site/app/layout.tsx",
-        "apps/site/app/page.tsx",
-        "apps/site/app/threads/page.tsx",
         "apps/site/components/thread-showcase.tsx",
-        "apps/site/tests/thread-playground.visual.ts",
         "packages/cli/src/helpers/scaffold.ts"
       ],
       "rules": {
@@ -182,12 +158,6 @@
       "files": ["packages/gateways/src/gateway-provider.ts"],
       "rules": {
         "typescript/method-signature-style": "off"
-      }
-    },
-    {
-      "files": ["apps/site/components/thread-showcase.tsx"],
-      "rules": {
-        "unicorn/consistent-existence-index-check": "off"
       }
     },
     {


### PR DESCRIPTION
## Summary

Clear straightforward lint debt in the Site app while preserving rendered behavior:

- Convert eligible function declarations and React components to arrow expressions.
- Apply safe key ordering to metadata, plain data, style, and visual capture options.
- Preserve evaluation order for the `useThread` options object, retaining its baseline exemption.
- Preserve all literal strings, numeric values, array order, and UI content.
- Remove only resolved Site baseline entries.

The remaining Site diagnostics are intentional or behavior-sensitive: thread playground model rules, Unicode regexp suggestions, sequential visual-test awaits, React compiler TODO, JSX comment text handling, and one function-scoping suggestion.

## Validation

- `bun lint`
- `bun test:types`
- `bun test:visual:site` with `CHATJS_DEV_SLOT=1` on `http://localhost:3012/threads`
- Inspected representative deterministic captures: initial desktop and mobile live states
- Strict Site audit: 20 residual nontrivial/behavior-sensitive diagnostics


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears straightforward lint debt in the Site app without changing rendered behavior.

**Refactors**
- Converts eligible function declarations and React components to arrow expressions.
- Orders keys in metadata, plain data, style, and visual capture options.
- Preserves the `useThread` options object evaluation order and its baseline exemption.
- Updates the Site visual test to match the new ordering and removes resolved entries from `oxlint-baseline.json`.

**Validation**
- Passes `bun lint`, `bun test:types`, and `bun test:visual:site` with `CHATJS_DEV_SLOT=1` on the threads playground.
- The remaining Site diagnostics are intentional or behavior-sensitive and stay in the baseline.

<sup>Written for commit 0376369dd82aa0c46af3017857301ac62790f391. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

