### PR TITLE
refactor: use arrow functions in chat providers

### DIFF
--- a/apps/chat/lib/app-chat-runtime.ts
+++ b/apps/chat/lib/app-chat-runtime.ts
@@ -37,27 +37,25 @@ export interface ProvisionalAppRuntimeIdentity {
 const ProvisionalAppRuntimeIdentityContext =
   createContext<ProvisionalAppRuntimeIdentity | null>(null);
 
-export function ProvisionalAppRuntimeIdentityProvider({
+export const ProvisionalAppRuntimeIdentityProvider = ({
   children,
   identity,
 }: {
   children: ReactNode;
   identity: ProvisionalAppRuntimeIdentity | null;
-}) {
-  return createElement(
+}) =>
+  createElement(
     ProvisionalAppRuntimeIdentityContext.Provider,
     { value: identity },
     children
   );
-}
 
-export function useCurrentProvisionalAppRuntimeIdentity() {
-  return useContext(ProvisionalAppRuntimeIdentityContext);
-}
+export const useCurrentProvisionalAppRuntimeIdentity = () =>
+  useContext(ProvisionalAppRuntimeIdentityContext);
 
-export function useProvisionalAppRuntimeIdentity(
+export const useProvisionalAppRuntimeIdentity = (
   scopeKey: string | null | undefined
-): ProvisionalAppRuntimeIdentity | null {
+): ProvisionalAppRuntimeIdentity | null => {
   const identityRef = useRef<{
     identity: ProvisionalAppRuntimeIdentity;
     scopeKey: string;
@@ -81,9 +79,23 @@ export function useProvisionalAppRuntimeIdentity(
   }
 
   return identityRef.current.identity;
-}
+};
 
-export function createAppRuntimeInput({
+const createAppRuntimeStore = ({
+  bootstrap,
+  initialMessages,
+  initialTree,
+}: {
+  bootstrap: boolean;
+  initialMessages?: ChatMessage[];
+  initialTree?: MessageTreeSnapshot<ChatMessage>;
+}) =>
+  createCustomChatStore<ChatMessage>(initialMessages ?? [], {
+    initialIsChatPersisted: bootstrap,
+    initialTree,
+  });
+
+export const createAppRuntimeInput = ({
   bootstrap,
   initialMessages,
   initialTree,
@@ -95,7 +107,7 @@ export function createAppRuntimeInput({
   initialTree?: MessageTreeSnapshot<ChatMessage>;
   initialTool?: UiToolName | null;
   runtimeId: ChatRuntimeId;
-}): CreateAppRuntimeInput {
+}): CreateAppRuntimeInput => {
   const parsed = parseChatRuntimeId(runtimeId);
   if (!parsed) {
     throw new Error(`Invalid chat runtime id: ${runtimeId}`);
@@ -123,27 +135,8 @@ export function createAppRuntimeInput({
     },
     runtimeId,
   };
-}
+};
 
-function createAppRuntimeStore({
-  bootstrap,
-  initialMessages,
-  initialTree,
-}: {
-  bootstrap: boolean;
-  initialMessages?: ChatMessage[];
-  initialTree?: MessageTreeSnapshot<ChatMessage>;
-}) {
-  return createCustomChatStore<ChatMessage>(initialMessages ?? [], {
-    initialIsChatPersisted: bootstrap,
-    initialTree,
-  });
-}
+export const getAppRuntimeStore = (runtime: AppRuntime) => runtime.data.store;
 
-export function getAppRuntimeStore(runtime: AppRuntime) {
-  return runtime.data.store;
-}
-
-export function getAppRuntimeThread(runtime: AppRuntime) {
-  return runtime.data.thread;
-}
+export const getAppRuntimeThread = (runtime: AppRuntime) => runtime.data.thread;

--- a/apps/chat/lib/runtime-registry/runtime-registry-provider.tsx
+++ b/apps/chat/lib/runtime-registry/runtime-registry-provider.tsx
@@ -34,26 +34,28 @@ interface RuntimeRegistryContextValue<TData = unknown> {
 const RuntimeRegistryContext =
   createContext<RuntimeRegistryContextValue | null>(null);
 
-function assertValidRuntimeId(runtimeId: RuntimeId): asserts runtimeId {
+const assertValidRuntimeId: (runtimeId: RuntimeId) => asserts runtimeId = (
+  runtimeId
+) => {
   if (!runtimeId) {
     throw new Error("Runtime id is required");
   }
-}
+};
 
-function createRuntime<TData>(
+const createRuntime = <TData,>(
   input: CreateRuntimeInput<TData>
-): Runtime<TData> {
+): Runtime<TData> => {
   assertValidRuntimeId(input.runtimeId);
 
   return {
     data: input.data,
     runtimeId: input.runtimeId,
   };
-}
+};
 
-function createInitialRuntimes<TData>(
+const createInitialRuntimes = <TData,>(
   initialRuntimes: CreateRuntimeInput<TData>[]
-) {
+) => {
   const runtimes: Runtime<TData>[] = [];
   const seenRuntimeIds = new Set<string>();
 
@@ -69,15 +71,15 @@ function createInitialRuntimes<TData>(
   }
 
   return runtimes;
-}
+};
 
-export function RuntimeRegistryProvider<TData = unknown>({
+export const RuntimeRegistryProvider = <TData = unknown,>({
   children,
   initialRuntimes = [],
 }: {
   children: ReactNode;
   initialRuntimes?: CreateRuntimeInput<TData>[];
-}) {
+}) => {
   const [runtimes, setRuntimes] = useState<Runtime<TData>[]>(() =>
     createInitialRuntimes(initialRuntimes)
   );
@@ -148,9 +150,9 @@ export function RuntimeRegistryProvider<TData = unknown>({
       {children}
     </RuntimeRegistryContext.Provider>
   );
-}
+};
 
-export function useRuntimeRegistry<TData = unknown>() {
+export const useRuntimeRegistry = <TData = unknown,>() => {
   const context = useContext(RuntimeRegistryContext);
   if (!context) {
     throw new Error(
@@ -158,13 +160,13 @@ export function useRuntimeRegistry<TData = unknown>() {
     );
   }
   return context as RuntimeRegistryContextValue<TData>;
-}
+};
 
-export function RuntimeSlots<TData = unknown>({
+export const RuntimeSlots = <TData = unknown,>({
   children,
 }: {
   children: (runtime: Runtime<TData>) => ReactNode;
-}) {
+}) => {
   const { runtimes } = useRuntimeRegistry<TData>();
 
   return (
@@ -174,4 +176,4 @@ export function RuntimeSlots<TData = unknown>({
       ))}
     </>
   );
-}
+};

--- a/apps/chat/lib/stores/custom-store-provider.tsx
+++ b/apps/chat/lib/stores/custom-store-provider.tsx
@@ -38,13 +38,13 @@ export type CustomChatStoreState<UI_MESSAGE extends UIMessage = UIMessage> =
     ThreadStateStore<UI_MESSAGE>;
 
 const ENABLE_TRACING_ON_DEV = false;
-export function createCustomChatStore<TMessage extends UIMessage = UIMessage>(
+export const createCustomChatStore = <TMessage extends UIMessage = UIMessage>(
   initialMessages: TMessage[] = [],
   options: {
     initialIsChatPersisted?: boolean;
     initialTree?: MessageTreeSnapshot<TMessage>;
   } = {}
-) {
+) => {
   const initialSnapshot = options.initialTree
     ? createThreadStateSnapshot({ initialTree: options.initialTree })
     : createThreadStateSnapshot({ messages: initialMessages });
@@ -74,24 +74,24 @@ export function createCustomChatStore<TMessage extends UIMessage = UIMessage>(
       { name: "chat-store" }
     )
   );
-}
+};
 
 export type CustomChatStoreApi<TMessage extends UIMessage = UIMessage> =
   ReturnType<typeof createCustomChatStore<TMessage>>;
 
 const ApplicationThreadContext = createContext<ApplicationThread | null>(null);
 
-export function useCustomChatStoreApi<
+export const useCustomChatStoreApi = <
   TMessage extends UIMessage = UIMessage,
->() {
+>() => {
   const store = useContext(ChatStoreContext);
   if (!store) {
     throw new Error("useChatStoreApi must be used within Provider");
   }
   return store as CustomChatStoreApi<TMessage>;
-}
+};
 
-export function useApplicationThread() {
+export const useApplicationThread = () => {
   const thread = useContext(ApplicationThreadContext);
   if (!thread) {
     throw new Error(
@@ -99,11 +99,11 @@ export function useApplicationThread() {
     );
   }
   return thread;
-}
+};
 
 type ChatProviderProps = Parameters<typeof ChatProvider>[0];
 
-export function CustomStoreProvider({
+export const CustomStoreProvider = ({
   initialMessages = [],
   initialTree,
   children,
@@ -117,7 +117,7 @@ export function CustomStoreProvider({
   thread?: ApplicationThread;
   threadId?: string;
 }> &
-  Omit<ChatProviderProps, "initialMessages" | "store">) {
+  Omit<ChatProviderProps, "initialMessages" | "store">) => {
   const storeRef = useRef<CustomChatStoreApi<ChatMessage> | null>(null);
 
   if (storeRef.current === null) {
@@ -154,4 +154,4 @@ export function CustomStoreProvider({
       </ChatProvider>
     </ApplicationThreadContext.Provider>
   );
-}
+};

--- a/apps/chat/providers/chat-input-provider.tsx
+++ b/apps/chat/providers/chat-input-provider.tsx
@@ -55,7 +55,7 @@ interface ChatInputProviderProps {
   overrideModelSelection?: SelectedModelValue; // For message editing with multi-model selection
 }
 
-export function ChatInputProvider({
+export const ChatInputProvider = ({
   children,
   initialInput = "",
   initialTool = null,
@@ -64,7 +64,7 @@ export function ChatInputProvider({
   overrideModelSelection,
   localStorageEnabled = true,
   isProjectContext = false,
-}: ChatInputProviderProps) {
+}: ChatInputProviderProps) => {
   const [hasHydrated, setHasHydrated] = useState(false);
 
   useEffect(() => {
@@ -257,12 +257,12 @@ export function ChatInputProvider({
       {children}
     </ChatInputContext.Provider>
   );
-}
+};
 
-export function useChatInput() {
+export const useChatInput = () => {
   const context = useContext(ChatInputContext);
   if (context === undefined) {
     throw new Error("useChatInput must be used within a ChatInputProvider");
   }
   return context;
-}
+};

--- a/apps/chat/providers/chat-models-provider.tsx
+++ b/apps/chat/providers/chat-models-provider.tsx
@@ -20,13 +20,13 @@ const ChatModelsContext = createContext<ChatModelsContextType | undefined>(
   undefined
 );
 
-export function ChatModelsProvider({
+export const ChatModelsProvider = ({
   children,
   models,
 }: {
   children: ReactNode;
   models: AppModelDefinition[];
-}) {
+}) => {
   const trpc = useTRPC();
   const { data: session } = useSession();
   const isAuthenticated = !!session?.user;
@@ -73,12 +73,12 @@ export function ChatModelsProvider({
       {children}
     </ChatModelsContext.Provider>
   );
-}
+};
 
-export function useChatModels() {
+export const useChatModels = () => {
   const context = useContext(ChatModelsContext);
   if (context === undefined) {
     throw new Error("useChatModels must be used within a ChatModelsProvider");
   }
   return context;
-}
+};

--- a/apps/chat/providers/default-model-provider.tsx
+++ b/apps/chat/providers/default-model-provider.tsx
@@ -26,10 +26,10 @@ interface DefaultModelClientProviderProps {
   defaultModel: AppModelId;
 }
 
-export function DefaultModelProvider({
+export const DefaultModelProvider = ({
   children,
   defaultModel: initialModel,
-}: DefaultModelClientProviderProps) {
+}: DefaultModelClientProviderProps) => {
   const [currentModel, setCurrentModel] = useState<AppModelId>(initialModel);
 
   const changeModel = useCallback(
@@ -69,9 +69,9 @@ export function DefaultModelProvider({
       {children}
     </DefaultModelContext.Provider>
   );
-}
+};
 
-export function useDefaultModel() {
+export const useDefaultModel = () => {
   const context = useContext(DefaultModelContext);
   if (context === undefined) {
     throw new Error(
@@ -79,9 +79,9 @@ export function useDefaultModel() {
     );
   }
   return context.defaultModel;
-}
+};
 
-export function useModelChange() {
+export const useModelChange = () => {
   const context = useContext(DefaultModelContext);
   if (context === undefined) {
     throw new Error(
@@ -89,4 +89,4 @@ export function useModelChange() {
     );
   }
   return context.changeModel;
-}
+};

--- a/apps/chat/providers/session-provider.tsx
+++ b/apps/chat/providers/session-provider.tsx
@@ -28,7 +28,11 @@ const SessionSeedContext = createContext<
   ((session: Session | null) => void) | null
 >(null);
 
-export function SessionProvider({ children }: { children: React.ReactNode }) {
+export const SessionProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
   const {
     data: clientSession,
     isPending: isClientPending,
@@ -73,9 +77,9 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
       </SessionContext.Provider>
     </SessionSeedContext.Provider>
   );
-}
+};
 
-export function SessionSeed({ session }: { session: Session | null }) {
+export const SessionSeed = ({ session }: { session: Session | null }) => {
   const setServerSession = useContext(SessionSeedContext);
 
   if (!setServerSession) {
@@ -87,12 +91,12 @@ export function SessionSeed({ session }: { session: Session | null }) {
   }, [session, setServerSession]);
 
   return null;
-}
+};
 
-export function useSession(): SessionContextValue {
+export const useSession = (): SessionContextValue => {
   const ctx = useContext(SessionContext);
   if (!ctx) {
     throw new Error("useSession must be used within a SessionProvider");
   }
   return ctx;
-}
+};

--- a/apps/chat/trpc/react.tsx
+++ b/apps/chat/trpc/react.tsx
@@ -18,7 +18,7 @@ export const { TRPCProvider, useTRPC, useTRPCClient } =
 
 let browserQueryClient: QueryClient | undefined;
 
-function getQueryClient() {
+const getQueryClient = () => {
   if (isServer) {
     // Server: always make a new query client
     return makeQueryClient();
@@ -31,9 +31,9 @@ function getQueryClient() {
     browserQueryClient = makeQueryClient();
   }
   return browserQueryClient;
-}
+};
 
-function getUrl() {
+const getUrl = () => {
   const base = (() => {
     if (typeof window !== "undefined") {
       return "";
@@ -41,8 +41,8 @@ function getUrl() {
     return getBaseUrl();
   })();
   return `${base}/api/trpc`;
-}
-export function TRPCReactProvider(props: { children: React.ReactNode }) {
+};
+export const TRPCReactProvider = (props: { children: React.ReactNode }) => {
   const queryClient = getQueryClient();
 
   const [trpcClient] = useState(() =>
@@ -74,4 +74,4 @@ export function TRPCReactProvider(props: { children: React.ReactNode }) {
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );
-}
+};

--- a/apps/chat/trpc/server.tsx
+++ b/apps/chat/trpc/server.tsx
@@ -18,18 +18,18 @@ export const trpc = createTRPCOptionsProxy({
   queryClient: getQueryClient,
 });
 
-export function HydrateClient(props: { children: React.ReactNode }) {
+export const HydrateClient = (props: { children: React.ReactNode }) => {
   const queryClient = getQueryClient();
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       {props.children}
     </HydrationBoundary>
   );
-}
+};
 
-export function prefetch<T extends ReturnType<TRPCQueryOptions<ResolverDef>>>(
+export const prefetch = <T extends ReturnType<TRPCQueryOptions<ResolverDef>>>(
   queryOptions: T
-) {
+) => {
   const queryClient = getQueryClient();
   if (queryOptions.queryKey[1]?.type === "infinite") {
     queryClient.prefetchInfiniteQuery(
@@ -40,4 +40,4 @@ export function prefetch<T extends ReturnType<TRPCQueryOptions<ResolverDef>>>(
   } else {
     queryClient.prefetchQuery(queryOptions);
   }
-}
+};


### PR DESCRIPTION
Convert 32 provider, runtime-wrapper, and tRPC helper declarations to arrow functions across nine files. Preserve component bodies, generic signatures, context types, effects, refs, memoization, and state behavior. Move the pure `createAppRuntimeStore` helper declaration above its caller and retain an explicit assertion-function signature for TypeScript narrowing.

Strict diagnostics in these files drop from 76 to 32 (44 fixed). This PR intentionally leaves the shared lint baseline unchanged; 19 resolved file/rule exemptions will be removed in the coordinated final baseline cleanup to avoid conflicts between parallel PRs.

Validation:
- `bun lint` and `bun test:types` pass.
- Chat unit suite: 47 files, 193 tests pass.
- Existing Playwright visual suite: 3 pass, no retries or snapshot updates.
- All 32 function bodies have identical emitted JavaScript/JSX ASTs; signatures are preserved, including the explicitly annotated assertion helper.
- Browser home-page screenshot inspected, React tree verified, Next MCP compilation/runtime errors empty.

## Summary by Sourcery

Enhancements:
- Standardize chat providers, runtime helpers, stores, hooks, and tRPC utilities on arrow-function declarations while preserving their existing behavior and TypeScript signatures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converts 32 function declarations to arrow functions in chat providers, runtime helpers, stores, hooks, and tRPC utilities without changing behavior. All component bodies, generic signatures, context types, effects, refs, memoization, and state are preserved. Strict diagnostics drop from 76 to 32.

**Refactors**
- Moves the pure `createAppRuntimeStore` helper above its caller and keeps an explicit assertion-function signature for TypeScript narrowing.
- Leaves the shared lint baseline unchanged; 19 resolved file/rule exemptions will be removed in a coordinated final cleanup.
- `bun lint`, `bun test:types`, and the chat unit suite (47 files, 193 tests) pass; Playwright visual suite passes with no retries or snapshot updates.

<sup>Written for commit a955c45489dff7a6a827c6f3cc8e31543777fb7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

