### PR TITLE
lint(chat): align component callback policy

### DIFF
--- a/apps/chat/components/artifact-actions.tsx
+++ b/apps/chat/components/artifact-actions.tsx
@@ -167,7 +167,7 @@ function TypedArtifactActions<M extends ArtifactMetadata>({
 }
 
 export const ArtifactActions = memo(
-  function ArtifactActions(props: ArtifactActionsProps) {
+  (props: ArtifactActionsProps) => {
     switch (props.artifact.kind) {
       case "code":
         return (
@@ -229,3 +229,5 @@ export const ArtifactActions = memo(
     return true;
   }
 );
+
+ArtifactActions.displayName = "ArtifactActions";

--- a/apps/chat/components/chat-composer.tsx
+++ b/apps/chat/components/chat-composer.tsx
@@ -21,10 +21,8 @@ import {
 } from "@/components/multimodal-input";
 
 /** The reference app's composer. Add, remove or reorder controls here. */
-export const ChatComposer = memo(function ChatComposer(
-  props: Omit<ComponentProps<typeof MultimodalInput>, "children">
-) {
-  return (
+export const ChatComposer = memo(
+  (props: Omit<ComponentProps<typeof MultimodalInput>, "children">) => (
     <MultimodalInput {...props}>
       <ComposerLimits />
       <ComposerAttachments />
@@ -42,5 +40,7 @@ export const ChatComposer = memo(function ChatComposer(
         </div>
       </PromptInputFooter>
     </MultimodalInput>
-  );
-});
+  )
+);
+
+ChatComposer.displayName = "ChatComposer";

--- a/apps/chat/components/chat-system.tsx
+++ b/apps/chat/components/chat-system.tsx
@@ -13,32 +13,32 @@ import { CustomStoreProvider } from "@/lib/stores/custom-store-provider";
 import type { CustomChatStoreApi } from "@/lib/stores/custom-store-provider";
 import { ChatInputProvider } from "@/providers/chat-input-provider";
 
-export const ChatSystem = memo(function PureChatSystem({
-  children,
-  id,
-  initialMessages,
-  initialTree,
-  isReadonly,
-  initialTool = null,
-  overrideModelId,
-  projectId,
-  runtimeKey,
-  store,
-  thread,
-}: {
-  children: ReactNode;
-  id: string;
-  initialMessages: ChatMessage[];
-  initialTree?: MessageTreeSnapshot<ChatMessage>;
-  isReadonly: boolean;
-  initialTool?: UiToolName | null;
-  overrideModelId?: AppModelId;
-  projectId?: string;
-  runtimeKey: string;
-  store?: CustomChatStoreApi<ChatMessage>;
-  thread?: ApplicationThread;
-}) {
-  return (
+export const ChatSystem = memo(
+  ({
+    children,
+    id,
+    initialMessages,
+    initialTree,
+    isReadonly,
+    initialTool = null,
+    overrideModelId,
+    projectId,
+    runtimeKey,
+    store,
+    thread,
+  }: {
+    children: ReactNode;
+    id: string;
+    initialMessages: ChatMessage[];
+    initialTree?: MessageTreeSnapshot<ChatMessage>;
+    isReadonly: boolean;
+    initialTool?: UiToolName | null;
+    overrideModelId?: AppModelId;
+    projectId?: string;
+    runtimeKey: string;
+    store?: CustomChatStoreApi<ChatMessage>;
+    thread?: ApplicationThread;
+  }) => (
     <ArtifactProvider key={runtimeKey}>
       <CustomStoreProvider
         initialMessages={initialMessages}
@@ -63,5 +63,7 @@ export const ChatSystem = memo(function PureChatSystem({
         )}
       </CustomStoreProvider>
     </ArtifactProvider>
-  );
-});
+  )
+);
+
+ChatSystem.displayName = "PureChatSystem";

--- a/apps/chat/components/header-breadcrumb.tsx
+++ b/apps/chat/components/header-breadcrumb.tsx
@@ -196,66 +196,70 @@ interface ChatBreadcrumbProps {
   startChatRename: () => void;
 }
 
-const PureChatBreadcrumb = memo(function InnerChatBreadcrumb({
-  canManageChat,
-  chatLabel,
-  chatTitleDraft,
-  handleChatInputKeyDown,
-  handleChatRename,
-  isChatEditing,
-  isPinned,
-  onChatTitleChange,
-  onShare,
-  onTogglePin,
-  openChatDeleteDialog,
-  showShare,
-  startChatRename: startChatRenameProp,
-}: ChatBreadcrumbProps) {
-  if (isChatEditing) {
-    return (
-      <Input
-        autoFocus
-        className="bg-background h-7 w-[220px] px-2 py-1 text-sm"
-        maxLength={255}
-        onBlur={handleChatRename}
-        onChange={(event) => onChatTitleChange(event.target.value)}
-        onKeyDown={handleChatInputKeyDown}
-        value={chatTitleDraft}
-      />
-    );
-  }
+const PureChatBreadcrumb = memo(
+  ({
+    canManageChat,
+    chatLabel,
+    chatTitleDraft,
+    handleChatInputKeyDown,
+    handleChatRename,
+    isChatEditing,
+    isPinned,
+    onChatTitleChange,
+    onShare,
+    onTogglePin,
+    openChatDeleteDialog,
+    showShare,
+    startChatRename: startChatRenameProp,
+  }: ChatBreadcrumbProps) => {
+    if (isChatEditing) {
+      return (
+        <Input
+          autoFocus
+          className="bg-background h-7 w-[220px] px-2 py-1 text-sm"
+          maxLength={255}
+          onBlur={handleChatRename}
+          onChange={(event) => onChatTitleChange(event.target.value)}
+          onKeyDown={handleChatInputKeyDown}
+          value={chatTitleDraft}
+        />
+      );
+    }
 
-  if (canManageChat) {
-    return (
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button
-            className="group text-foreground hover:bg-muted focus-visible:ring-ring flex min-w-0 items-center gap-1.5 rounded-md border border-transparent bg-transparent px-2 py-1 text-sm font-medium transition focus-visible:ring-1 focus-visible:outline-none"
-            type="button"
-          >
-            <span className="truncate">{chatLabel}</span>
-            <ChevronDown
-              aria-hidden
-              className="text-muted-foreground size-4 shrink-0"
+    if (canManageChat) {
+      return (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              className="group text-foreground hover:bg-muted focus-visible:ring-ring flex min-w-0 items-center gap-1.5 rounded-md border border-transparent bg-transparent px-2 py-1 text-sm font-medium transition focus-visible:ring-1 focus-visible:outline-none"
+              type="button"
+            >
+              <span className="truncate">{chatLabel}</span>
+              <ChevronDown
+                aria-hidden
+                className="text-muted-foreground size-4 shrink-0"
+              />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <ChatMenuItems
+              isPinned={isPinned}
+              onDelete={openChatDeleteDialog}
+              onRename={startChatRenameProp}
+              onShare={onShare}
+              onTogglePin={onTogglePin}
+              showShare={showShare}
             />
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <ChatMenuItems
-            isPinned={isPinned}
-            onDelete={openChatDeleteDialog}
-            onRename={startChatRenameProp}
-            onShare={onShare}
-            onTogglePin={onTogglePin}
-            showShare={showShare}
-          />
-        </DropdownMenuContent>
-      </DropdownMenu>
-    );
-  }
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+    }
 
-  return <BreadcrumbPage>{chatLabel}</BreadcrumbPage>;
-});
+    return <BreadcrumbPage>{chatLabel}</BreadcrumbPage>;
+  }
+);
+
+PureChatBreadcrumb.displayName = "InnerChatBreadcrumb";
 
 interface PerformChatRenameArgs {
   chatId: string;

--- a/apps/chat/components/search-chats-dialog.tsx
+++ b/apps/chat/components/search-chats-dialog.tsx
@@ -77,76 +77,81 @@ interface SearchChatsListProps {
   onSelectChat: (chatId: string) => void;
 }
 
-const SearchChatsList = memo(function SearchChatsListInner({
-  onSelectChat,
-  deferredQuery,
-}: SearchChatsListProps) {
-  const { data: chats, isLoading } = useGetAllChats();
+const SearchChatsList = memo(
+  ({ onSelectChat, deferredQuery }: SearchChatsListProps) => {
+    const { data: chats, isLoading } = useGetAllChats();
 
-  const groupedChats = useMemo(() => {
-    if (!chats) {
-      return null;
-    }
-    const filteredChats = filterChats(chats, deferredQuery);
-    return groupChatsByDate(filteredChats);
-  }, [chats, deferredQuery]);
+    const groupedChats = useMemo(() => {
+      if (!chats) {
+        return null;
+      }
+      const filteredChats = filterChats(chats, deferredQuery);
+      return groupChatsByDate(filteredChats);
+    }, [chats, deferredQuery]);
 
-  const renderChatGroup = (
-    groupChats: UIChat[],
-    groupName: string,
-    key: string
-  ) => {
-    if (groupChats.length === 0) {
-      return null;
-    }
+    const renderChatGroup = (
+      groupChats: UIChat[],
+      groupName: string,
+      key: string
+    ) => {
+      if (groupChats.length === 0) {
+        return null;
+      }
+
+      return (
+        <CommandGroup heading={groupName} key={key}>
+          {groupChats.map((chat) => (
+            <CommandItem
+              className="flex cursor-pointer items-center gap-2 p-2"
+              key={chat.id}
+              onSelect={() => onSelectChat(chat.id)}
+              value={chat.id}
+            >
+              <MessageSquare className="text-muted-foreground h-4 w-4" />
+              <div className="flex min-w-0 flex-1 flex-col">
+                <span className="truncate font-medium">{chat.title}</span>
+              </div>
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      );
+    };
+
+    const hasResults =
+      groupedChats &&
+      (groupedChats.today.length > 0 ||
+        groupedChats.yesterday.length > 0 ||
+        groupedChats.lastWeek.length > 0 ||
+        groupedChats.lastMonth.length > 0 ||
+        groupedChats.older.length > 0);
 
     return (
-      <CommandGroup heading={groupName} key={key}>
-        {groupChats.map((chat) => (
-          <CommandItem
-            className="flex cursor-pointer items-center gap-2 p-2"
-            key={chat.id}
-            onSelect={() => onSelectChat(chat.id)}
-            value={chat.id}
-          >
-            <MessageSquare className="text-muted-foreground h-4 w-4" />
-            <div className="flex min-w-0 flex-1 flex-col">
-              <span className="truncate font-medium">{chat.title}</span>
-            </div>
-          </CommandItem>
-        ))}
-      </CommandGroup>
+      <>
+        {!hasResults && (
+          <CommandEmpty>
+            {isLoading ? "Loading chats..." : "No chats found."}
+          </CommandEmpty>
+        )}
+
+        {groupedChats && (
+          <>
+            {renderChatGroup(groupedChats.today, "Today", "today")}
+            {renderChatGroup(groupedChats.yesterday, "Yesterday", "yesterday")}
+            {renderChatGroup(groupedChats.lastWeek, "Last 7 days", "lastWeek")}
+            {renderChatGroup(
+              groupedChats.lastMonth,
+              "Last 30 days",
+              "lastMonth"
+            )}
+            {renderChatGroup(groupedChats.older, "Older", "older")}
+          </>
+        )}
+      </>
     );
-  };
+  }
+);
 
-  const hasResults =
-    groupedChats &&
-    (groupedChats.today.length > 0 ||
-      groupedChats.yesterday.length > 0 ||
-      groupedChats.lastWeek.length > 0 ||
-      groupedChats.lastMonth.length > 0 ||
-      groupedChats.older.length > 0);
-
-  return (
-    <>
-      {!hasResults && (
-        <CommandEmpty>
-          {isLoading ? "Loading chats..." : "No chats found."}
-        </CommandEmpty>
-      )}
-
-      {groupedChats && (
-        <>
-          {renderChatGroup(groupedChats.today, "Today", "today")}
-          {renderChatGroup(groupedChats.yesterday, "Yesterday", "yesterday")}
-          {renderChatGroup(groupedChats.lastWeek, "Last 7 days", "lastWeek")}
-          {renderChatGroup(groupedChats.lastMonth, "Last 30 days", "lastMonth")}
-          {renderChatGroup(groupedChats.older, "Older", "older")}
-        </>
-      )}
-    </>
-  );
-});
+SearchChatsList.displayName = "SearchChatsListInner";
 
 interface SearchChatsDialogProps {
   onOpenChange: (open: boolean) => void;

--- a/apps/chat/components/settings/model-row.tsx
+++ b/apps/chat/components/settings/model-row.tsx
@@ -7,40 +7,44 @@ import { cn } from "@/lib/utils";
 import { ModelSelectorLogo } from "../model-selector-logo";
 import { Switch } from "../ui/switch";
 
-export const ModelRow = memo(function PureModelRow({
-  model,
-  isEnabled,
-  onToggle,
-}: {
-  model: { id: string; name: string; reasoning?: boolean };
-  isEnabled: boolean;
-  onToggle: (modelId: string, isEnabled: boolean) => void;
-}) {
-  const ReasoningIcon = AVAILABLE_FEATURES.reasoning.icon;
+export const ModelRow = memo(
+  ({
+    model,
+    isEnabled,
+    onToggle,
+  }: {
+    model: { id: string; name: string; reasoning?: boolean };
+    isEnabled: boolean;
+    onToggle: (modelId: string, isEnabled: boolean) => void;
+  }) => {
+    const ReasoningIcon = AVAILABLE_FEATURES.reasoning.icon;
 
-  return (
-    <TableRow>
-      <TableCell className="w-full py-2.5 pl-0">
-        <div className="flex items-center gap-2.5">
-          <ModelSelectorLogo modelId={model.id} />
-          <span className="text-sm font-medium">{model.name}</span>
-          {model.reasoning && (
-            <ReasoningIcon
-              aria-label={AVAILABLE_FEATURES.reasoning.description}
-              className={cn(
-                "text-muted-foreground size-3.5",
-                isEnabled && "text-foreground"
-              )}
-            />
-          )}
-        </div>
-      </TableCell>
-      <TableCell className="py-2.5 pr-0">
-        <Switch
-          checked={isEnabled}
-          onCheckedChange={() => onToggle(model.id, isEnabled)}
-        />
-      </TableCell>
-    </TableRow>
-  );
-});
+    return (
+      <TableRow>
+        <TableCell className="w-full py-2.5 pl-0">
+          <div className="flex items-center gap-2.5">
+            <ModelSelectorLogo modelId={model.id} />
+            <span className="text-sm font-medium">{model.name}</span>
+            {model.reasoning && (
+              <ReasoningIcon
+                aria-label={AVAILABLE_FEATURES.reasoning.description}
+                className={cn(
+                  "text-muted-foreground size-3.5",
+                  isEnabled && "text-foreground"
+                )}
+              />
+            )}
+          </div>
+        </TableCell>
+        <TableCell className="py-2.5 pr-0">
+          <Switch
+            checked={isEnabled}
+            onCheckedChange={() => onToggle(model.id, isEnabled)}
+          />
+        </TableCell>
+      </TableRow>
+    );
+  }
+);
+
+ModelRow.displayName = "PureModelRow";

--- a/apps/chat/oxlint.config.ts
+++ b/apps/chat/oxlint.config.ts
@@ -15,6 +15,14 @@ export default defineConfig({
     rules: Object.fromEntries(Object.keys(rules).map((rule) => [rule, "off"])),
   })),
   rules: {
+    // Keep anonymous React callbacks consistent with prefer-arrow-callback.
+    "react/function-component-definition": [
+      "error",
+      {
+        namedComponents: "arrow-function",
+        unnamedComponents: "arrow-function",
+      },
+    ],
     // The codebase uses interfaces alongside intersection and mapped types.
     "typescript/consistent-type-definitions": "off",
   },

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -15,6 +15,14 @@ export default defineConfig({
     rules: Object.fromEntries(Object.keys(rules).map((rule) => [rule, "off"])),
   })),
   rules: {
+    // Keep anonymous React callbacks consistent with prefer-arrow-callback.
+    "react/function-component-definition": [
+      "error",
+      {
+        namedComponents: "arrow-function",
+        unnamedComponents: "arrow-function",
+      },
+    ],
     // The codebase uses interfaces alongside intersection and mapped types.
     "typescript/consistent-type-definitions": "off",
   },


### PR DESCRIPTION
## Summary
- configure `react/function-component-definition` to require arrow functions for named and unnamed components, matching `prefer-arrow-callback`
- convert six existing named `memo` callback expressions to arrows
- preserve React DevTools names with explicit `displayName` assignments where callback names differed from exported values

## Validation
- `bun lint`
- `bun test:types`
- `bun test apps/chat/components/ai-elements/parse-incomplete-markdown.test.ts`
- existing visual suite: 3 passed (`ui-primitives`, `layout-primitives`, `model-toolbar`)
- AST body/parameter equivalence checks passed for all six conversions

## Summary by Sourcery

Align React component callback definitions with the project lint policy.

Enhancements:
- Standardize React component definitions on arrow functions across the chat application while preserving component names for React DevTools.

Chores:
- Apply the arrow-function component definition policy to the shared and chat-specific Oxlint configurations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns React component definitions in the chat app with the project's `prefer-arrow-callback` rule by requiring arrow functions for named and unnamed components in the root and `apps/chat` Oxlint configs. Converts six named `memo` callbacks to arrow functions and adds explicit `displayName` assignments where callback names differed from exported values, preserving React DevTools names.

<sup>Written for commit 81c40e0c19c27ca0c478eb1455aede32cd854ae7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

