### PR TITLE
refactor(chat): clean store helper functions

### DIFF
--- a/apps/chat/lib/stores/base/hooks.ts
+++ b/apps/chat/lib/stores/base/hooks.ts
@@ -348,8 +348,9 @@ export const createChatStoreCreator = <TMessage extends UIMessage>(
 
           currentState._messageIndex.update(messages);
           set({
-            _memoizedSelectors: new Map(), // Clear memoized selectors
             messages,
+            // Clear memoized selectors
+            _memoizedSelectors: new Map(),
           });
 
           // During streaming, update immediately for smooth text rendering

--- a/apps/chat/lib/stores/base/hooks.ts
+++ b/apps/chat/lib/stores/base/hooks.ts
@@ -279,9 +279,9 @@ export interface StoreState<TMessage extends UIMessage = UIMessage> {
 // ~60fps for smooth streaming
 const MESSAGES_THROTTLE_MS = 16;
 
-export function createChatStoreCreator<TMessage extends UIMessage>(
+export const createChatStoreCreator = <TMessage extends UIMessage>(
   initialMessages: TMessage[] = []
-): StateCreator<StoreState<TMessage>, [], []> {
+): StateCreator<StoreState<TMessage>, [], []> => {
   let throttledMessagesUpdater: (() => void) | null = null;
   const messageIndex = new MessageIndex<TMessage>();
   const throttledEffects = new Set<() => void>();
@@ -348,9 +348,8 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
 
           currentState._messageIndex.update(messages);
           set({
+            _memoizedSelectors: new Map(), // Clear memoized selectors
             messages,
-            // Clear memoized selectors
-            _memoizedSelectors: new Map(),
           });
 
           // During streaming, update immediately for smooth text rendering
@@ -386,11 +385,11 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
         batchUpdates(() => {
           get()._messageIndex.update(messages);
           set({
-            messages,
-            status: "ready",
+            _memoizedSelectors: new Map(),
             error: undefined,
             id,
-            _memoizedSelectors: new Map(),
+            messages,
+            status: "ready",
           });
           throttledMessagesUpdater?.();
         });
@@ -404,8 +403,8 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
             const messages = [...state.messages, message];
             state._messageIndex.update(messages);
             return {
-              messages,
               _memoizedSelectors: new Map(),
+              messages,
             };
           });
 
@@ -434,8 +433,8 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
             const messages = state.messages.slice(0, -1);
             state._messageIndex.update(messages);
             return {
-              messages,
               _memoizedSelectors: new Map(),
+              messages,
             };
           });
           throttledMessagesUpdater?.();
@@ -451,8 +450,8 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
             newMessages[index] = structuredClone(message);
             state._messageIndex.update(newMessages);
             return {
-              messages: newMessages,
               _memoizedSelectors: new Map(),
+              messages: newMessages,
             };
           });
 
@@ -488,8 +487,8 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
             newMessages[index] = structuredClone(message);
             state._messageIndex.update(newMessages);
             return {
-              messages: newMessages,
               _memoizedSelectors: new Map(),
+              messages: newMessages,
             };
           });
 
@@ -539,14 +538,14 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
           }
 
           set({
+            _memoizedSelectors: new Map(),
+            _messageIndex: newMessageIndex,
+            _throttledMessages: [],
+            _transientDataParts: new Map(),
+            error: undefined,
             id: undefined,
             messages: [],
             status: "ready" as const,
-            error: undefined,
-            _throttledMessages: [],
-            _messageIndex: newMessageIndex,
-            _memoizedSelectors: new Map(),
-            _transientDataParts: new Map(),
           });
         });
       },
@@ -614,7 +613,7 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
         }
 
         const result = selector();
-        state._memoizedSelectors.set(key, { result, deps: [...deps] });
+        state._memoizedSelectors.set(key, { deps: [...deps], result });
         return result;
       },
 
@@ -660,18 +659,17 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
       },
     };
   };
-}
+};
 
