### PR TITLE
chore(site): clean playground helper declarations

### DIFF
--- a/apps/site/components/thread-playground-model.ts
+++ b/apps/site/components/thread-playground-model.ts
@@ -23,7 +23,7 @@ export interface LayoutNode {
   y: number;
 }
 
-function createMessage({
+const createMessage = ({
   id,
   role,
   text,
@@ -33,18 +33,16 @@ function createMessage({
   role: "assistant" | "user";
   text: string;
   title: string;
-}): PlaygroundMessage {
-  return {
-    id,
-    metadata: {
-      activeStreamId: null,
-      createdAt: new Date().toISOString(),
-      title,
-    },
-    parts: [{ text, type: "text" }],
-    role,
-  };
-}
+}): PlaygroundMessage => ({
+  id,
+  metadata: {
+    activeStreamId: null,
+    createdAt: new Date().toISOString(),
+    title,
+  },
+  parts: [{ text, type: "text" }],
+  role,
+});
 
 const initialNodes = [
   {
@@ -118,8 +116,8 @@ export const initialTree: MessageTreeSnapshot<PlaygroundMessage> = {
   version: 1,
 };
 
-function delay(ms: number, signal?: AbortSignal) {
-  return new Promise<void>((resolve, reject) => {
+const delay = (ms: number, signal?: AbortSignal) =>
+  new Promise<void>((resolve, reject) => {
     if (signal?.aborted) {
       reject(new DOMException("Aborted", "AbortError"));
       return;
@@ -135,7 +133,6 @@ function delay(ms: number, signal?: AbortSignal) {
     }, ms);
     signal?.addEventListener("abort", onAbort, { once: true });
   });
-}
 
 const RESPONSE_NUMBER_PATTERN = /\d+/u;
 
@@ -218,18 +215,18 @@ export class PlaygroundTransport implements ChatTransport<PlaygroundMessage> {
   }
 }
 
-export function buildTreeLayout({
+export const buildTreeLayout = ({
   childrenByParentId,
   rootIds,
 }: {
   childrenByParentId: Record<string, string[]>;
   rootIds: string[];
-}) {
+}) => {
   const positions = new Map<string, LayoutNode>();
   let nextLeaf = 0;
   let maxDepth = 0;
 
-  function visit(id: string, depth: number): number {
+  const visit = (id: string, depth: number): number => {
     maxDepth = Math.max(maxDepth, depth);
     const children = childrenByParentId[id] ?? [];
     let column: number;
@@ -246,7 +243,7 @@ export function buildTreeLayout({
 
     positions.set(id, { depth, id, x: column * 164 + 92, y: depth * 122 + 64 });
     return column;
-  }
+  };
 
   for (const rootId of rootIds) {
     visit(rootId, 0);
@@ -259,4 +256,4 @@ export function buildTreeLayout({
     positions,
     width: Math.max(430, Math.max(0, nextLeaf - 2) * 164 + 184),
   };
-}
+};

--- a/apps/site/tests/thread-playground.visual.ts
+++ b/apps/site/tests/thread-playground.visual.ts
@@ -37,7 +37,7 @@ try {
   const intro = page.locator("main > section").first();
   assert.match(
     (await intro.locator("pre").textContent()) ?? "",
-    /useThread\(\)/
+    /useThread\(\)/u
   );
   await intro.screenshot({
     animations: "disabled",
@@ -118,7 +118,7 @@ try {
   );
   const stoppedText = await first.textContent();
   await page.clock.runFor(1200);
-  assert.match(stoppedText ?? "", /Stopped/);
+  assert.match(stoppedText ?? "", /Stopped/u);
   assert.equal(
     await first.textContent(),
     stoppedText,
@@ -165,7 +165,7 @@ try {
   assert.match(
     (await page.locator('[data-node-id][aria-pressed="true"]').textContent()) ??
       "",
-    /Response 2 of 3/
+    /Response 2 of 3/u
   );
   await page.locator('[data-node-id="msg_02"]').click();
   assert.equal(
@@ -183,7 +183,7 @@ try {
     await page.locator('[data-node-id][data-state="streaming"]').count(),
     0
   );
-  assert.match((await second.textContent()) ?? "", /Complete/);
+  assert.match((await second.textContent()) ?? "", /Complete/u);
   await second.click();
   await capture(page, "threads-complete");
 
@@ -206,7 +206,7 @@ try {
   assert.match(
     (await page.locator('[data-node-id][aria-pressed="true"]').textContent()) ??
       "",
-    /Branch response/
+    /Branch response/u
   );
   await capture(page, "threads-new-branch");
 

--- a/oxlint-baseline.json
+++ b/oxlint-baseline.json
@@ -24,7 +24,6 @@
     },
     {
       "files": [
-        "apps/site/components/thread-playground-model.ts",
         "apps/videos/src/ThreadsLaunch.tsx",
         "packages/cli/src/utils/run-command.ts"
       ],
@@ -137,12 +136,6 @@
       "files": ["apps/site/components/thread-showcase.tsx"],
       "rules": {
         "react/todo": "off"
-      }
-    },
-    {
-      "files": ["apps/site/tests/thread-playground.visual.ts"],
-      "rules": {
-        "require-unicode-regexp": "off"
       }
     },
     {


### PR DESCRIPTION
## Changes

Clears nine remaining mechanical diagnostics in the thread playground model and visual checks: helper declarations become arrows and five ASCII-only assertion regexes use Unicode mode.

Preserves message initialization order, the abortable timer, stream cadence, and transport method contracts. Removes two obsolete file/rule exemptions; scoped timing/interface exceptions remain.

## Validation

- `bun lint`
- `bun test:types`
- `bun test:visual:site`: deterministic interaction checks and all captures passed.
- Inspected desktop initial and mobile streaming captures.
- Strict scope audit: 15 → 6 diagnostics.

## Summary by Sourcery

Clean up remaining mechanical diagnostics in the thread playground model and visual checks.

Enhancements:
- Standardize remaining playground model and layout helper declarations as arrow functions while preserving existing behavior.
- Enable Unicode mode on visual test assertion regular expressions.

Chores:
- Remove obsolete Oxlint baseline exemptions for the cleaned-up diagnostics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up the remaining mechanical lint diagnostics in the thread playground model and visual checks without changing behavior.

- Converts helper declarations to arrow functions in `apps/site/components/thread-playground-model.ts`.
- Enables Unicode mode on five assertion regexes in `apps/site/tests/thread-playground.visual.ts`.
- Removes the two obsolete oxlint baseline exemptions for those files.

<sup>Written for commit 477323e8207be8e9f5efda0ed40657122b0b5207. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

