### PR TITLE
chore(chat): scope artifact and editor switch branches

### DIFF
--- a/apps/chat/components/artifact-actions.tsx
+++ b/apps/chat/components/artifact-actions.tsx
@@ -169,7 +169,7 @@ function TypedArtifactActions<M extends ArtifactMetadata>({
 export const ArtifactActions = memo(
   function ArtifactActions(props: ArtifactActionsProps) {
     switch (props.artifact.kind) {
-      case "code":
+      case "code": {
         return (
           <TypedArtifactActions
             {...props}
@@ -181,7 +181,8 @@ export const ArtifactActions = memo(
             )}
           />
         );
-      case "sheet":
+      }
+      case "sheet": {
         return (
           <TypedArtifactActions
             {...props}
@@ -193,7 +194,8 @@ export const ArtifactActions = memo(
             )}
           />
         );
-      case "text":
+      }
+      case "text": {
         return (
           <TypedArtifactActions
             {...props}
@@ -202,8 +204,10 @@ export const ArtifactActions = memo(
             setMetadata={props.setMetadata}
           />
         );
-      default:
+      }
+      default: {
         throw new Error("Artifact definition not found!");
+      }
     }
   },
   (prevProps, nextProps) => {

--- a/apps/chat/components/artifact-panel.tsx
+++ b/apps/chat/components/artifact-panel.tsx
@@ -238,7 +238,7 @@ function PureArtifactPanel({
   useEffect(() => {
     if (artifact.documentId !== "init" && artifact.status !== "streaming") {
       switch (artifact.kind) {
-        case "code":
+        case "code": {
           codeArtifact.initialize?.({
             documentId: artifact.documentId,
             setMetadata: createTypedMetadataSetter(
@@ -250,7 +250,8 @@ function PureArtifactPanel({
             isAuthenticated,
           });
           break;
-        case "sheet":
+        }
+        case "sheet": {
           sheetArtifact.initialize?.({
             documentId: artifact.documentId,
             setMetadata: createTypedMetadataSetter(
@@ -262,7 +263,8 @@ function PureArtifactPanel({
             isAuthenticated,
           });
           break;
-        case "text":
+        }
+        case "text": {
           textArtifact.initialize?.({
             documentId: artifact.documentId,
             setMetadata,
@@ -271,8 +273,10 @@ function PureArtifactPanel({
             isAuthenticated,
           });
           break;
-        default:
+        }
+        default: {
           break;
+        }
       }
     }
   }, [
@@ -311,7 +315,7 @@ function PureArtifactPanel({
 
   const renderArtifactContent = () => {
     switch (artifact.kind) {
-      case "code":
+      case "code": {
         return (
           <>
             <codeArtifact.content
@@ -334,7 +338,8 @@ function PureArtifactPanel({
             ) : null}
           </>
         );
-      case "sheet":
+      }
+      case "sheet": {
         return (
           <>
             <sheetArtifact.content
@@ -357,7 +362,8 @@ function PureArtifactPanel({
             ) : null}
           </>
         );
-      case "text":
+      }
+      case "text": {
         return (
           <>
             <textArtifact.content
@@ -374,8 +380,10 @@ function PureArtifactPanel({
             ) : null}
           </>
         );
-      default:
+      }
+      default: {
         return null;
+      }
     }
   };
 

--- a/apps/chat/components/code-editor.tsx
+++ b/apps/chat/components/code-editor.tsx
@@ -20,16 +20,21 @@ interface EditorProps {
 
 function getLanguageExtension(language: string) {
   switch (language) {
-    case "typescript":
+    case "typescript": {
       return javascript({ jsx: false, typescript: true });
-    case "javascript":
+    }
+    case "javascript": {
       return javascript({ jsx: false, typescript: false });
-    case "jsx":
+    }
+    case "jsx": {
       return javascript({ jsx: true, typescript: false });
-    case "tsx":
+    }
+    case "tsx": {
       return javascript({ jsx: true, typescript: true });
-    default:
+    }
+    default: {
       return python();
+    }
   }
 }
 

--- a/apps/chat/components/data-stream-handler.tsx
+++ b/apps/chat/components/data-stream-handler.tsx
@@ -69,7 +69,7 @@ function processArtifactStreamPart({
   setMetadata: ReturnType<typeof useArtifact>["setMetadata"];
 }): void {
   switch (artifact.kind) {
-    case "code":
+    case "code": {
       codeArtifact.onStreamPart?.({
         streamPart: delta,
         setArtifact,
@@ -79,7 +79,8 @@ function processArtifactStreamPart({
         ),
       });
       break;
-    case "sheet":
+    }
+    case "sheet": {
       sheetArtifact.onStreamPart?.({
         streamPart: delta,
         setArtifact,
@@ -89,15 +90,18 @@ function processArtifactStreamPart({
         ),
       });
       break;
-    case "text":
+    }
+    case "text": {
       textArtifact.onStreamPart?.({
         streamPart: delta,
         setArtifact,
         setMetadata,
       });
       break;
-    default:
+    }
+    default: {
       break;
+    }
   }
 }
 

--- a/apps/chat/components/diffview.tsx
+++ b/apps/chat/components/diffview.tsx
@@ -72,16 +72,19 @@ class DiffTextNode extends TextNode {
     if (diffType) {
       let className = "";
       switch (diffType) {
-        case DiffType.Inserted:
+        case DiffType.Inserted: {
           className =
             "bg-green-100 text-green-700 dark:bg-green-500/70 dark:text-green-300";
           break;
-        case DiffType.Deleted:
+        }
+        case DiffType.Deleted: {
           className =
             "bg-red-100 line-through text-red-600 dark:bg-red-500/70 dark:text-red-300";
           break;
-        default:
+        }
+        default: {
           className = "";
+        }
       }
       element.className = className;
     }

--- a/apps/chat/components/part/document-common.tsx
+++ b/apps/chat/components/part/document-common.tsx
@@ -40,12 +40,15 @@ const getActionText = (
   tense: "present" | "past"
 ) => {
   switch (type) {
-    case "create":
+    case "create": {
       return tense === "present" ? "Creating" : "Created";
-    case "update":
+    }
+    case "update": {
       return tense === "present" ? "Updating" : "Updated";
-    default:
+    }
+    default: {
       return null;
+    }
   }
 };
 

--- a/apps/chat/components/part/document-preview.tsx
+++ b/apps/chat/components/part/document-preview.tsx
@@ -240,12 +240,15 @@ const getActionText = (
   tense: "present" | "past"
 ) => {
   switch (type) {
-    case "create":
+    case "create": {
       return tense === "present" ? "Creating" : "Created";
-    case "update":
+    }
+    case "update": {
       return tense === "present" ? "Updating" : "Updated";
-    default:
+    }
+    default: {
       return "";
+    }
   }
 };
 


### PR DESCRIPTION
Add explicit blocks to 30 switch branches in artifact rendering, stream handling, editor language selection, and document previews. Branch statements, return values, breaks, fallthrough behavior, and JSX are unchanged; none of these branches declares a local binding.

Validation: `bun lint`, `bun test:types`, 193 unit tests, and all three existing Playwright visual tests passed. AST comparison confirms the seven files are identical after unwrapping the added case blocks. The focused rule audit reports zero violations. The home screen was inspected in a browser and Next.js reported no compilation or runtime errors. The initial local visual run used a server without Playwright mode and redirected fixtures to login; rerunning with the repository's test environment passed without snapshot updates.

Baseline exemption pruning is deferred to a dedicated follow-up after parallel source PRs merge, avoiding shared baseline conflicts.

## Summary by Sourcery

Enhancements:
- Scope artifact rendering, stream handling, editor language selection, diff styling, and document preview switch branches with explicit blocks without changing behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes all 30 switch branches across artifact rendering, stream handling, editor language selection, and document previews in explicit `case` blocks. No behavior changes: branch logic, return values, breaks, fallthrough, and JSX stay identical, and no branch declares a local binding.

**Validation**
- `bun lint`, `bun test:types`, 193 unit tests, and all three Playwright visual tests pass.
- AST comparison confirms the seven files are identical after unwrapping the added case blocks.
- Baseline exemption pruning is deferred to a follow-up to avoid conflicts with parallel source PRs.

<sup>Written for commit 4dd0a126007d905ade5c8f98d1f33432325d703e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

