### PR TITLE
chore(chat): clean session and storage lint rules

### DIFF
--- a/apps/chat/lib/anonymous-session-server.ts
+++ b/apps/chat/lib/anonymous-session-server.ts
@@ -41,8 +41,8 @@ export const setAnonymousSession = async (
 ): Promise<void> => {
   const cookieStore = await cookies();
   cookieStore.set(ANONYMOUS_SESSION_COOKIES_KEY, JSON.stringify(session), {
-    path: "/",
     maxAge: ANONYMOUS_LIMITS.SESSION_DURATION,
+    path: "/",
     sameSite: "lax",
     secure: process.env.NODE_ENV === "production",
   });

--- a/apps/chat/lib/create-anonymous-session.ts
+++ b/apps/chat/lib/create-anonymous-session.ts
@@ -2,8 +2,9 @@ import { ANONYMOUS_LIMITS } from "./types/anonymous";
 import type { AnonymousSession } from "./types/anonymous";
 import { generateUUID } from "./utils";
 
-export const createAnonymousSession = (): AnonymousSession => ({
-  id: generateUUID(),
-  remainingCredits: ANONYMOUS_LIMITS.CREDITS,
-  createdAt: new Date(),
-});
+export const createAnonymousSession = (): AnonymousSession => {
+  const id = generateUUID();
+  const remainingCredits = ANONYMOUS_LIMITS.CREDITS;
+  const createdAt = new Date();
+  return { createdAt, id, remainingCredits };
+};

--- a/apps/chat/lib/db/mcp-queries.ts
+++ b/apps/chat/lib/db/mcp-queries.ts
@@ -101,13 +101,13 @@ export const createMcpConnector = async ({
     const [connector] = await db
       .insert(mcpConnector)
       .values({
-        userId,
         name,
         nameId,
-        url,
-        type,
         oauthClientId: oauthClientId ?? null,
         oauthClientSecret: oauthClientSecret ?? null,
+        type,
+        url,
+        userId,
       })
       .returning();
     return connector;
@@ -211,11 +211,11 @@ export const createOAuthSession = async ({
   const [session] = await db
     .insert(mcpOAuthSession)
     .values({
+      clientInfo,
+      codeVerifier,
       mcpConnectorId,
       serverUrl,
       state,
-      codeVerifier,
-      clientInfo,
     })
     .returning();
   return session;

--- a/apps/chat/lib/env-schema.ts
+++ b/apps/chat/lib/env-schema.ts
@@ -25,7 +25,8 @@ export const serverEnvSchema = {
   DATABASE_URL: z
     .preprocess(
       (value) =>
-        isPlaywrightTestEnvironmentEnabled && (value == null || value === "")
+        isPlaywrightTestEnvironmentEnabled &&
+        (value === null || value === undefined || value === "")
           ? "postgres://postgres:postgres@127.0.0.1:5432/playwright"
           : value,
       z.string().min(1)
@@ -34,7 +35,8 @@ export const serverEnvSchema = {
   AUTH_SECRET: z
     .preprocess(
       (value) =>
-        isPlaywrightTestEnvironmentEnabled && (value == null || value === "")
+        isPlaywrightTestEnvironmentEnabled &&
+        (value === null || value === undefined || value === "")
           ? "playwright-test-auth-secret"
           : value,
       z.string().min(1)

--- a/apps/chat/lib/file-content-response.test.ts
+++ b/apps/chat/lib/file-content-response.test.ts
@@ -2,6 +2,9 @@ import assert from "node:assert/strict";
 
 import { describe, it, vi } from "vitest";
 
+import { createFileContentResponse } from "./file-content-response";
+import { uploadFile } from "./file-storage";
+
 vi.mock("@/lib/config", () => ({
   config: { appPrefix: "file-response-test" },
 }));
@@ -12,9 +15,6 @@ vi.mock("./storage-provider", async () => {
     createStorageAdapter: () => memory(),
   };
 });
-
-import { createFileContentResponse } from "./file-content-response";
-import { uploadFile } from "./file-storage";
 
 describe("file content response", () => {
   it("serves byte ranges", async () => {

--- a/apps/chat/lib/file-storage.test.ts
+++ b/apps/chat/lib/file-storage.test.ts
@@ -2,6 +2,9 @@ import assert from "node:assert/strict";
 
 import { describe, it, vi } from "vitest";
 
+import { deleteFilesByUrls, listFiles, uploadFile } from "./file-storage";
+import { keyFromFileUrl } from "./file-url";
+
 vi.mock("@/lib/config", () => ({
   config: { appPrefix: "storage-test" },
 }));
@@ -13,20 +16,18 @@ vi.mock("./storage-provider", async () => {
   };
 });
 
-import { deleteFilesByUrls, listFiles, uploadFile } from "./file-storage";
-import { keyFromFileUrl } from "./file-url";
-
 describe("file storage", () => {
   it("uploads, lists, and deletes through Files SDK", async () => {
     const uploaded = await uploadFile("../hello.txt", "hello", "text/plain");
     const key = keyFromFileUrl(uploaded.url);
 
-    assert(key);
+    assert.ok(key);
     assert.equal(uploaded.pathname, "hello.txt");
     assert.equal(uploaded.contentType, "text/plain");
     assert.equal(uploaded.url, `/api/files/content?key=${key}`);
+    const uploadedFiles = await listFiles();
     assert.deepEqual(
-      (await listFiles()).files.map((file) => file.pathname),
+      uploadedFiles.files.map((file) => file.pathname),
       [key]
     );
 
@@ -35,6 +36,7 @@ describe("file storage", () => {
       "https://old-chat.example"
     ).toString();
     await deleteFilesByUrls([previousDeploymentUrl]);
-    assert.equal((await listFiles()).files.length, 0);
+    const remainingFiles = await listFiles();
+    assert.equal(remainingFiles.files.length, 0);
   });
 });

--- a/apps/chat/lib/logger.ts
+++ b/apps/chat/lib/logger.ts
@@ -4,15 +4,13 @@ import type { Logger } from "pino";
 import userConfig from "@/chat.config";
 
 const appBinding = userConfig.appPrefix || userConfig.appName || "chatjs";
-
 // Prefer JSON in production; pretty in development.
 // We also add base bindings so child loggers inherit app metadata.
 const logger: Logger =
   process.env.NODE_ENV === "production"
     ? pino({
-        level: "info",
         base: { app: appBinding },
-        timestamp: stdTimeFunctions.isoTime,
+        level: "info",
         redact: {
           paths: [
             "password",
@@ -23,21 +21,21 @@ const logger: Logger =
           ],
           remove: false,
         },
+        timestamp: stdTimeFunctions.isoTime,
       })
     : pino({
-        level: "debug",
         base: { app: appBinding },
+        level: "debug",
         timestamp: stdTimeFunctions.isoTime,
         transport: {
-          target: "pino-pretty",
           options: {
             colorize: true,
-            translateTime: "SYS:standard",
             ignore: "pid,hostname",
             singleLine: false,
+            translateTime: "SYS:standard",
           },
+          target: "pino-pretty",
         },
       });
-
 export const createModuleLogger = (moduleName: string): Logger =>
   logger.child({ module: moduleName });

--- a/apps/chat/lib/types/anonymous.ts
+++ b/apps/chat/lib/types/anonymous.ts
@@ -10,12 +10,13 @@ export interface AnonymousSession {
 const anonConfig = config.anonymous;
 
 export const ANONYMOUS_LIMITS = {
-  CREDITS: anonConfig.credits,
   AVAILABLE_MODELS: config.ai.anonymousModels,
   AVAILABLE_TOOLS: anonConfig.availableTools as ToolName[],
-  SESSION_DURATION: 2_147_483_647, // Max session time
+  CREDITS: anonConfig.credits,
   RATE_LIMIT: {
     REQUESTS_PER_MINUTE: anonConfig.rateLimit.requestsPerMinute,
     REQUESTS_PER_MONTH: anonConfig.rateLimit.requestsPerMonth,
   },
+  // Max session time
+  SESSION_DURATION: 2_147_483_647,
 } as const;

--- a/apps/chat/oxlint-baseline.json
+++ b/apps/chat/oxlint-baseline.json
@@ -49,11 +49,7 @@
       }
     },
     {
-      "files": [
-        "lib/ai/text-splitter.ts",
-        "lib/env-schema.ts",
-        "providers/session-provider.tsx"
-      ],
+      "files": ["lib/ai/text-splitter.ts", "providers/session-provider.tsx"],
       "rules": {
         "eqeqeq": "off"
       }
@@ -260,8 +256,6 @@
     {
       "files": [
         "components/part/tool-part.test.tsx",
-        "lib/file-content-response.test.ts",
-        "lib/file-storage.test.ts",
         "tools/chatjs/vercel-code-execution/tool.test.ts"
       ],
       "rules": {
@@ -390,11 +384,7 @@
       }
     },
     {
-      "files": [
-        "lib/ai/text-splitter.ts",
-        "lib/env-schema.ts",
-        "providers/session-provider.tsx"
-      ],
+      "files": ["lib/ai/text-splitter.ts", "providers/session-provider.tsx"],
       "rules": {
         "no-eq-null": "off"
       }
@@ -413,7 +403,6 @@
         "lib/editor/config.ts",
         "lib/message-conversion.ts",
         "lib/stores/base/hooks.ts",
-        "lib/types/anonymous.ts",
         "providers/chat-input-provider.tsx",
         "trpc/server.tsx"
       ],
@@ -1177,7 +1166,6 @@
         "lib/ai/markdown-joiner-transform.ts",
         "lib/ai/text-splitter.ts",
         "lib/anonymous-session-client.ts",
-        "lib/anonymous-session-server.ts",
         "lib/artifacts/code/client.tsx",
         "lib/artifacts/sheet/client.tsx",
         "lib/artifacts/text/client.tsx",
@@ -1185,27 +1173,22 @@
         "lib/chat-tree-actions.test.ts",
         "lib/config-requirements.ts",
         "lib/config-schema.ts",
-        "lib/create-anonymous-session.ts",
         "lib/credits/cost-accumulator.test.ts",
         "lib/credits/cost-accumulator.ts",
         "lib/data-stream.test.ts",
-        "lib/db/mcp-queries.ts",
         "lib/db/queries.ts",
         "lib/db/schema.ts",
         "lib/draft-chat-submission.ts",
-        "lib/env-schema.ts",
         "lib/env.ts",
         "lib/file-content-response.ts",
         "lib/files/upload-prep.ts",
         "lib/features-config.ts",
-        "lib/logger.ts",
         "lib/message-conversion.ts",
         "lib/redis/client.test.ts",
         "lib/stores/base/hooks.ts",
         "lib/stores/with-data-stream.test.ts",
         "lib/stores/with-message-parts.ts",
         "lib/thread-utils.test.ts",
-        "lib/types/anonymous.ts",
         "lib/utils.ts",
         "lib/utils/message-mapping.ts",
         "providers/chat-input-provider.tsx",
@@ -1225,6 +1208,12 @@
         "trpc/react.tsx",
         "trpc/server.tsx"
       ],
+      "rules": {
+        "sort-keys": "off"
+      }
+    },
+    {
+      "files": ["lib/env-schema.ts"],
       "rules": {
         "sort-keys": "off"
       }
@@ -1279,12 +1268,6 @@
       }
     },
     {
-      "files": ["lib/file-storage.test.ts"],
-      "rules": {
-        "unicorn/consistent-assert": "off"
-      }
-    },
-    {
       "files": ["components/settings/models-table.tsx"],
       "rules": {
         "unicorn/consistent-existence-index-check": "off"
@@ -1324,12 +1307,6 @@
       ],
       "rules": {
         "unicorn/no-array-sort": "off"
-      }
-    },
-    {
-      "files": ["lib/file-storage.test.ts"],
-      "rules": {
-        "unicorn/no-await-expression-member": "off"
       }
     },
     {


### PR DESCRIPTION
## Changes

Clears 21 diagnostics in session helpers, logger options, MCP query value records, environment preprocessing, and storage tests. Preserves UUID generation before the session timestamp, the environment checklist's declaration order, and Vitest mock hoisting.

Removes 12 resolved file/rule exemptions. The environment schema keeps its ordering exemption because those keys drive the CLI checklist.

## Validation

- `bun lint`
- `bun test:types`
- Storage and content-response tests: 3 passed.
- Strict scoped audit: 22 → 1 diagnostics; reviewed query-value and initialization ordering.

## Summary by Sourcery

Clean up chat session and storage lint violations and reduce the Oxlint baseline to the remaining required exemption.

Enhancements:
- Align session, logger, query record, environment preprocessing, and storage test code with lint rules while preserving required ordering semantics.
- Remove resolved Oxlint baseline exemptions and retain only the environment schema ordering exemption required by the CLI checklist.

Tests:
- Update storage-related tests to satisfy linting and preserve Vitest mock hoisting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears 21 lint diagnostics in session helpers, logger options, MCP query value records, environment preprocessing, and storage tests without changing runtime behavior.

- Removes 12 resolved file/rule exemptions from `oxlint-baseline.json`.
- Keeps `env-schema.ts` sort-keys exemption because key order drives the CLI checklist.
- Switches `env-schema.ts` null preprocessing to explicit `null`/`undefined` checks.
- Preserves session creation order and Vitest mock hoisting in test files.

<sup>Written for commit 15ee569aab23ad827c55423e7c7e2eb4f1b4df47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

