### PR TITLE
refactor(chat): use arrow functions in ai elements

### DIFF
--- a/apps/chat/components/ai-elements/code-block.tsx
+++ b/apps/chat/components/ai-elements/code-block.tsx
@@ -44,11 +44,11 @@ const lineNumberTransformer: ShikiTransformer = {
   },
 };
 
-export async function highlightCode(
+export const highlightCode = async (
   code: string,
   language: BundledLanguage,
   showLineNumbers = false
-) {
+) => {
   const transformers: ShikiTransformer[] = showLineNumbers
     ? [lineNumberTransformer]
     : [];
@@ -65,7 +65,7 @@ export async function highlightCode(
       transformers,
     }),
   ]);
-}
+};
 
 export const CodeBlock = ({
   code,

--- a/apps/chat/components/ai-elements/message.tsx
+++ b/apps/chat/components/ai-elements/message.tsx
@@ -333,12 +333,12 @@ export type MessageAttachmentProps = HTMLAttributes<HTMLDivElement> & {
   onRemove?: () => void;
 };
 
-export function MessageAttachment({
+export const MessageAttachment = ({
   data,
   className,
   onRemove,
   ...props
-}: MessageAttachmentProps) {
+}: MessageAttachmentProps) => {
   const filename = data.filename || "";
   const mediaType =
     data.mediaType?.startsWith("image/") && data.url ? "image" : "file";
@@ -409,15 +409,15 @@ export function MessageAttachment({
       )}
     </div>
   );
-}
+};
 
 export type MessageAttachmentsProps = ComponentProps<"div">;
 
-export function MessageAttachments({
+export const MessageAttachments = ({
   children,
   className,
   ...props
-}: MessageAttachmentsProps) {
+}: MessageAttachmentsProps) => {
   if (!children) {
     return null;
   }
@@ -433,7 +433,7 @@ export function MessageAttachments({
       {children}
     </div>
   );
-}
+};
 
 export type MessageToolbarProps = ComponentProps<"div">;
 

--- a/apps/chat/components/ai-elements/prompt-input.tsx
+++ b/apps/chat/components/ai-elements/prompt-input.tsx
@@ -144,10 +144,10 @@ export type PromptInputProviderProps = PropsWithChildren<{
  * Optional global provider that lifts PromptInput state outside of PromptInput.
  * If you don't use it, PromptInput stays fully self-managed.
  */
-export function PromptInputProvider({
+export const PromptInputProvider = ({
   initialInput: initialTextInput = "",
   children,
-}: PromptInputProviderProps) {
+}: PromptInputProviderProps) => {
   // ----- textInput state
   const [textInput, setTextInput] = useState(initialTextInput);
   const clearInput = useCallback(() => setTextInput(""), []);
@@ -243,7 +243,7 @@ export function PromptInputProvider({
       </ProviderAttachmentsContext.Provider>
     </PromptInputController.Provider>
   );
-}
+};
 
 // ============================================================================
 // Component Context & Hooks
@@ -269,11 +269,11 @@ export type PromptInputAttachmentProps = HTMLAttributes<HTMLDivElement> & {
   className?: string;
 };
 
-export function PromptInputAttachment({
+export const PromptInputAttachment = ({
   data,
   className,
   ...props
-}: PromptInputAttachmentProps) {
+}: PromptInputAttachmentProps) => {
   const attachments = usePromptInputAttachments();
 
   const filename = data.filename || "";
@@ -358,7 +358,7 @@ export function PromptInputAttachment({
       </PromptInputHoverCardContent>
     </PromptInputHoverCard>
   );
-}
+};
 
 export type PromptInputAttachmentsProps = Omit<
   HTMLAttributes<HTMLDivElement>,
@@ -367,11 +367,11 @@ export type PromptInputAttachmentsProps = Omit<
   children: (attachment: FileUIPart & { id: string }) => ReactNode;
 };
 
-export function PromptInputAttachments({
+export const PromptInputAttachments = ({
   children,
   className,
   ...props
-}: PromptInputAttachmentsProps) {
+}: PromptInputAttachmentsProps) => {
   const attachments = usePromptInputAttachments();
 
   if (!attachments.files.length) {
@@ -388,7 +388,7 @@ export function PromptInputAttachments({
       ))}
     </div>
   );
-}
+};
 
 export type PromptInputActionAddAttachmentsProps = ComponentProps<
   typeof DropdownMenuItem


### PR DESCRIPTION
## Summary
- convert six ai-elements function declarations to equivalent arrow functions
- preserve parameters, bodies, async behavior, exports, and evaluation order

## Validation
- `bun lint`
- `bun test:types`
- strict baseline-free ai-elements audit: target style diagnostics 16 → 5; remaining five are existing anonymous `forwardRef` callback function-component-definition diagnostics
- AST body and parameter-count comparison against `origin/main` passed for all six conversions
- browser smoke render at `http://localhost:3410/` produced the ChatJS prompt UI screenshot; dev login was unavailable because local Postgres was not running

## Summary by Sourcery

Enhancements:
- Standardize six exported AI Elements utilities and components on arrow-function declarations while preserving their existing behavior and interfaces.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converts six function declarations in the chat AI elements components to arrow functions, standardizing style while preserving parameters, bodies, async behavior, exports, and evaluation order.

<sup>Written for commit 541e10c450c62553f9357eb32ab2bc40a5b4210c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

