### PR TITLE
chore(chat): normalize hook helper declarations

### DIFF
--- a/apps/chat/components/chat/use-chat-votes.ts
+++ b/apps/chat/components/chat/use-chat-votes.ts
@@ -8,10 +8,10 @@ import { useIsChatPersisted } from "@/lib/stores/hooks-chat-persistence";
 import { useSession } from "@/providers/session-provider";
 import { useTRPC } from "@/trpc/react";
 
-export function useChatVotes(
+export const useChatVotes = (
   chatId: string,
   { isReadonly }: { isReadonly: boolean }
-) {
+) => {
   const trpc = useTRPC();
   const { data: session } = useSession();
   const isLoading = chatId !== useChatId();
@@ -27,4 +27,4 @@ export function useChatVotes(
       !!session?.user &&
       !isLoading,
   });
-}
+};

--- a/apps/chat/hooks/use-artifact.tsx
+++ b/apps/chat/hooks/use-artifact.tsx
@@ -45,7 +45,7 @@ const ArtifactContext = createContext<ArtifactContextType | undefined>(
   undefined
 );
 
-export function ArtifactProvider({ children }: { children: ReactNode }) {
+export const ArtifactProvider = ({ children }: { children: ReactNode }) => {
   const [artifact, setArtifactState] =
     useState<UIArtifact>(initialArtifactData);
   const [metadataStore, setMetadataStore] = useState<MetadataStore>({});
@@ -90,25 +90,27 @@ export function ArtifactProvider({ children }: { children: ReactNode }) {
       {children}
     </ArtifactContext.Provider>
   );
-}
+};
 
-function useArtifactContext() {
+const useArtifactContext = () => {
   const context = useContext(ArtifactContext);
   if (!context) {
     throw new Error("Artifact hooks must be used within ArtifactProvider");
   }
   return context;
-}
+};
 
-export function useArtifactSelector<Selected>(selector: Selector<Selected>) {
+export const useArtifactSelector = <Selected,>(
+  selector: Selector<Selected>
+) => {
   const { artifact } = useArtifactContext();
 
   const selectedValue = useMemo(() => selector(artifact), [artifact, selector]);
 
   return selectedValue;
-}
+};
 
-export function useArtifact() {
+export const useArtifact = () => {
   const {
     artifact,
     setArtifact,
@@ -157,4 +159,4 @@ export function useArtifact() {
     }),
     [artifact, setArtifact, metadata, setMetadata, resetArtifact, closeArtifact]
   );
-}
+};

--- a/apps/chat/lib/url-utils.tsx
+++ b/apps/chat/lib/url-utils.tsx
@@ -1,12 +1,10 @@
-export function getDomainFromUrl(url: string) {
-  return new URL(url).hostname.replace("www.", "");
-}
-export function getFaviconUrl(result: {
+export const getDomainFromUrl = (url: string) =>
+  new URL(url).hostname.replace("www.", "");
+export const getFaviconUrl = (result: {
   title: string;
   source: "web" | "academic" | "x";
   url: string;
   content: string;
   tweetId?: string | undefined;
-}) {
-  return `https://www.google.com/s2/favicons?domain=${new URL(result.url).hostname}&sz=128`;
-}
+}) =>
+  `https://www.google.com/s2/favicons?domain=${new URL(result.url).hostname}&sz=128`;


### PR DESCRIPTION
Converts seven safe helper declarations to const arrows and normalizes the artifact provider component declaration. The generic hook signature is retained; no hook dependencies, state behavior, or object-key ordering changes.\n\nValidation:\n- bun lint\n- bun test:types\n- AST comparison against main for all seven function parameter lists, generic parameters, and bodies\n- PORT=3090 PLAYWRIGHT=True bunx playwright test tests/artifacts.e2e.ts tests/model-toolbar.visual.e2e.ts --project=artifacts --project=visual --workers=1

## Summary by Sourcery

Enhancements:
- Normalize chat hooks, the artifact provider, and URL utilities to use const arrow declarations without changing their behavior or signatures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converts seven hook and URL utility declarations to const arrow functions, and aligns the `ArtifactProvider` component to the same style. No behavior, hook dependencies, or signatures change.

<sup>Written for commit 988b697da17039c6f9b19b5f72b0ca87d5f9ed0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

