### PR TITLE
style(chat): sort markdown stream part fields

### DIFF
--- a/apps/chat/lib/ai/markdown-joiner-transform.ts
+++ b/apps/chat/lib/ai/markdown-joiner-transform.ts
@@ -101,9 +101,9 @@ export const markdownJoinerTransform =
           const remaining = parts.get(chunk.id)?.flush();
           if (remaining) {
             controller.enqueue({
-              type: "text-delta",
               id: chunk.id,
               text: remaining,
+              type: "text-delta",
             });
           }
           parts.delete(chunk.id);


### PR DESCRIPTION
Sort the plain TextStreamPart literal emitted when buffered markdown is flushed. The existing transform test asserts the same field values and downstream consumers read fields by name; no runtime values or stream behavior change.\n\nValidation: bun test apps/chat/lib/ai/markdown-joiner-transform.test.ts; bun lint; bun test:types.

## Summary by Sourcery

Enhancements:
- Sort the fields in buffered markdown text stream parts for consistent output formatting without changing runtime behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sorts the fields in the markdown stream part object emitted when buffered markdown is flushed. The existing transform test asserts the same field values, and downstream consumers read fields by name, so this is a style-only change with no runtime or stream behavior differences.

<sup>Written for commit 22a6bea5c5fcbaaf82966c0b466199025362508f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

