### PR TITLE
chore(chat): normalize artifact helper declarations

### DIFF
--- a/apps/chat/lib/artifacts/code/client.tsx
+++ b/apps/chat/lib/artifacts/code/client.tsx
@@ -45,7 +45,7 @@ const OUTPUT_HANDLERS = {
   `,
 };
 
-function detectRequiredHandlers(code: string): string[] {
+const detectRequiredHandlers = (code: string): string[] => {
   const handlers: string[] = ["basic"];
 
   if (code.includes("matplotlib") || code.includes("plt.")) {
@@ -53,36 +53,32 @@ function detectRequiredHandlers(code: string): string[] {
   }
 
   return handlers;
-}
+};
 
 export interface CodeArtifactMetadata {
   language: string;
   outputs: ConsoleOutput[];
 }
 
-export function isCodeArtifactMetadata(
+export const isCodeArtifactMetadata = (
   metadata: ArtifactMetadata
-): metadata is CodeArtifactMetadata {
-  return (
-    metadata !== null &&
-    typeof metadata === "object" &&
-    "language" in metadata &&
-    typeof metadata.language === "string" &&
-    "outputs" in metadata &&
-    Array.isArray(metadata.outputs)
-  );
-}
+): metadata is CodeArtifactMetadata =>
+  metadata !== null &&
+  typeof metadata === "object" &&
+  "language" in metadata &&
+  typeof metadata.language === "string" &&
+  "outputs" in metadata &&
+  Array.isArray(metadata.outputs);
 
-export function getCodeArtifactMetadata(
+export const getCodeArtifactMetadata = (
   metadata: ArtifactMetadata
-): CodeArtifactMetadata {
-  return isCodeArtifactMetadata(metadata)
+): CodeArtifactMetadata =>
+  isCodeArtifactMetadata(metadata)
     ? metadata
     : {
         language: "python",
         outputs: [],
       };
-}
 
 export const codeArtifact = new Artifact<"code", CodeArtifactMetadata>({
   kind: "code",

--- a/apps/chat/lib/artifacts/sheet/client.tsx
+++ b/apps/chat/lib/artifacts/sheet/client.tsx
@@ -9,13 +9,12 @@ import { config } from "@/lib/config";
 
 export type SheetArtifactMetadata = Record<string, unknown>;
 
-export function getSheetArtifactMetadata(
+export const getSheetArtifactMetadata = (
   metadata: ArtifactMetadata
-): SheetArtifactMetadata {
-  return metadata && typeof metadata === "object"
+): SheetArtifactMetadata =>
+  metadata && typeof metadata === "object"
     ? Object.fromEntries(Object.entries(metadata))
     : {};
-}
 
 export const sheetArtifact = new Artifact<"sheet", SheetArtifactMetadata>({
   kind: "sheet",

--- a/apps/chat/lib/editor/config.ts
+++ b/apps/chat/lib/editor/config.ts
@@ -8,44 +8,40 @@ import { $getSelection, $insertNodes } from "lexical";
 import type { EditorState, LexicalEditor, TextNode } from "lexical";
 
 // Create initial editor configuration
-export function createEditorConfig() {
-  return {
-    namespace: "DocumentEditor",
-    nodes: [
-      HeadingNode,
-      ListNode,
-      ListItemNode,
-      QuoteNode,
-      CodeNode,
-      CodeHighlightNode,
-      LinkNode,
-    ],
-    onError: (error: Error) => {
-      console.error("Lexical error:", error);
-    },
-  };
-}
+export const createEditorConfig = () => ({
+  namespace: "DocumentEditor",
+  nodes: [
+    HeadingNode,
+    ListNode,
+    ListItemNode,
+    QuoteNode,
+    CodeNode,
+    CodeHighlightNode,
+    LinkNode,
+  ],
+  onError: (error: Error) => {
+    console.error("Lexical error:", error);
+  },
+});
 
 // Heading transform function equivalent to ProseMirror's headingRule
-function _createHeadingTransform(level: number) {
-  return {
-    dependencies: [],
-    export: null,
-    importDOM: null,
-    regExp: new RegExp(`^(#{1,${level}})\\s$`, "u"),
-    replace: (_textNode: TextNode) => {
-      const selection = $getSelection();
-      if (selection) {
-        const headingTag = `h${level}` as HeadingTagType;
-        const headingNode = $createHeadingNode(headingTag);
-        headingNode.append();
-        $insertNodes([headingNode]);
-      }
-    },
-    trigger: " ",
-    type: "text-match",
-  };
-}
+const _createHeadingTransform = (level: number) => ({
+  dependencies: [],
+  export: null,
+  importDOM: null,
+  regExp: new RegExp(`^(#{1,${level}})\\s$`, "u"),
+  replace: (_textNode: TextNode) => {
+    const selection = $getSelection();
+    if (selection) {
+      const headingTag = `h${level}` as HeadingTagType;
+      const headingNode = $createHeadingNode(headingTag);
+      headingNode.append();
+      $insertNodes([headingNode]);
+    }
+  },
+  trigger: " ",
+  type: "text-match",
+});
 
 export const handleEditorChange = ({
   editorState: _editorState,


### PR DESCRIPTION
Converts six safe declaration-style artifact/editor helpers to const arrows. Parameters and bodies are unchanged; return-only bodies use concise expressions.\n\nValidation:\n- bun lint\n- bun test:types\n- AST comparison against main for all six function parameter lists and bodies\n- PORT=3090 PLAYWRIGHT=True bunx playwright test tests/artifacts.e2e.ts --project=artifacts --workers=1