### PR TITLE
chore(chat): sort safe artifact records

### DIFF
--- a/apps/chat/lib/artifacts/code/client.tsx
+++ b/apps/chat/lib/artifacts/code/client.tsx
@@ -10,6 +10,9 @@ import { config } from "@/lib/config";
 import { generateUUID, getLanguageFromFileName } from "@/lib/utils";
 
 const OUTPUT_HANDLERS = {
+  basic: `
+    # Basic output capture setup
+  `,
   matplotlib: `
     import io
     import base64
@@ -39,9 +42,6 @@ const OUTPUT_HANDLERS = {
             plt.close('all')
 
         plt.show = custom_show
-  `,
-  basic: `
-    # Basic output capture setup
   `,
 };
 
@@ -90,8 +90,8 @@ export const codeArtifact = new Artifact<"code", CodeArtifactMetadata>({
     "Useful for code generation; Code execution is only available for Python code.",
   initialize: ({ setMetadata }) => {
     setMetadata({
-      outputs: [],
       language: "python",
+      outputs: [],
     });
   },
   content: ({ isReadonly, content, title, ...props }) => {
@@ -138,8 +138,8 @@ export const codeArtifact = new Artifact<"code", CodeArtifactMetadata>({
           outputs: [
             ...metadata.outputs,
             {
-              id: runId,
               contents: [],
+              id: runId,
               status: "in_progress",
             },
           ],
@@ -170,8 +170,8 @@ export const codeArtifact = new Artifact<"code", CodeArtifactMetadata>({
                 outputs: [
                   ...metadata.outputs.filter((output) => output.id !== runId),
                   {
-                    id: runId,
                     contents: [{ type: "text", value: message }],
+                    id: runId,
                     status: "loading_packages",
                   },
                 ],
@@ -201,8 +201,8 @@ export const codeArtifact = new Artifact<"code", CodeArtifactMetadata>({
             outputs: [
               ...metadata.outputs.filter((output) => output.id !== runId),
               {
-                id: runId,
                 contents: outputContent,
+                id: runId,
                 status: "completed",
               },
             ],
@@ -213,7 +213,6 @@ export const codeArtifact = new Artifact<"code", CodeArtifactMetadata>({
             outputs: [
               ...metadata.outputs.filter((output) => output.id !== runId),
               {
-                id: runId,
                 contents: [
                   {
                     type: "text",
@@ -221,6 +220,7 @@ export const codeArtifact = new Artifact<"code", CodeArtifactMetadata>({
                       error instanceof Error ? error.message : String(error),
                   },
                 ],
+                id: runId,
                 status: "failed",
               },
             ],

--- a/apps/chat/lib/artifacts/sheet/client.tsx
+++ b/apps/chat/lib/artifacts/sheet/client.tsx
@@ -94,7 +94,7 @@ export const sheetArtifact = new Artifact<"sheet", SheetArtifactMetadata>({
         sendMessage({
           role: "user",
           parts: [
-            { type: "text", text: "Can you please format and clean the data?" },
+            { text: "Can you please format and clean the data?", type: "text" },
           ],
           metadata: {
             selectedModel: config.ai.tools.sheet.format,
@@ -113,8 +113,8 @@ export const sheetArtifact = new Artifact<"sheet", SheetArtifactMetadata>({
           role: "user",
           parts: [
             {
-              type: "text",
               text: "Can you please analyze and visualize the data by creating a new code artifact in python?",
+              type: "text",
             },
           ],
           metadata: {

--- a/apps/chat/lib/artifacts/text/client.tsx
+++ b/apps/chat/lib/artifacts/text/client.tsx
@@ -124,8 +124,8 @@ export const textArtifact = new Artifact<"text">({
           role: "user",
           parts: [
             {
-              type: "text",
               text: "Please add final polish and check for grammar, add section titles for better structure, and ensure everything reads smoothly.",
+              type: "text",
             },
           ],
           metadata: {


### PR DESCRIPTION
Sorts nine order-insensitive artifact record literals: a static handler lookup, initialization/output records made only of literals or local values, and literal text parts. It intentionally leaves artifact/action configuration objects and message metadata that contain callbacks, UI ordering, or effectful evaluation. No baseline changes.\n\nValidation:\n- bun lint\n- bun test:types\n- PORT=3090 PLAYWRIGHT=True bunx playwright test tests/artifacts.e2e.ts tests/model-toolbar.visual.e2e.ts --project=artifacts --project=visual --workers=1

## Summary by Sourcery

Enhancements:
- Normalize property ordering in order-insensitive artifact handlers, output records, and literal message parts without changing runtime behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sorts property order in nine order-insensitive artifact record literals: a static handler lookup, initialization/output records made only of literals or local values, and literal text parts. No runtime behavior changes or baseline changes. Intentionally leaves artifact/action configuration objects and message metadata that contain callbacks, UI ordering, or effectful evaluation unsorted.

<sup>Written for commit 478de4d7d1f8190b30f355cc5753c5dba84c1af5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