-export function createChatStore<TMessage extends UIMessage = UIMessage>(
+export const createChatStore = <TMessage extends UIMessage = UIMessage>(
   initialMessages: TMessage[] = []
-) {
-  return createStore<StoreState<TMessage>>()(
+) =>
+  createStore<StoreState<TMessage>>()(
     devtools(
       subscribeWithSelector(createChatStoreCreator<TMessage>(initialMessages)),
       { name: "chat-store" }
     )
   );
-}
 
 type ChatStoreApi<TMessage extends UIMessage = UIMessage> = ReturnType<
   typeof createChatStore<TMessage>
@@ -707,7 +705,7 @@ type CompatibleChatStoreApi<TMessage extends UIMessage = UIMessage> = Omit<
   ): void;
 };
 
-export function Provider<TMessage extends UIMessage = UIMessage>({
+export const Provider = <TMessage extends UIMessage = UIMessage>({
   children,
   initialMessages,
   store,
@@ -715,7 +713,7 @@ export function Provider<TMessage extends UIMessage = UIMessage>({
   children: React.ReactNode;
   initialMessages?: TMessage[];
   store?: CompatibleChatStoreApi<TMessage>;
-}) {
+}) => {
   const storeRef = useRef<CompatibleChatStoreApi<TMessage> | null>(null);
 
   if (storeRef.current === null) {
@@ -728,7 +726,7 @@ export function Provider<TMessage extends UIMessage = UIMessage>({
     { value: storeRef.current },
     children
   );
-}
+};
 
 // Standard Zustand v5 store hook
 export function useChatStore<T, TMessage extends UIMessage = UIMessage>(
@@ -753,13 +751,13 @@ export function useChatStore<
   return useStore(store, selectorOrIdentity as (state: any) => T);
 }
 
-export function useChatStoreApi<TMessage extends UIMessage = UIMessage>() {
+export const useChatStoreApi = <TMessage extends UIMessage = UIMessage>() => {
   const store = useContext(ChatStoreContext);
   if (!store) {
     throw new Error("useChatStoreApi must be used within Provider");
   }
   return store as ChatStoreApi<TMessage>;
-}
+};
 
 // Optimized selector hooks with memoization
 export const useChatMessages = <TMessage extends UIMessage = UIMessage>() =>
@@ -785,27 +783,25 @@ export const useMessageIds = <TMessage extends UIMessage = UIMessage>() =>
 // Optimized message selector with O(1) lookup
 export const useMessageById = <TMessage extends UIMessage = UIMessage>(
   messageId: string
-) => {
-  return useChatStore(
+) =>
+  useChatStore(
     useCallback(
       (state: StoreState<TMessage>) => state.getMessageById(messageId),
       [messageId]
     )
   );
-};
 
 // Virtualization helper for large message lists
 export const useVirtualMessages = <TMessage extends UIMessage = UIMessage>(
   start: number,
   end?: number
-) => {
-  return useChatStore(
+) =>
+  useChatStore(
     useCallback(
       (state: StoreState<TMessage>) => state.getMessagesSlice(start, end),
       [start, end]
     )
   );
-};
 
 export const useMessageCount = () => useChatStore(messageCountSelector);
 
@@ -863,13 +859,13 @@ export const useChatActions = <
 >(): ChatActions<TMessage> =>
   useChatStore(
     useShallow((state: StoreState<TMessage>) => ({
-      sendMessage: state.sendMessage || fallbackSendMessage,
-      startRun: state.startRun || fallbackStartRun,
-      regenerate: state.regenerate || fallbackRegenerate,
-      stop: state.stop || fallbackStop,
-      resumeStream: state.resumeStream || fallbackResumeStream,
       addToolResult: state.addToolResult || fallbackAddToolResult,
       clearError: state.clearError || fallbackClearError,
+      regenerate: state.regenerate || fallbackRegenerate,
+      resumeStream: state.resumeStream || fallbackResumeStream,
+      sendMessage: state.sendMessage || fallbackSendMessage,
+      startRun: state.startRun || fallbackStartRun,
+      stop: state.stop || fallbackStop,
     }))
   );
 
@@ -878,8 +874,8 @@ export const useSelector = <TMessage extends UIMessage = UIMessage, T = any>(
   key: string,
   selector: (messages: TMessage[]) => T,
   deps: any[] = []
-) => {
-  return useChatStore(
+) =>
+  useChatStore(
     useCallback(
       (state: StoreState<TMessage>) =>
         state.getMemoizedSelector(
@@ -890,4 +886,3 @@ export const useSelector = <TMessage extends UIMessage = UIMessage, T = any>(
       [key, selector, ...deps]
     )
   );
-};

--- a/apps/chat/lib/stores/with-message-parts.ts
+++ b/apps/chat/lib/stores/with-message-parts.ts
@@ -10,11 +10,13 @@ import type { StoreState as BaseChatStoreState } from "@/lib/stores/base";
 // Helper types to safely derive the message part and part.type types from UI_MESSAGE
 type UIMessageParts<UI_MSG> = UI_MSG extends { parts: infer P } ? P : never;
 type UIMessagePart<UI_MSG> =
-  UIMessageParts<UI_MSG> extends Array<infer I> ? I : never;
+  UIMessageParts<UI_MSG> extends (infer I)[] ? I : never;
 type UIMessagePartType<UI_MSG> =
   UIMessagePart<UI_MSG> extends { type: infer T } ? T : never;
 
-function extractPartTypes<UI_MESSAGE extends UIMessage>(
+const extractPartTypes = function extractPartTypes<
+  UI_MESSAGE extends UIMessage,
+>(
   message: UI_MESSAGE
 ): {
   partsRef: UIMessageParts<UI_MESSAGE>;
@@ -31,7 +33,7 @@ function extractPartTypes<UI_MESSAGE extends UIMessage>(
       ).type
   ) as UIMessagePartType<UI_MESSAGE>[];
   return { partsRef, types };
-}
+};
 
 export type PartsAugmentedState<UM extends UIMessage> =
   BaseChatStoreState<UM> & {
@@ -57,6 +59,22 @@ export const withMessageParts =
     return {
       ...base,
 
+      getMessagePartByIdx: (messageId: string, partIdx: number) => {
+        const state = get();
+        const message = (state._throttledMessages || state.messages).find(
+          (msg) => msg.id === messageId
+        ) as unknown as { parts: unknown[] } | undefined;
+        if (!message) {
+          throw new Error(`Message not found for id: ${messageId}`);
+        }
+        const selected = message.parts[partIdx];
+        if (selected === undefined) {
+          throw new Error(
+            `Part not found for id: ${messageId} at partIdx: ${partIdx}`
+          );
+        }
+        return selected as UIMessageParts<UI_MESSAGE>[number];
+      },
       getMessagePartTypesById: (messageId: string) => {
         const state = get();
         const message = (state._throttledMessages || state.messages).find(
@@ -77,7 +95,7 @@ export const withMessageParts =
         const state = get();
         const message = (state._throttledMessages || state.messages).find(
           (msg) => msg.id === messageId
-        ) as unknown as { parts: Array<{ type: string }> } | undefined;
+        ) as unknown as { parts: { type: string }[] } | undefined;
         if (!message) {
           throw new Error(`Message not found for id: ${messageId}`);
         }
@@ -96,22 +114,6 @@ export const withMessageParts =
               ) as unknown as UIMessageParts<UI_MESSAGE>)
         ) as UIMessageParts<UI_MESSAGE>;
         return result as UIMessageParts<UI_MESSAGE>;
-      },
-      getMessagePartByIdx: (messageId: string, partIdx: number) => {
-        const state = get();
-        const message = (state._throttledMessages || state.messages).find(
-          (msg) => msg.id === messageId
-        ) as unknown as { parts: unknown[] } | undefined;
-        if (!message) {
-          throw new Error(`Message not found for id: ${messageId}`);
-        }
-        const selected = message.parts[partIdx];
-        if (selected === undefined) {
-          throw new Error(
-            `Part not found for id: ${messageId} at partIdx: ${partIdx}`
-          );
-        }
-        return selected as UIMessageParts<UI_MESSAGE>[number];
       },
     };
   };

--- a/apps/chat/lib/stores/with-thread-state.ts
+++ b/apps/chat/lib/stores/with-thread-state.ts
@@ -15,10 +15,10 @@ export type ThreadStateStore<TMessage extends UIMessage> =
     ) => void;
   };
 
