### PR TITLE
chore(chat): sort artifact configuration records

### DIFF
--- a/apps/chat/lib/artifacts/code/client.tsx
+++ b/apps/chat/lib/artifacts/code/client.tsx
@@ -10,6 +10,9 @@ import { config } from "@/lib/config";
 import { generateUUID, getLanguageFromFileName } from "@/lib/utils";
 
 const OUTPUT_HANDLERS = {
+  basic: `
+    # Basic output capture setup
+  `,
   matplotlib: `
     import io
     import base64
@@ -39,9 +42,6 @@ const OUTPUT_HANDLERS = {
             plt.close('all')
 
         plt.show = custom_show
-  `,
-  basic: `
-    # Basic output capture setup
   `,
 };
 
@@ -85,50 +85,18 @@ export function getCodeArtifactMetadata(
 }
 
 export const codeArtifact = new Artifact<"code", CodeArtifactMetadata>({
-  kind: "code",
-  description:
-    "Useful for code generation; Code execution is only available for Python code.",
-  initialize: ({ setMetadata }) => {
-    setMetadata({
-      outputs: [],
-      language: "python",
-    });
-  },
-  content: ({ isReadonly, content, title, ...props }) => {
-    const language = getLanguageFromFileName(title) || "python";
-
-    return (
-      <CodeEditor
-        {...props}
-        content={content}
-        isReadonly={isReadonly}
-        language={language}
-      />
-    );
-  },
-  footer: ({ metadata, setMetadata }) => {
-    if (!metadata?.outputs?.length) {
-      return null;
-    }
-
-    return (
-      <Console
-        className="min-h-[200px]"
-        consoleOutputs={metadata.outputs}
-        setConsoleOutputs={() => {
-          setMetadata({
-            ...metadata,
-            outputs: [],
-          });
-        }}
-      />
-    );
-  },
   actions: [
     {
-      icon: <Play size={18} />,
-      label: "Run",
       description: "Execute code",
+      icon: <Play size={18} />,
+      isDisabled: ({ isReadonly, content: _content, metadata }) => {
+        if (isReadonly) {
+          return true;
+        }
+        const language = metadata?.language || "python";
+        return language !== "python";
+      },
+      label: "Run",
       onClick: async ({ content, setMetadata, metadata: _metadata }) => {
         const runId = generateUUID();
         const outputContent: ConsoleOutputContent[] = [];
@@ -138,8 +106,8 @@ export const codeArtifact = new Artifact<"code", CodeArtifactMetadata>({
           outputs: [
             ...metadata.outputs,
             {
-              id: runId,
               contents: [],
+              id: runId,
               status: "in_progress",
             },
           ],
@@ -170,8 +138,8 @@ export const codeArtifact = new Artifact<"code", CodeArtifactMetadata>({
                 outputs: [
                   ...metadata.outputs.filter((output) => output.id !== runId),
                   {
-                    id: runId,
                     contents: [{ type: "text", value: message }],
+                    id: runId,
                     status: "loading_packages",
                   },
                 ],
@@ -201,8 +169,8 @@ export const codeArtifact = new Artifact<"code", CodeArtifactMetadata>({
             outputs: [
               ...metadata.outputs.filter((output) => output.id !== runId),
               {
-                id: runId,
                 contents: outputContent,
+                id: runId,
                 status: "completed",
               },
             ],
@@ -213,7 +181,6 @@ export const codeArtifact = new Artifact<"code", CodeArtifactMetadata>({
             outputs: [
               ...metadata.outputs.filter((output) => output.id !== runId),
               {
-                id: runId,
                 contents: [
                   {
                     type: "text",
@@ -221,26 +188,17 @@ export const codeArtifact = new Artifact<"code", CodeArtifactMetadata>({
                       error instanceof Error ? error.message : String(error),
                   },
                 ],
+                id: runId,
                 status: "failed",
               },
             ],
           }));
         }
       },
-      isDisabled: ({ isReadonly, content: _content, metadata }) => {
-        if (isReadonly) {
-          return true;
-        }
-        const language = metadata?.language || "python";
-        return language !== "python";
-      },
     },
     {
-      icon: <Undo2 size={18} />,
       description: "View Previous version",
-      onClick: ({ handleVersionChange }) => {
-        handleVersionChange("prev");
-      },
+      icon: <Undo2 size={18} />,
       isDisabled: ({ currentVersionIndex }) => {
         if (currentVersionIndex === 0) {
           return true;
@@ -248,13 +206,13 @@ export const codeArtifact = new Artifact<"code", CodeArtifactMetadata>({
 
         return false;
       },
+      onClick: ({ handleVersionChange }) => {
+        handleVersionChange("prev");
+      },
     },
     {
-      icon: <Redo2 size={18} />,
       description: "View Next version",
-      onClick: ({ handleVersionChange }) => {
-        handleVersionChange("next");
-      },
+      icon: <Redo2 size={18} />,
       isDisabled: ({ isCurrentVersion }) => {
         if (isCurrentVersion) {
           return true;
@@ -262,56 +220,106 @@ export const codeArtifact = new Artifact<"code", CodeArtifactMetadata>({
 
         return false;
       },
+      onClick: ({ handleVersionChange }) => {
+        handleVersionChange("next");
+      },
     },
     {
-      icon: <Copy size={18} />,
       description: "Copy code to clipboard",
+      icon: <Copy size={18} />,
       onClick: ({ content }) => {
         navigator.clipboard.writeText(content);
         toast.success("Copied to clipboard!");
       },
     },
   ],
+  content: ({ isReadonly, content, title, ...props }) => {
+    const language = getLanguageFromFileName(title) || "python";
+
+    return (
+      <CodeEditor
+        {...props}
+        content={content}
+        isReadonly={isReadonly}
+        language={language}
+      />
+    );
+  },
+  description:
+    "Useful for code generation; Code execution is only available for Python code.",
+  footer: ({ metadata, setMetadata }) => {
+    if (!metadata?.outputs?.length) {
+      return null;
+    }
+
+    return (
+      <Console
+        className="min-h-[200px]"
+        consoleOutputs={metadata.outputs}
+        setConsoleOutputs={() => {
+          setMetadata({
+            ...metadata,
+            outputs: [],
+          });
+        }}
+      />
+    );
+  },
+  initialize: ({ setMetadata }) => {
+    setMetadata({
+      language: "python",
+      outputs: [],
+    });
+  },
+  kind: "code",
   toolbar: [
     {
-      icon: <MessageSquare size={16} />,
       description: "Add comments",
+      icon: <MessageSquare size={16} />,
       onClick: ({ sendMessage, storeApi }) => {
+        const selectedModel = config.ai.tools.code.edits;
+        const createdAt = new Date();
+        const parentMessageId = storeApi.getState().getLastMessageId();
+
         sendMessage({
-          role: "user",
+          metadata: {
+            activeStreamId: null,
+            createdAt,
+            parentMessageId,
+            selectedModel,
+          },
           parts: [
             {
-              type: "text",
               text: "Add comments to the code snippet for understanding",
+              type: "text",
             },
           ],
-          metadata: {
-            selectedModel: config.ai.tools.code.edits,
-            createdAt: new Date(),
-            parentMessageId: storeApi.getState().getLastMessageId(),
-            activeStreamId: null,
-          },
+          role: "user",
         });
       },
     },
     {
-      icon: <List size={16} />,
       description: "Add logs",
+      icon: <List size={16} />,
       onClick: ({ sendMessage, storeApi }) => {
+        const selectedModel = config.ai.tools.code.edits;
+        const createdAt = new Date();
+        const parentMessageId = storeApi.getState().getLastMessageId();
+
         sendMessage({
-          role: "user",
+          metadata: {
+            activeStreamId: null,
+            createdAt,
+            parentMessageId,
+            selectedModel,
+          },
           parts: [
             {
-              type: "text",
               text: "Add logs to the code snippet for debugging",
+              type: "text",
             },
           ],
-          metadata: {
-            selectedModel: config.ai.tools.code.edits,
-            createdAt: new Date(),
-            parentMessageId: storeApi.getState().getLastMessageId(),
-            activeStreamId: null,
-          },
+          role: "user",
         });
       },
     },

--- a/apps/chat/lib/artifacts/sheet/client.tsx
+++ b/apps/chat/lib/artifacts/sheet/client.tsx
@@ -18,11 +18,52 @@ export function getSheetArtifactMetadata(
 }
 
 export const sheetArtifact = new Artifact<"sheet", SheetArtifactMetadata>({
-  kind: "sheet",
-  description: "Useful for working with spreadsheets",
-  initialize: async () => {
-    // No initialization needed for sheet artifact
-  },
+  actions: [
+    {
+      description: "View Previous version",
+      icon: <Undo2 size={18} />,
+      isDisabled: ({ currentVersionIndex }) => {
+        if (currentVersionIndex === 0) {
+          return true;
+        }
+
+        return false;
+      },
+      onClick: ({ handleVersionChange }) => {
+        handleVersionChange("prev");
+      },
+    },
+    {
+      description: "View Next version",
+      icon: <Redo2 size={18} />,
+      isDisabled: ({ isCurrentVersion }) => {
+        if (isCurrentVersion) {
+          return true;
+        }
+
+        return false;
+      },
+      onClick: ({ handleVersionChange }) => {
+        handleVersionChange("next");
+      },
+    },
+    {
+      description: "Copy as .csv",
+      icon: <Copy size={16} />,
+      onClick: ({ content }) => {
+        const parsed = parse<string[]>(content, { skipEmptyLines: true });
+
+        const nonEmptyRows = parsed.data.filter((row) =>
+          row.some((cell) => cell.trim() !== "")
+        );
+
+        const cleanedCsv = unparse(nonEmptyRows);
+
+        navigator.clipboard.writeText(cleanedCsv);
+        toast.success("Copied csv to clipboard!");
+      },
+    },
+  ],
   content: ({
     content,
     currentVersionIndex,
@@ -40,68 +81,31 @@ export const sheetArtifact = new Artifact<"sheet", SheetArtifactMetadata>({
       status={status}
     />
   ),
-  actions: [
-    {
-      icon: <Undo2 size={18} />,
-      description: "View Previous version",
-      onClick: ({ handleVersionChange }) => {
-        handleVersionChange("prev");
-      },
-      isDisabled: ({ currentVersionIndex }) => {
-        if (currentVersionIndex === 0) {
-          return true;
-        }
-
-        return false;
-      },
-    },
-    {
-      icon: <Redo2 size={18} />,
-      description: "View Next version",
-      onClick: ({ handleVersionChange }) => {
-        handleVersionChange("next");
-      },
-      isDisabled: ({ isCurrentVersion }) => {
-        if (isCurrentVersion) {
-          return true;
-        }
-
-        return false;
-      },
-    },
-    {
-      icon: <Copy size={16} />,
-      description: "Copy as .csv",
-      onClick: ({ content }) => {
-        const parsed = parse<string[]>(content, { skipEmptyLines: true });
-
-        const nonEmptyRows = parsed.data.filter((row) =>
-          row.some((cell) => cell.trim() !== "")
-        );
-
-        const cleanedCsv = unparse(nonEmptyRows);
-
-        navigator.clipboard.writeText(cleanedCsv);
-        toast.success("Copied csv to clipboard!");
-      },
-    },
-  ],
+  description: "Useful for working with spreadsheets",
+  initialize: async () => {
+    // No initialization needed for sheet artifact
+  },
+  kind: "sheet",
   toolbar: [
     {
       description: "Format and clean data",
       icon: <Sparkles size={16} />,
       onClick: ({ sendMessage, storeApi }) => {
+        const selectedModel = config.ai.tools.sheet.format;
+        const createdAt = new Date();
+        const parentMessageId = storeApi.getState().getLastMessageId();
+
         sendMessage({
-          role: "user",
-          parts: [
-            { type: "text", text: "Can you please format and clean the data?" },
-          ],
           metadata: {
-            selectedModel: config.ai.tools.sheet.format,
-            createdAt: new Date(),
-            parentMessageId: storeApi.getState().getLastMessageId(),
             activeStreamId: null,
+            createdAt,
+            parentMessageId,
+            selectedModel,
           },
+          parts: [
+            { text: "Can you please format and clean the data?", type: "text" },
+          ],
+          role: "user",
         });
       },
     },
@@ -109,20 +113,24 @@ export const sheetArtifact = new Artifact<"sheet", SheetArtifactMetadata>({
       description: "Analyze and visualize data",
       icon: <LineChart size={16} />,
       onClick: ({ sendMessage, storeApi }) => {
+        const selectedModel = config.ai.tools.sheet.analyze;
+        const createdAt = new Date();
+        const parentMessageId = storeApi.getState().getLastMessageId();
+
         sendMessage({
-          role: "user",
+          metadata: {
+            activeStreamId: null,
+            createdAt,
+            parentMessageId,
+            selectedModel,
+          },
           parts: [
             {
-              type: "text",
               text: "Can you please analyze and visualize the data by creating a new code artifact in python?",
+              type: "text",
             },
           ],
-          metadata: {
-            selectedModel: config.ai.tools.sheet.analyze,
-            createdAt: new Date(),
-            parentMessageId: storeApi.getState().getLastMessageId(),
-            activeStreamId: null,
-          },
+          role: "user",
         });
       },
     },

--- a/apps/chat/lib/artifacts/text/client.tsx
+++ b/apps/chat/lib/artifacts/text/client.tsx
@@ -22,8 +22,58 @@ const Editor = dynamic(
   }
 );
 export const textArtifact = new Artifact<"text">({
-  kind: "text",
-  description: "Useful for text content, like drafting essays and emails.",
+  actions: [
+    {
+      description: "View changes",
+      icon: <History size={18} />,
+      isDisabled: ({ currentVersionIndex }) => {
+        if (currentVersionIndex === 0) {
+          return true;
+        }
+
+        return false;
+      },
+      onClick: ({ handleVersionChange }) => {
+        handleVersionChange("toggle");
+      },
+    },
+    {
+      description: "View Previous version",
+      icon: <Undo2 size={18} />,
+      isDisabled: ({ currentVersionIndex }) => {
+        if (currentVersionIndex === 0) {
+          return true;
+        }
+
+        return false;
+      },
+      onClick: ({ handleVersionChange }) => {
+        handleVersionChange("prev");
+      },
+    },
+    {
+      description: "View Next version",
+      icon: <Redo2 size={18} />,
+      isDisabled: ({ isCurrentVersion }) => {
+        if (isCurrentVersion) {
+          return true;
+        }
+
+        return false;
+      },
+      onClick: ({ handleVersionChange }) => {
+        handleVersionChange("next");
+      },
+    },
+    {
+      description: "Copy to clipboard",
+      icon: <Copy size={18} />,
+      onClick: ({ content }) => {
+        navigator.clipboard.writeText(content);
+        toast.success("Copied to clipboard!");
+      },
+    },
+  ],
   content: ({
     mode,
     status,
@@ -63,77 +113,31 @@ export const textArtifact = new Artifact<"text">({
       </div>
     );
   },
-  actions: [
-    {
-      icon: <History size={18} />,
-      description: "View changes",
-      onClick: ({ handleVersionChange }) => {
-        handleVersionChange("toggle");
-      },
-      isDisabled: ({ currentVersionIndex }) => {
-        if (currentVersionIndex === 0) {
-          return true;
-        }
-
-        return false;
-      },
-    },
-    {
-      icon: <Undo2 size={18} />,
-      description: "View Previous version",
-      onClick: ({ handleVersionChange }) => {
-        handleVersionChange("prev");
-      },
-      isDisabled: ({ currentVersionIndex }) => {
-        if (currentVersionIndex === 0) {
-          return true;
-        }
-
-        return false;
-      },
-    },
-    {
-      icon: <Redo2 size={18} />,
-      description: "View Next version",
-      onClick: ({ handleVersionChange }) => {
-        handleVersionChange("next");
-      },
-      isDisabled: ({ isCurrentVersion }) => {
-        if (isCurrentVersion) {
-          return true;
-        }
-
-        return false;
-      },
-    },
-    {
-      icon: <Copy size={18} />,
-      description: "Copy to clipboard",
-      onClick: ({ content }) => {
-        navigator.clipboard.writeText(content);
-        toast.success("Copied to clipboard!");
-      },
-    },
-  ],
+  description: "Useful for text content, like drafting essays and emails.",
+  kind: "text",
   toolbar: [
     {
-      icon: <Pen size={16} />,
       description: "Add final polish",
+      icon: <Pen size={16} />,
       onClick: ({ sendMessage, storeApi }) => {
+        const selectedModel = config.ai.tools.text.polish;
+        const createdAt = new Date();
+        const parentMessageId = storeApi.getState().getLastMessageId();
+
         sendMessage({
-          role: "user",
+          metadata: {
+            activeStreamId: null,
+            createdAt,
+            parentMessageId,
+            selectedModel,
+          },
           parts: [
             {
-              type: "text",
               text: "Please add final polish and check for grammar, add section titles for better structure, and ensure everything reads smoothly.",
+              type: "text",
             },
           ],
-          metadata: {
-            selectedModel: config.ai.tools.text.polish,
-            createdAt: new Date(),
-            parentMessageId: storeApi.getState().getLastMessageId(),
-            activeStreamId: null,
-          },
+          role: "user",
         });
       },
     },


### PR DESCRIPTION
Sorts the 29 remaining artifact client records after confirming Artifact consumers access action and toolbar fields by name while preserving action-array order. This branch also contains the nine pure-record fixes already proposed in #412 because it began before that PR; #412 should merge first. Metadata values are precomputed in their original config/date/store evaluation sequence before sorted construction. No baseline changes.\n\nValidation after merging origin/main:\n- bun lint\n- bun test:types\n- PORT=3090 PLAYWRIGHT=True bunx playwright test tests/artifacts.e2e.ts --project=artifacts --workers=1

## Summary by Sourcery

Enhancements:
- Sort artifact configuration records into the expected field order while preserving action and toolbar behavior.