### PR TITLE
chore(chat): clean tool renderer lint

### DIFF
--- a/apps/chat/components/parallel-response-cards.test.ts
+++ b/apps/chat/components/parallel-response-cards.test.ts
@@ -9,15 +9,12 @@ import {
   getStatusLabel,
 } from "./parallel-response-status";
 
-function createAssistantMessage(activeStreamId: string | null) {
-  return {
-    metadata: { activeStreamId },
-  };
-}
+const createAssistantMessage = (activeStreamId: string | null) => ({
+  metadata: { activeStreamId },
+});
 
-function pendingLifecycle(runStatus: ChatStatus) {
-  return getParallelResponseLifecycle(null, runStatus);
-}
+const pendingLifecycle = (runStatus: ChatStatus) =>
+  getParallelResponseLifecycle(null, runStatus);
 
 describe("parallel response card status", () => {
   it("keeps queued and streaming responses in a loading state", () => {

--- a/apps/chat/tools/chatjs/get-weather/renderer.test.tsx
+++ b/apps/chat/tools/chatjs/get-weather/renderer.test.tsx
@@ -5,21 +5,21 @@ import { GetWeatherRenderer } from "./renderer";
 import type { WeatherAtLocation } from "./tool";
 
 const weather: WeatherAtLocation = {
-  current: { time: "2026-09-08T20:00", interval: 900, temperature_2m: 20 },
-  current_units: { time: "iso8601", interval: "seconds", temperature_2m: "°C" },
+  current: { interval: 900, temperature_2m: 20, time: "2026-09-08T20:00" },
+  current_units: { interval: "seconds", temperature_2m: "°C", time: "iso8601" },
   daily: {
-    time: ["2026-09-08"],
     sunrise: ["2026-09-08T06:00"],
     sunset: ["2026-09-08T19:00"],
+    time: ["2026-09-08"],
   },
-  daily_units: { time: "iso8601", sunrise: "iso8601", sunset: "iso8601" },
-  hourly: {
-    time: Array.from({ length: 8 }, (_, i) => `2026-09-08T${10 + i}:00`),
-    temperature_2m: [10, 11, 12, 13, 14, 15, 16, 17],
-  },
-  hourly_units: { time: "iso8601", temperature_2m: "°C" },
+  daily_units: { sunrise: "iso8601", sunset: "iso8601", time: "iso8601" },
   elevation: 0,
   generationtime_ms: 0,
+  hourly: {
+    temperature_2m: [10, 11, 12, 13, 14, 15, 16, 17],
+    time: Array.from({ length: 8 }, (_, i) => `2026-09-08T${10 + i}:00`),
+  },
+  hourly_units: { temperature_2m: "°C", time: "iso8601" },
   latitude: 0,
   longitude: 0,
   timezone: "UTC",
@@ -36,10 +36,10 @@ test.each([
       isReadonly
       messageId="weather-test"
       tool={{
-        toolCallId: "weather-test",
-        state: "output-available",
         input: { latitude: 0, longitude: 0 },
         output: { ...weather, current: { ...weather.current, time } },
+        state: "output-available",
+        toolCallId: "weather-test",
       }}
     />
   );

--- a/apps/chat/tools/chatjs/tavily-search/renderer.tsx
+++ b/apps/chat/tools/chatjs/tavily-search/renderer.tsx
@@ -5,6 +5,7 @@ import type { UIToolInvocation } from "ai";
 import { WebSearch } from "@/components/part/web-search";
 
 import type { webSearch } from "./tool";
+
 export const WebSearchRenderer = ({
   tool,
   messageId,

--- a/apps/chat/tools/chatjs/tavily-search/renderer.tsx
+++ b/apps/chat/tools/chatjs/tavily-search/renderer.tsx
@@ -1,16 +1,15 @@
 "use client";
+
 import type { UIToolInvocation } from "ai";
 
 import { WebSearch } from "@/components/part/web-search";
 
 import type { webSearch } from "./tool";
-export function WebSearchRenderer({
+export const WebSearchRenderer = ({
   tool,
   messageId,
 }: {
   tool: UIToolInvocation<typeof webSearch>;
   messageId: string;
   isReadonly: boolean;
-}) {
-  return <WebSearch messageId={messageId} part={tool} />;
-}
+}) => <WebSearch messageId={messageId} part={tool} />;

--- a/apps/chat/tools/chatjs/tavily-search/tool.test.ts
+++ b/apps/chat/tools/chatjs/tavily-search/tool.test.ts
@@ -61,7 +61,7 @@ test("Tavily forwards native options and preserves source events", async () => {
   expect(events).toContainEqual(
     expect.objectContaining({
       data: expect.objectContaining({
-        results: [expect.objectContaining({ title: "Source", source: "web" })],
+        results: [expect.objectContaining({ source: "web", title: "Source" })],
         status: "completed",
         toolCallId: "call",
         type: "web",

--- a/apps/chat/tools/chatjs/vercel-code-execution/renderer.tsx
+++ b/apps/chat/tools/chatjs/vercel-code-execution/renderer.tsx
@@ -49,12 +49,12 @@ const pngSchema = z.object({
   format: z.literal("png"),
 });
 
-export function CodeExecution({ tool }: { tool: CodeExecutionTool }) {
+export const CodeExecution = ({ tool }: { tool: CodeExecutionTool }) => {
   const args = tool.input ?? {
     code: "",
-    title: "",
-    language: "python",
     icon: "default",
+    language: "python",
+    title: "",
   };
   const result = tool.state === "output-available" ? tool.output : null;
   const parsedChart = chartSchema.safeParse(result?.chart);
@@ -94,4 +94,4 @@ export function CodeExecution({ tool }: { tool: CodeExecutionTool }) {
       )}
     </div>
   );
-}
+};


### PR DESCRIPTION
Converts the Tavily and Vercel code-execution renderers to arrow components without changing parameters or returned JSX. It also sorts safe test fixture/data records and normalizes the parallel-response test helpers. No baseline changes.\n\nValidation:\n- bun lint\n- bun test:types\n- bunx vitest run tools/chatjs/get-weather/renderer.test.tsx tools/chatjs/tavily-search/tool.test.ts tools/chatjs/vercel-code-execution/tool.test.ts components/parallel-response-cards.test.ts\n- PORT=3090 PLAYWRIGHT=True bunx playwright test tests/model-toolbar.visual.e2e.ts --project=visual --workers=1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converts the Tavily and Vercel code-execution renderers to arrow components, separates the Tavily renderer imports, and normalizes fixture/test data ordering. No behavior or output changes.

<sup>Written for commit 36efec35b64d48d4308414f7e4e89cbd02b805e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Clean up chat tool renderers and test data formatting while preserving existing behavior and output.

Enhancements:
- Standardize Tavily search and Vercel code-execution renderers as arrow components without changing their behavior or output.
- Normalize test helper definitions and fixture/data record ordering for consistent linting and formatting.