### PR TITLE
chore: define pure helpers before their callers

### DIFF
--- a/apps/chat/lib/gated-chat-transport.test.ts
+++ b/apps/chat/lib/gated-chat-transport.test.ts
@@ -8,19 +8,17 @@ import {
   gateChatRequest,
 } from "./gated-chat-transport";
 
-function requestOptions(
+const requestOptions = (
   metadata: unknown,
   abortSignal?: AbortSignal
-): Parameters<ChatTransport<UIMessage>["sendMessages"]>[0] {
-  return {
-    abortSignal,
-    chatId: "chat-1",
-    messageId: undefined,
-    messages: [],
-    metadata,
-    trigger: "submit-message",
-  };
-}
+): Parameters<ChatTransport<UIMessage>["sendMessages"]>[0] => ({
+  abortSignal,
+  chatId: "chat-1",
+  messageId: undefined,
+  messages: [],
+  metadata,
+  trigger: "submit-message",
+});
 
 describe("createGatedChatTransport", () => {
   it("waits before forwarding a request and restores its metadata", async () => {

--- a/apps/chat/lib/stores/base/use-data-parts.ts
+++ b/apps/chat/lib/stores/base/use-data-parts.ts
@@ -33,6 +33,68 @@ export interface UseDataPartOptions<T = unknown> {
 }
 
 /**
+ * Extract all data parts from messages.
+ * Data parts are identified by types starting with "data-".
+ */
+const extractDataPartsFromMessages = (
+  messages: UIMessage[]
+): DataPart<unknown>[] => {
+  const dataParts: DataPart<unknown>[] = [];
+
+  for (const message of messages) {
+    // Check message parts for data parts
+    if (message.parts && Array.isArray(message.parts)) {
+      for (const part of message.parts) {
+        // Check if this part is a data part (starts with "data-")
+        if (part.type.startsWith("data-") && "data" in part) {
+          const dataPart = part as {
+            type: string;
+            data: unknown;
+            timestamp?: number;
+          };
+          if (dataPart.data !== undefined) {
+            dataParts.push({
+              data: dataPart.data,
+              timestamp: dataPart.timestamp || Date.now(),
+              type: dataPart.type,
+            });
+          }
+        }
+
+        // Also check tool call results that might contain data parts
+        if (part.type.startsWith("tool-") && "result" in part && part.result) {
+          const { result } = part;
+          if (typeof result === "object" && result && "parts" in result) {
+            const { parts } = result as { parts?: unknown[] };
+            if (Array.isArray(parts)) {
+              for (const nestedPart of parts) {
+                const typedPart = nestedPart as {
+                  type?: string;
+                  data?: unknown;
+                  timestamp?: number;
+                };
+                if (
+                  typedPart.type?.startsWith("data-") &&
+                  typedPart.data !== undefined
+                ) {
+                  dataParts.push({
+                    data: typedPart.data,
+                    timestamp: typedPart.timestamp || Date.now(),
+                    type: typedPart.type,
+                  });
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return dataParts;
+};
+
+/**
  * Hook to extract and access data parts from messages.
  * Returns the latest value for each data part type.
  *
@@ -187,66 +249,4 @@ export const useDataPart = <T = unknown>(
   }, [type, removeTransientDataPart]);
 
   return [result ? result.data : null, clear];
-};
-
-/**
- * Extract all data parts from messages.
- * Data parts are identified by types starting with "data-".
- */
-const extractDataPartsFromMessages = (
-  messages: UIMessage[]
-): DataPart<unknown>[] => {
-  const dataParts: DataPart<unknown>[] = [];
-
-  for (const message of messages) {
-    // Check message parts for data parts
-    if (message.parts && Array.isArray(message.parts)) {
-      for (const part of message.parts) {
-        // Check if this part is a data part (starts with "data-")
-        if (part.type.startsWith("data-") && "data" in part) {
-          const dataPart = part as {
-            type: string;
-            data: unknown;
-            timestamp?: number;
-          };
-          if (dataPart.data !== undefined) {
-            dataParts.push({
-              data: dataPart.data,
-              timestamp: dataPart.timestamp || Date.now(),
-              type: dataPart.type,
-            });
-          }
-        }
-
-        // Also check tool call results that might contain data parts
-        if (part.type.startsWith("tool-") && "result" in part && part.result) {
-          const { result } = part;
-          if (typeof result === "object" && result && "parts" in result) {
-            const { parts } = result as { parts?: unknown[] };
-            if (Array.isArray(parts)) {
-              for (const nestedPart of parts) {
-                const typedPart = nestedPart as {
-                  type?: string;
-                  data?: unknown;
-                  timestamp?: number;
-                };
-                if (
-                  typedPart.type?.startsWith("data-") &&
-                  typedPart.data !== undefined
-                ) {
-                  dataParts.push({
-                    data: typedPart.data,
-                    timestamp: typedPart.timestamp || Date.now(),
-                    type: typedPart.type,
-                  });
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-
-  return dataParts;
 };

--- a/apps/chat/lib/thread-utils.ts
+++ b/apps/chat/lib/thread-utils.ts
@@ -120,6 +120,43 @@ export const getDefaultThread = <T extends MessageNode>(
   return buildThreadFromLeaf(allMessages, defaultLeaf.id);
 };
 
+// Build parent->children mapping sorted by createdAt
+export const buildChildrenMap = <T extends MessageNode>(
+  allMessages: T[]
+): Map<string | null, T[]> => {
+  const map = new Map<string | null, T[]>();
+  for (const message of allMessages) {
+    const parentId = message.metadata?.parentMessageId || null;
+    if (!map.has(parentId)) {
+      map.set(parentId, []);
+    }
+    map.get(parentId)?.push(message);
+  }
+  for (const siblings of map.values()) {
+    siblings.sort((a, b) => {
+      const aParallelIndex = a.metadata?.parallelIndex;
+      const bParallelIndex = b.metadata?.parallelIndex;
+      const sameParallelGroup =
+        a.metadata?.parallelGroupId &&
+        a.metadata?.parallelGroupId === b.metadata?.parallelGroupId;
+
+      if (
+        sameParallelGroup &&
+        typeof aParallelIndex === "number" &&
+        typeof bParallelIndex === "number" &&
+        aParallelIndex !== bParallelIndex
+      ) {
+        return aParallelIndex - bParallelIndex;
+      }
+
+      return (
+        toTimestamp(a.metadata?.createdAt) - toTimestamp(b.metadata?.createdAt)
+      );
+    });
+  }
+  return map;
+};
+
 export const buildTreeSnapshotFromMessages = <
   TMessage extends UIMessage & MessageNode,
 >(
@@ -181,43 +218,6 @@ export const buildTreeSnapshotFromMessages = <
   }
 
   return { cursorId, nodes, version: 1 };
-};
-
-// Build parent->children mapping sorted by createdAt
-export const buildChildrenMap = <T extends MessageNode>(
-  allMessages: T[]
-): Map<string | null, T[]> => {
-  const map = new Map<string | null, T[]>();
-  for (const message of allMessages) {
-    const parentId = message.metadata?.parentMessageId || null;
-    if (!map.has(parentId)) {
-      map.set(parentId, []);
-    }
-    map.get(parentId)?.push(message);
-  }
-  for (const siblings of map.values()) {
-    siblings.sort((a, b) => {
-      const aParallelIndex = a.metadata?.parallelIndex;
-      const bParallelIndex = b.metadata?.parallelIndex;
-      const sameParallelGroup =
-        a.metadata?.parallelGroupId &&
-        a.metadata?.parallelGroupId === b.metadata?.parallelGroupId;
-
-      if (
-        sameParallelGroup &&
-        typeof aParallelIndex === "number" &&
-        typeof bParallelIndex === "number" &&
-        aParallelIndex !== bParallelIndex
-      ) {
-        return aParallelIndex - bParallelIndex;
-      }
-
-      return (
-        toTimestamp(a.metadata?.createdAt) - toTimestamp(b.metadata?.createdAt)
-      );
-    });
-  }
-  return map;
 };
 
 export const findLeafDfsToRightFromMessageId = <T extends MessageNode>(

--- a/apps/electron/src/main.ts
+++ b/apps/electron/src/main.ts
@@ -267,22 +267,6 @@ ipcMain.handle("chatjs:cancel-auth-flow", async () => {
   await resetAuthFlow();
 });
 
-ipcMain.removeHandler("better-auth:signOut");
-ipcMain.handle("better-auth:signOut", async () => {
-  const result = await electronAuthClient.signOut();
-  await syncAuthSessionCookies();
-  return result;
-});
-
-ipcMain.removeHandler("better-auth:getUser");
-ipcMain.handle("better-auth:getUser", async () => {
-  const sessionResult = await electronAuthClient.getSession();
-  return sessionResult.data?.user ?? null;
-});
-
-const getAppAssetPath = (...segments: string[]): string =>
-  path.join(app.getAppPath(), ...segments);
-
 const isBetterAuthCookieName = (name: string): boolean =>
   name.startsWith(ELECTRON_AUTH_COOKIE_PREFIX) ||
   name.startsWith(`__Secure-${ELECTRON_AUTH_COOKIE_PREFIX}`) ||
@@ -346,6 +330,22 @@ const syncAuthSessionCookies = async (
     )
   );
 };
+
+ipcMain.removeHandler("better-auth:signOut");
+ipcMain.handle("better-auth:signOut", async () => {
+  const result = await electronAuthClient.signOut();
+  await syncAuthSessionCookies();
+  return result;
+});
+
+ipcMain.removeHandler("better-auth:getUser");
+ipcMain.handle("better-auth:getUser", async () => {
+  const sessionResult = await electronAuthClient.getSession();
+  return sessionResult.data?.user ?? null;
+});
+
+const getAppAssetPath = (...segments: string[]): string =>
+  path.join(app.getAppPath(), ...segments);
 
 const hasSessionCookie = (cookieHeader: string): boolean =>
   /(?:^|;\s*)(?:__Secure-)?better-auth\.session_token=/u.test(cookieHeader);


### PR DESCRIPTION
Move tree, data-part, and Electron cookie-sync helpers before their first references, preserving every statement and comment. The gated-transport test request factory now uses a concise arrow. This removes four use-before-definition findings and one function-style finding without changing initialization side effects, callback timing, or function bodies.

Validation: `bun lint`, `bun test:types`, and all 193 chat unit tests passed. AST comparison verifies that the three reordered source files contain identical statements and comments. The focused audit reports zero violations across all four files. Baseline pruning remains deferred to the final cleanup PR.

## Summary by Sourcery

Define helper functions before their callers and modernize the gated transport test factory without changing runtime behavior.

Enhancements:
- Reorder tree, data-part, and Electron authentication helpers before their first use to eliminate use-before-definition findings while preserving behavior.
- Use a concise arrow-function request factory in the gated transport tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorders helper functions above their first call sites in `apps/chat/lib/stores/base/use-data-parts.ts`, `apps/chat/lib/thread-utils.ts`, and `apps/electron/src/main.ts` to clear use-before-definition lint findings without changing behavior.

- Converts the request factory in `apps/chat/lib/gated-chat-transport.test.ts` from a function declaration to a concise arrow function.
- No statements, comments, initialization side effects, callback timing, or function bodies changed.

<sup>Written for commit 1a2b047c34ae0d20aacd81b425c060d9e11a02b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

