### PR TITLE
chore: clean transport and command helper syntax

### DIFF
--- a/apps/chat/lib/auth.ts
+++ b/apps/chat/lib/auth.ts
@@ -45,7 +45,8 @@ export const auth = betterAuth({
   session: {
     cookieCache: {
       enabled: true,
-      maxAge: 60 * 5, // 5 minutes - reduces database queries for session validation
+      // 5 minutes - reduces database queries for session validation
+      maxAge: 60 * 5,
     },
   },
 

--- a/apps/chat/lib/cancellation-aware-chat-transport.ts
+++ b/apps/chat/lib/cancellation-aware-chat-transport.ts
@@ -97,11 +97,15 @@ const observeCancellation = ({
   target: GenerationCancellationTarget;
 }) => {
   if (!signal || signal.aborted) {
-    return () => undefined;
+    return () => {
+      // No listener was registered, so cleanup has no work.
+    };
   }
 
   const cancel = () => {
-    onCancel(target).catch(() => undefined);
+    onCancel(target).catch(() => {
+      // Cancellation is best effort; transport termination still proceeds.
+    });
   };
   signal.addEventListener("abort", cancel, { once: true });
 

--- a/apps/chat/lib/files/upload-prep.ts
+++ b/apps/chat/lib/files/upload-prep.ts
@@ -85,7 +85,7 @@ export const processFilesForUpload = async (
   const pdfFiles: File[] = [];
   const stillOversized: File[] = [];
   const unsupportedFiles: File[] = [];
-  const maxBytes = options.maxBytes;
+  const { maxBytes } = options;
 
   for (const file of files) {
     if (file.type.startsWith("image/")) {

--- a/apps/chat/lib/gated-chat-transport.ts
+++ b/apps/chat/lib/gated-chat-transport.ts
@@ -14,7 +14,9 @@ const waitForGate = (ready: Promise<void>, signal?: AbortSignal) => {
     return ready;
   }
   if (signal.aborted) {
-    ready.catch(() => undefined);
+    ready.catch(() => {
+      // Observe a rejected gate after cancellation without changing the abort error.
+    });
     return Promise.reject(createAbortError());
   }
 

--- a/apps/chat/lib/message-conversion.ts
+++ b/apps/chat/lib/message-conversion.ts
@@ -46,7 +46,7 @@ export const chatMessageToDbMessage = (
   chatId: string
 ): DBMessage => {
   const parentMessageId = message.metadata.parentMessageId || null;
-  const selectedModel = message.metadata.selectedModel;
+  const { selectedModel } = message.metadata;
 
   // Ensure createdAt is a Date object
   let createdAt: Date;

--- a/apps/chat/lib/start-provisional-chat.ts
+++ b/apps/chat/lib/start-provisional-chat.ts
@@ -71,7 +71,7 @@ export const useStartProvisionalChat = (chatId: string) => {
 
       const primaryRequest = requestSpecs[0] ?? null;
       const storeState = storeApi.getState();
-      const startRun = storeState.startRun;
+      const { startRun } = storeState;
 
       if (!startRun) {
         return false;

--- a/packages/cli/src/utils/run-command.ts
+++ b/packages/cli/src/utils/run-command.ts
@@ -1,22 +1,22 @@
 import { spawn } from "node:child_process";
 
-export async function runCommand(
+export const runCommand = async (
   command: string,
   args: string[],
   cwd: string
-): Promise<void> {
-  await new Promise<void>((resolvePromise, rejectPromise) => {
+): Promise<void> => {
+  await new Promise<void>((resolve, reject) => {
     const child = spawn(command, args, { cwd, stdio: "pipe" });
     const stderr: string[] = [];
     child.stderr?.on("data", (data) => {
       stderr.push(String(data));
     });
-    child.on("error", rejectPromise);
+    child.on("error", reject);
     child.on("close", (code) => {
       if (code === 0) {
-        resolvePromise();
+        resolve();
       } else {
-        rejectPromise(
+        reject(
           new Error(
             `${command} exited with code ${code}\n${stderr.join("")}`.trim()
           )
@@ -24,4 +24,4 @@ export async function runCommand(
       }
     });
   });
-}
+};

--- a/packages/thread/src/abstract-thread.ts
+++ b/packages/thread/src/abstract-thread.ts
@@ -802,7 +802,9 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
     this.publish();
     const finished = start(chat).finally(() => this.publish());
     // startRun may be detached; observing the rejection keeps finished awaitable.
-    void finished.catch(() => undefined);
+    void finished.catch(() => {
+      // The original finished promise retains the rejection for callers.
+    });
     record.finished = finished;
     return this.createRunHandle(record);
   }


### PR DESCRIPTION
Clear 11 straightforward lint findings across transport cleanup, message/upload helpers, authentication configuration, and the CLI command runner. Promise rejection observers and cleanup callbacks keep their existing no-op behavior with explicit rationale; property reads use destructuring, and the CLI helper uses an arrow declaration with conventional promise parameter names.

Validation: `bun lint`, `bun test:types`, 193 chat unit tests, 68 thread tests, and 74 CLI tests pass. A focused audit of the five affected rules reports zero violations in the eight changed files. No new behavior or UI state is introduced.

Baseline pruning remains deferred to the final independent cleanup PR after parallel source branches merge.

## Summary by Sourcery

Enhancements:
- Clean up lint findings across authentication, transport cancellation, upload preparation, message conversion, provisional chat startup, thread execution, and CLI command handling without changing behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves 11 lint findings across transport, message/upload helpers, auth configuration, and the CLI command runner. No behavior changes: rejection observers and cleanup callbacks keep their no-op behavior, property reads use destructuring, and the CLI helper uses conventional promise parameter names.

**Validation**
- `bun lint`, `bun test:types`, 193 chat unit tests, 68 thread tests, and 74 CLI tests pass.
- A focused audit of the five affected rules reports zero violations in the eight changed files.

**Notes**
- Baseline pruning stays deferred to the final cleanup PR after parallel source branches merge.

<sup>Written for commit 0fad78a69eda149fe35c772a861551e72da7f3ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