-function haveSelectedPathIdsChanged<TMessage extends { id: string }>(
+const haveSelectedPathIdsChanged = <TMessage extends { id: string }>(
   previous: TMessage[] | null | undefined,
   next: TMessage[]
-): boolean {
+): boolean => {
   const previousMessages = previous ?? [];
   if (previousMessages.length !== next.length) {
     return true;
@@ -26,7 +26,7 @@ function haveSelectedPathIdsChanged<TMessage extends { id: string }>(
   return previousMessages.some(
     (message, index) => message.id !== next[index]?.id
   );
-}
+};
 
 export const withThreadState =
   <TMessage extends UIMessage, TState extends BaseChatStoreState<TMessage>>(

--- a/apps/chat/lib/stores/with-tracing.ts
+++ b/apps/chat/lib/stores/with-tracing.ts
@@ -4,7 +4,7 @@ import type { StateCreator } from "zustand";
 
 type AnyFn = (...args: unknown[]) => unknown;
 
-function safeStringifyArgs(args: unknown[]) {
+const safeStringifyArgs = (args: unknown[]) => {
   try {
     return args.map((a) => {
       if (typeof a === "string") {
@@ -12,10 +12,10 @@ function safeStringifyArgs(args: unknown[]) {
       }
       return JSON.stringify(a);
     });
-  } catch (_err) {
+  } catch {
     return ["<unstringifiable args>"];
   }
-}
+};
 
 /**
  * Middleware that wraps all function fields on the store state and logs a stack
@@ -58,7 +58,7 @@ export const withTracing =
 
         try {
           groupCollapsed?.(header);
-          const stack = new Error("stack").stack;
+          const { stack } = new Error("stack");
           if (stack) {
             // Avoid printing "Error: ..." so it doesn't look like an exception in the console.
             const lines = stack.split("\n");


### PR DESCRIPTION
## Summary
- convert remaining safe store helper and provider declarations to equivalent function expressions/arrows
- preserve the overloaded `useChatStore` declarations and Zustand store variance
- simplify safe arrow bodies and array syntax, and remove an unused catch binding
- sort only plain store records with pure values; preserve action callbacks and scheduler logic

## Validation
- `bun lint`
- `bun test:types`
- store tests: 11 passed across `with-data-stream`, `zustand-thread-state`, and `with-chat-persistence`
- strict audit of four changed files: all targeted function-style, arrow-body, array-type, unused-variable, destructuring, and sort-key diagnostics resolved except the mixed state initializer record sort diagnostic, left unchanged to preserve the action/state layout

## Summary by Sourcery

Refactor chat store helpers and related utilities for consistent syntax and cleaner types without changing behavior.

Enhancements:
- Standardize chat store helpers, providers, and hooks on consistent arrow or function-expression syntax while preserving store APIs and behavior.
- Simplify type annotations and expressions across chat store utilities, including array types, destructuring, and unused catch bindings.
- Normalize key ordering in plain store records without changing mixed state and action layouts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes chat store helpers, providers, and hooks on consistent arrow/function-expression syntax and cleans up type annotations. No behavior changes.

**Refactors**
- Converts remaining function declarations to `const` arrows/function expressions, preserving the overloaded `useChatStore` and its surrounding comment contract.
- Replaces `Array<X>` with `X[]` and removes an unused catch binding.
- Sorts keys in plain store records and leaves mixed state/action initializer layouts untouched.

<sup>Written for commit 91664636be2a6545724e628afb3fefc45107e0c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

