### PR TITLE
refactor: clear component declaration and syntax lint

### DIFF
--- a/apps/chat/components/ai-elements/context.tsx
+++ b/apps/chat/components/ai-elements/context.tsx
@@ -51,14 +51,7 @@ export const Context = ({
   modelId,
   ...props
 }: ContextProps) => (
-  <ContextContext.Provider
-    value={{
-      usedTokens,
-      maxTokens,
-      usage,
-      modelId,
-    }}
-  >
+  <ContextContext.Provider value={{ maxTokens, modelId, usage, usedTokens }}>
     <HoverCard closeDelay={0} openDelay={0} {...props} />
   </ContextContext.Provider>
 );
@@ -110,8 +103,8 @@ export const ContextTrigger = ({ children, ...props }: ContextTriggerProps) => {
   const { usedTokens, maxTokens } = useContextValue();
   const usedPercent = usedTokens / maxTokens;
   const renderedPercent = new Intl.NumberFormat("en-US", {
-    style: "percent",
     maximumFractionDigits: 1,
+    style: "percent",
   }).format(usedPercent);
 
   return (
@@ -150,8 +143,8 @@ export const ContextContentHeader = ({
   const { usedTokens, maxTokens } = useContextValue();
   const usedPercent = usedTokens / maxTokens;
   const displayPct = new Intl.NumberFormat("en-US", {
-    style: "percent",
     maximumFractionDigits: 1,
+    style: "percent",
   }).format(usedPercent);
   const used = new Intl.NumberFormat("en-US", {
     notation: "compact",
@@ -209,8 +202,8 @@ export const ContextContentFooter = ({
       }).costUSD?.totalUSD
     : undefined;
   const totalCost = new Intl.NumberFormat("en-US", {
-    style: "currency",
     currency: "USD",
+    style: "currency",
   }).format(costUSD ?? 0);
 
   return (
@@ -232,6 +225,25 @@ export const ContextContentFooter = ({
 };
 
 export type ContextInputUsageProps = ComponentProps<"div">;
+
+const TokensWithCost = ({
+  tokens,
+  costText,
+}: {
+  tokens?: number;
+  costText?: string;
+}) => (
+  <span>
+    {tokens === undefined
+      ? "—"
+      : new Intl.NumberFormat("en-US", {
+          notation: "compact",
+        }).format(tokens)}
+    {costText ? (
+      <span className="text-muted-foreground ml-2">• {costText}</span>
+    ) : null}
+  </span>
+);
 
 export const ContextInputUsage = ({
   className,
@@ -256,8 +268,8 @@ export const ContextInputUsage = ({
       }).costUSD?.totalUSD
     : undefined;
   const inputCostText = new Intl.NumberFormat("en-US", {
-    style: "currency",
     currency: "USD",
+    style: "currency",
   }).format(inputCost ?? 0);
 
   return (
@@ -296,8 +308,8 @@ export const ContextOutputUsage = ({
       }).costUSD?.totalUSD
     : undefined;
   const outputCostText = new Intl.NumberFormat("en-US", {
-    style: "currency",
     currency: "USD",
+    style: "currency",
   }).format(outputCost ?? 0);
 
   return (
@@ -336,8 +348,8 @@ export const ContextReasoningUsage = ({
       }).costUSD?.totalUSD
     : undefined;
   const reasoningCostText = new Intl.NumberFormat("en-US", {
-    style: "currency",
     currency: "USD",
+    style: "currency",
   }).format(reasoningCost ?? 0);
 
   return (
@@ -376,8 +388,8 @@ export const ContextCacheUsage = ({
       }).costUSD?.totalUSD
     : undefined;
   const cacheCostText = new Intl.NumberFormat("en-US", {
-    style: "currency",
     currency: "USD",
+    style: "currency",
   }).format(cacheCost ?? 0);
 
   return (
@@ -390,22 +402,3 @@ export const ContextCacheUsage = ({
     </div>
   );
 };
-
-const TokensWithCost = ({
-  tokens,
-  costText,
-}: {
-  tokens?: number;
-  costText?: string;
-}) => (
-  <span>
-    {tokens === undefined
-      ? "—"
-      : new Intl.NumberFormat("en-US", {
-          notation: "compact",
-        }).format(tokens)}
-    {costText ? (
-      <span className="text-muted-foreground ml-2">• {costText}</span>
-    ) : null}
-  </span>
-);

--- a/apps/chat/components/ai-elements/prompt-input.tsx
+++ b/apps/chat/components/ai-elements/prompt-input.tsx
@@ -269,6 +269,21 @@ export type PromptInputAttachmentProps = HTMLAttributes<HTMLDivElement> & {
   className?: string;
 };
 
+export const PromptInputHoverCard = ({
+  openDelay = 0,
+  closeDelay = 0,
+  ...props
+}: PromptInputHoverCardProps) => (
+  <HoverCard closeDelay={closeDelay} openDelay={openDelay} {...props} />
+);
+
+export const PromptInputHoverCardContent = ({
+  align = "start",
+  ...props
+}: PromptInputHoverCardContentProps) => (
+  <HoverCardContent align={align} {...props} />
+);
+
 export const PromptInputAttachment = ({
   data,
   className,
@@ -581,7 +596,9 @@ export const PromptInput = ({
 
   // Let provider know about our hidden file input so external menus can call openFileDialog()
   useEffect(() => {
-    if (!usingProvider) return;
+    if (!usingProvider) {
+      return;
+    }
     controller.__registerFileInput(inputRef, () => inputRef.current?.click());
   }, [usingProvider, controller]);
 
@@ -596,7 +613,9 @@ export const PromptInput = ({
   // Attach drop handlers on nearest form and document (opt-in)
   useEffect(() => {
     const form = formRef.current;
-    if (!form) return;
+    if (!form) {
+      return;
+    }
 
     const onDragOver = (e: DragEvent) => {
       if (e.dataTransfer?.types?.includes("Files")) {
@@ -620,7 +639,9 @@ export const PromptInput = ({
   }, [add]);
 
   useEffect(() => {
-    if (!globalDrop) return;
+    if (!globalDrop) {
+      return;
+    }
 
     const onDragOver = (e: DragEvent) => {
       if (e.dataTransfer?.types?.includes("Files")) {
@@ -647,7 +668,9 @@ export const PromptInput = ({
     () => () => {
       if (!usingProvider) {
         for (const f of files) {
-          if (f.url) URL.revokeObjectURL(f.url);
+          if (f.url) {
+            URL.revokeObjectURL(f.url);
+          }
         }
       }
     },
@@ -1241,14 +1264,6 @@ export const PromptInputSelectValue = ({
 
 export type PromptInputHoverCardProps = ComponentProps<typeof HoverCard>;
 
-export const PromptInputHoverCard = ({
-  openDelay = 0,
-  closeDelay = 0,
-  ...props
-}: PromptInputHoverCardProps) => (
-  <HoverCard closeDelay={closeDelay} openDelay={openDelay} {...props} />
-);
-
 export type PromptInputHoverCardTriggerProps = ComponentProps<
   typeof HoverCardTrigger
 >;
@@ -1260,13 +1275,6 @@ export const PromptInputHoverCardTrigger = (
 export type PromptInputHoverCardContentProps = ComponentProps<
   typeof HoverCardContent
 >;
-
-export const PromptInputHoverCardContent = ({
-  align = "start",
-  ...props
-}: PromptInputHoverCardContentProps) => (
-  <HoverCardContent align={align} {...props} />
-);
 
 export type PromptInputTabsListProps = HTMLAttributes<HTMLDivElement>;
 

--- a/apps/chat/components/artifact-actions.tsx
+++ b/apps/chat/components/artifact-actions.tsx
@@ -79,9 +79,9 @@ const TypedArtifactActions = <M extends ArtifactMetadata>({
     isReadonly,
   };
 
-  function isActionDisabled(action: {
+  const isActionDisabled = (action: {
     isDisabled?: (context: ArtifactActionContext<M>) => boolean;
-  }): boolean {
+  }): boolean => {
     if (isLoading || artifact.status === "streaming") {
       return true;
     }
@@ -89,7 +89,7 @@ const TypedArtifactActions = <M extends ArtifactMetadata>({
       return action.isDisabled(actionContext);
     }
     return false;
-  }
+  };
 
   return (
     <div className="flex flex-row gap-1">

--- a/apps/chat/components/artifact-panel.tsx
+++ b/apps/chat/components/artifact-panel.tsx
@@ -187,7 +187,7 @@ const PureArtifactPanel = ({
     [document, debouncedHandleContentChange, handleContentChange, isReadonly]
   );
 
-  function getDocumentContentById(index: number) {
+  const getDocumentContentById = (index: number) => {
     if (!documents) {
       return "";
     }
@@ -195,7 +195,7 @@ const PureArtifactPanel = ({
       return "";
     }
     return documents[index].content ?? "";
-  }
+  };
 
   const handleVersionChange = (type: "next" | "prev" | "toggle" | "latest") => {
     if (!documents) {

--- a/apps/chat/components/auth-providers.tsx
+++ b/apps/chat/components/auth-providers.tsx
@@ -111,7 +111,7 @@ export const SocialAuthProviders = ({
     return <ElectronBrowserSignIn buttonLabel={electronBrowserLabel} />;
   }
 
-  async function signIn(provider: SocialAuthProvider) {
+  const signIn = async (provider: SocialAuthProvider) => {
     try {
       const result = await authClient.signIn.social({
         provider,
@@ -130,7 +130,7 @@ export const SocialAuthProviders = ({
       console.error(`Failed to start ${provider} sign-in`, error);
       toast.error("Couldn't start sign-in. Please try again.");
     }
-  }
+  };
 
   return (
     <div className="space-y-2">

--- a/apps/chat/components/device-login-page.tsx
+++ b/apps/chat/components/device-login-page.tsx
@@ -20,6 +20,70 @@ type DeviceLoginState = "checking-session" | "transferring" | "waiting-for-app";
 
 const DEVICE_LOGIN_COMPLETED_PARAM = "done";
 
+const DeviceAuthScreen = ({
+  state,
+  onRetry,
+}: {
+  state: "checking-session" | "transferring" | "waiting-for-app";
+  onRetry: () => void;
+}) => {
+  const isLoading = state === "checking-session" || state === "transferring";
+  let title = "You're signed in";
+
+  if (isLoading) {
+    title =
+      state === "checking-session"
+        ? "Checking your session..."
+        : "Opening the desktop app...";
+  }
+
+  return (
+    <div className="bg-background flex min-h-dvh w-screen items-center justify-center">
+      <div className="w-full max-w-sm px-6">
+        <Card>
+          <CardHeader className="text-center">
+            <div className="mb-2 flex justify-center">
+              {isLoading ? (
+                <LoaderCircle className="text-muted-foreground size-8 animate-spin" />
+              ) : (
+                <div className="bg-foreground text-background inline-flex h-14 w-14 items-center justify-center rounded-2xl">
+                  <CheckCircle2 className="size-7" />
+                </div>
+              )}
+            </div>
+            <CardTitle className="text-xl">{title}</CardTitle>
+            {!isLoading && (
+              <CardDescription>
+                You can close this tab and return to {config.appName}.
+              </CardDescription>
+            )}
+          </CardHeader>
+          {!isLoading && (
+            <CardContent className="text-center">
+              <div className="mb-4">
+                <Button asChild className="w-full" variant="outline">
+                  <a href="/">Continue on web</a>
+                </Button>
+              </div>
+              <p className="text-muted-foreground/60 text-xs">
+                Didn&apos;t open?{" "}
+                <Button
+                  className="text-muted-foreground/60 hover:text-muted-foreground h-auto p-0 text-xs underline underline-offset-2 hover:no-underline"
+                  onClick={onRetry}
+                  type="button"
+                  variant="link"
+                >
+                  Try again
+                </Button>
+              </p>
+            </CardContent>
+          )}
+        </Card>
+      </div>
+    </div>
+  );
+};
+
 export const DeviceLoginPage = () => {
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -124,69 +188,5 @@ export const DeviceLoginPage = () => {
       }}
       state={state}
     />
-  );
-};
-
-const DeviceAuthScreen = ({
-  state,
-  onRetry,
-}: {
-  state: "checking-session" | "transferring" | "waiting-for-app";
-  onRetry: () => void;
-}) => {
-  const isLoading = state === "checking-session" || state === "transferring";
-  let title = "You're signed in";
-
-  if (isLoading) {
-    title =
-      state === "checking-session"
-        ? "Checking your session..."
-        : "Opening the desktop app...";
-  }
-
-  return (
-    <div className="bg-background flex min-h-dvh w-screen items-center justify-center">
-      <div className="w-full max-w-sm px-6">
-        <Card>
-          <CardHeader className="text-center">
-            <div className="mb-2 flex justify-center">
-              {isLoading ? (
-                <LoaderCircle className="text-muted-foreground size-8 animate-spin" />
-              ) : (
-                <div className="bg-foreground text-background inline-flex h-14 w-14 items-center justify-center rounded-2xl">
-                  <CheckCircle2 className="size-7" />
-                </div>
-              )}
-            </div>
-            <CardTitle className="text-xl">{title}</CardTitle>
-            {!isLoading && (
-              <CardDescription>
-                You can close this tab and return to {config.appName}.
-              </CardDescription>
-            )}
-          </CardHeader>
-          {!isLoading && (
-            <CardContent className="text-center">
-              <div className="mb-4">
-                <Button asChild className="w-full" variant="outline">
-                  <a href="/">Continue on web</a>
-                </Button>
-              </div>
-              <p className="text-muted-foreground/60 text-xs">
-                Didn&apos;t open?{" "}
-                <Button
-                  className="text-muted-foreground/60 hover:text-muted-foreground h-auto p-0 text-xs underline underline-offset-2 hover:no-underline"
-                  onClick={onRetry}
-                  type="button"
-                  variant="link"
-                >
-                  Try again
-                </Button>
-              </p>
-            </CardContent>
-          )}
-        </Card>
-      </div>
-    </div>
   );
 };

--- a/apps/chat/components/electron-auth-handler.tsx
+++ b/apps/chat/components/electron-auth-handler.tsx
@@ -9,6 +9,83 @@ import { Button } from "@/components/ui/button";
 import authClient from "@/lib/auth-client";
 import { config } from "@/lib/config";
 
+const ElectronAuthOverlay = ({
+  state,
+}: {
+  state: ElectronRendererAuthState;
+}) => {
+  const [isDismissed, setIsDismissed] = useState(false);
+
+  if (state.status === "idle" || !state.message) {
+    return null;
+  }
+
+  const isLoading =
+    state.status === "awaiting-browser" || state.status === "finishing";
+  const canCancel = state.status === "awaiting-browser";
+  let detailMessage: string;
+
+  if (state.status === "awaiting-browser") {
+    detailMessage = "Complete sign-in in your browser, then come back here.";
+  } else if (state.status === "finishing") {
+    detailMessage =
+      "Your browser has returned to ChatJS. We're finalizing the session now.";
+  } else {
+    detailMessage =
+      state.detail || "If nothing changes, try the browser flow again.";
+  }
+
+  if (!isLoading && isDismissed) {
+    return null;
+  }
+
+  return (
+    <div className="bg-background/90 pointer-events-auto fixed inset-0 z-[999999] flex items-center justify-center px-4 backdrop-blur-sm">
+      <div className="bg-background w-full max-w-sm rounded-2xl border p-6 shadow-2xl">
+        <div className="flex items-start gap-3">
+          <div className="text-muted-foreground mt-0.5">
+            {isLoading ? (
+              <LoaderCircle className="size-5 animate-spin" />
+            ) : (
+              <AlertCircle className="size-5 text-amber-600" />
+            )}
+          </div>
+          <div className="space-y-2">
+            <p className="font-medium">{state.message}</p>
+            <p className="text-muted-foreground text-sm">{detailMessage}</p>
+            {canCancel ? (
+              <Button
+                className="mt-2"
+                onClick={() => {
+                  window.electronAPI?.cancelAuthFlow?.().catch((error) => {
+                    console.error("Failed to cancel Electron auth flow", error);
+                  });
+                }}
+                size="sm"
+                type="button"
+                variant="outline"
+              >
+                Go back
+              </Button>
+            ) : null}
+            {isLoading ? null : (
+              <Button
+                className="mt-2"
+                onClick={() => setIsDismissed(true)}
+                size="sm"
+                type="button"
+                variant="outline"
+              >
+                Dismiss
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
 /**
  * Handles the electron auth redirect after OAuth completes in the browser.
  * When the user finishes OAuth, `ensureElectronRedirect` detects the
@@ -109,81 +186,4 @@ export const ElectronAuthHandler = () => {
   }`;
 
   return <ElectronAuthOverlay key={overlayKey} state={authState} />;
-};
-
-const ElectronAuthOverlay = ({
-  state,
-}: {
-  state: ElectronRendererAuthState;
-}) => {
-  const [isDismissed, setIsDismissed] = useState(false);
-
-  if (state.status === "idle" || !state.message) {
-    return null;
-  }
-
-  const isLoading =
-    state.status === "awaiting-browser" || state.status === "finishing";
-  const canCancel = state.status === "awaiting-browser";
-  let detailMessage: string;
-
-  if (state.status === "awaiting-browser") {
-    detailMessage = "Complete sign-in in your browser, then come back here.";
-  } else if (state.status === "finishing") {
-    detailMessage =
-      "Your browser has returned to ChatJS. We're finalizing the session now.";
-  } else {
-    detailMessage =
-      state.detail || "If nothing changes, try the browser flow again.";
-  }
-
-  if (!isLoading && isDismissed) {
-    return null;
-  }
-
-  return (
-    <div className="bg-background/90 pointer-events-auto fixed inset-0 z-[999999] flex items-center justify-center px-4 backdrop-blur-sm">
-      <div className="bg-background w-full max-w-sm rounded-2xl border p-6 shadow-2xl">
-        <div className="flex items-start gap-3">
-          <div className="text-muted-foreground mt-0.5">
-            {isLoading ? (
-              <LoaderCircle className="size-5 animate-spin" />
-            ) : (
-              <AlertCircle className="size-5 text-amber-600" />
-            )}
-          </div>
-          <div className="space-y-2">
-            <p className="font-medium">{state.message}</p>
-            <p className="text-muted-foreground text-sm">{detailMessage}</p>
-            {canCancel ? (
-              <Button
-                className="mt-2"
-                onClick={() => {
-                  window.electronAPI?.cancelAuthFlow?.().catch((error) => {
-                    console.error("Failed to cancel Electron auth flow", error);
-                  });
-                }}
-                size="sm"
-                type="button"
-                variant="outline"
-              >
-                Go back
-              </Button>
-            ) : null}
-            {isLoading ? null : (
-              <Button
-                className="mt-2"
-                onClick={() => setIsDismissed(true)}
-                size="sm"
-                type="button"
-                variant="outline"
-              >
-                Dismiss
-              </Button>
-            )}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
 };

--- a/apps/chat/components/feedback-actions.tsx
+++ b/apps/chat/components/feedback-actions.tsx
@@ -14,6 +14,19 @@ import { MessageAction as Action } from "./ai-elements/message";
 import { RetryButton } from "./retry-button";
 import { Tag } from "./tag";
 
+const SelectedModelId = ({ messageId }: { messageId: string }) => {
+  const message = useMessageById<ChatMessage>(messageId);
+  const selectedModelId = getPrimarySelectedModelId(
+    message?.metadata?.selectedModel
+  );
+
+  return selectedModelId ? (
+    <div className="ml-2 flex items-center">
+      <Tag>{selectedModelId}</Tag>
+    </div>
+  ) : null;
+};
+
 export const FeedbackActions = ({
   chatId,
   messageId,
@@ -102,17 +115,4 @@ export const FeedbackActions = ({
       <SelectedModelId messageId={messageId} />
     </>
   );
-};
-
-const SelectedModelId = ({ messageId }: { messageId: string }) => {
-  const message = useMessageById<ChatMessage>(messageId);
-  const selectedModelId = getPrimarySelectedModelId(
-    message?.metadata?.selectedModel
-  );
-
-  return selectedModelId ? (
-    <div className="ml-2 flex items-center">
-      <Tag>{selectedModelId}</Tag>
-    </div>
-  ) : null;
 };

--- a/apps/chat/components/followup-suggestions.tsx
+++ b/apps/chat/components/followup-suggestions.tsx
@@ -91,6 +91,23 @@ const FollowUpSuggestions = ({
   );
 };
 
+const FollowUpSuggestionsPart = ({
+  messageId,
+  partIdx,
+}: {
+  messageId: string;
+  partIdx: number;
+}) => {
+  const part = useMessagePartByPartIdx(
+    messageId,
+    partIdx,
+    "data-followupSuggestions"
+  );
+  const { data } = part;
+
+  return <FollowUpSuggestions suggestions={data.suggestions} />;
+};
+
 export const FollowUpSuggestionsParts = ({
   messageId,
 }: {
@@ -109,21 +126,4 @@ export const FollowUpSuggestionsParts = ({
     return null;
   }
   return <FollowUpSuggestionsPart messageId={messageId} partIdx={partIdx} />;
-};
-
-const FollowUpSuggestionsPart = ({
-  messageId,
-  partIdx,
-}: {
-  messageId: string;
-  partIdx: number;
-}) => {
-  const part = useMessagePartByPartIdx(
-    messageId,
-    partIdx,
-    "data-followupSuggestions"
-  );
-  const { data } = part;
-
-  return <FollowUpSuggestions suggestions={data.suggestions} />;
 };

--- a/apps/chat/components/get-url-without-params.ts
+++ b/apps/chat/components/get-url-without-params.ts
@@ -1,4 +1,4 @@
-export function getUrlWithoutParams(url: string): string {
+export const getUrlWithoutParams = (url: string): string => {
   try {
     const parsed = new URL(url);
     return `${parsed.origin}${parsed.pathname}`;
@@ -7,4 +7,4 @@ export function getUrlWithoutParams(url: string): string {
     const qIndex = url.indexOf("?");
     return qIndex === -1 ? url : url.slice(0, qIndex);
   }
-}
+};

--- a/apps/chat/components/header-breadcrumb.tsx
+++ b/apps/chat/components/header-breadcrumb.tsx
@@ -43,6 +43,100 @@ interface HeaderBreadcrumbProps {
   user?: Session["user"];
 }
 
+const useSyncDraftValue = ({
+  isEditing,
+  setDraft,
+  value,
+}: {
+  isEditing: boolean;
+  setDraft: (val: string) => void;
+  value: string | undefined;
+}) => {
+  useEffect(() => {
+    if (!isEditing) {
+      setDraft(value ?? "");
+    }
+  }, [isEditing, setDraft, value]);
+};
+
+const performChatRename = async ({
+  chatId,
+  chatTitleDraft,
+  privateChat,
+  renameChat,
+  setChatTitleDraft,
+  setIsChatEditing,
+}: PerformChatRenameArgs) => {
+  if (!privateChat) {
+    setIsChatEditing(false);
+    return;
+  }
+  const trimmed = chatTitleDraft.trim();
+  if (!trimmed || trimmed === privateChat.title) {
+    setIsChatEditing(false);
+    setChatTitleDraft(privateChat.title ?? "");
+    return;
+  }
+  try {
+    await renameChat({ chatId, title: trimmed });
+    toast.success("Chat renamed successfully");
+  } catch {
+    // Errors handled in hook
+  } finally {
+    setIsChatEditing(false);
+  }
+};
+
+const createInputKeyDownHandler =
+  ({ onEnter, onEscape }: InputKeyHandlerOptions) =>
+  (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      onEnter();
+      return;
+    }
+    if (event.key === "Escape") {
+      onEscape();
+    }
+  };
+
+const ProjectBreadcrumb = ({
+  projectLabel,
+  projectId,
+  projectIcon,
+  projectColor,
+}: {
+  projectLabel?: string;
+  projectId: string | null;
+  projectIcon?: ProjectIconName;
+  projectColor?: ProjectColorName;
+}) => {
+  if (!(projectLabel && projectId)) {
+    return null;
+  }
+
+  return (
+    <>
+      <BreadcrumbItem>
+        <BreadcrumbLink asChild>
+          <InternalLink
+            aria-label={projectLabel}
+            className="flex items-center"
+            href={`/project/${projectId}`}
+            title={projectLabel}
+          >
+            {projectIcon && projectColor ? (
+              <ProjectIcon color={projectColor} icon={projectIcon} size={16} />
+            ) : (
+              projectLabel
+            )}
+          </InternalLink>
+        </BreadcrumbLink>
+      </BreadcrumbItem>
+      <BreadcrumbSeparator />
+    </>
+  );
+};
+
 export const HeaderBreadcrumb = ({
   chat,
   chatId,
@@ -144,23 +238,21 @@ export const HeaderBreadcrumb = ({
             projectLabel={projectLabel}
           />
           <BreadcrumbItem className="min-w-0">
-            {
-              <PureChatBreadcrumb
-                canManageChat={canManageChat}
-                chatLabel={chatLabel}
-                chatTitleDraft={chatTitleDraft}
-                handleChatInputKeyDown={handleChatInputKeyDown}
-                handleChatRename={handleChatRename}
-                isChatEditing={isChatEditing}
-                isPinned={!!chat?.isPinned}
-                onChatTitleChange={(value: string) => setChatTitleDraft(value)}
-                onShare={() => setShowShareDialog(true)}
-                onTogglePin={handlePinToggle}
-                openChatDeleteDialog={openChatDeleteDialog}
-                showShare={!!hasMessages}
-                startChatRename={startChatRename}
-              />
-            }
+            <PureChatBreadcrumb
+              canManageChat={canManageChat}
+              chatLabel={chatLabel}
+              chatTitleDraft={chatTitleDraft}
+              handleChatInputKeyDown={handleChatInputKeyDown}
+              handleChatRename={handleChatRename}
+              isChatEditing={isChatEditing}
+              isPinned={!!chat?.isPinned}
+              onChatTitleChange={(value: string) => setChatTitleDraft(value)}
+              onShare={() => setShowShareDialog(true)}
+              onTogglePin={handlePinToggle}
+              openChatDeleteDialog={openChatDeleteDialog}
+              showShare={!!hasMessages}
+              startChatRename={startChatRename}
+            />
           </BreadcrumbItem>
         </BreadcrumbList>
       </Breadcrumb>
@@ -266,101 +358,7 @@ interface PerformChatRenameArgs {
   setIsChatEditing: (value: boolean) => void;
 }
 
-const performChatRename = async ({
-  chatId,
-  chatTitleDraft,
-  privateChat,
-  renameChat,
-  setChatTitleDraft,
-  setIsChatEditing,
-}: PerformChatRenameArgs) => {
-  if (!privateChat) {
-    setIsChatEditing(false);
-    return;
-  }
-  const trimmed = chatTitleDraft.trim();
-  if (!trimmed || trimmed === privateChat.title) {
-    setIsChatEditing(false);
-    setChatTitleDraft(privateChat.title ?? "");
-    return;
-  }
-  try {
-    await renameChat({ chatId, title: trimmed });
-    toast.success("Chat renamed successfully");
-  } catch {
-    // Errors handled in hook
-  } finally {
-    setIsChatEditing(false);
-  }
-};
-
 interface InputKeyHandlerOptions {
   onEnter: () => void;
   onEscape: () => void;
 }
-
-const createInputKeyDownHandler =
-  ({ onEnter, onEscape }: InputKeyHandlerOptions) =>
-  (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === "Enter") {
-      onEnter();
-      return;
-    }
-    if (event.key === "Escape") {
-      onEscape();
-    }
-  };
-
-const useSyncDraftValue = ({
-  isEditing,
-  setDraft,
-  value,
-}: {
-  isEditing: boolean;
-  setDraft: (val: string) => void;
-  value: string | undefined;
-}) => {
-  useEffect(() => {
-    if (!isEditing) {
-      setDraft(value ?? "");
-    }
-  }, [isEditing, setDraft, value]);
-};
-
-const ProjectBreadcrumb = ({
-  projectLabel,
-  projectId,
-  projectIcon,
-  projectColor,
-}: {
-  projectLabel?: string;
-  projectId: string | null;
-  projectIcon?: ProjectIconName;
-  projectColor?: ProjectColorName;
-}) => {
-  if (!(projectLabel && projectId)) {
-    return null;
-  }
-
-  return (
-    <>
-      <BreadcrumbItem>
-        <BreadcrumbLink asChild>
-          <InternalLink
-            aria-label={projectLabel}
-            className="flex items-center"
-            href={`/project/${projectId}`}
-            title={projectLabel}
-          >
-            {projectIcon && projectColor ? (
-              <ProjectIcon color={projectColor} icon={projectIcon} size={16} />
-            ) : (
-              projectLabel
-            )}
-          </InternalLink>
-        </BreadcrumbLink>
-      </BreadcrumbItem>
-      <BreadcrumbSeparator />
-    </>
-  );
-};

--- a/apps/chat/components/parallel-response-status.ts
+++ b/apps/chat/components/parallel-response-status.ts
@@ -13,10 +13,10 @@ interface ParallelResponseStatusMessage {
   };
 }
 
-export function getParallelResponseLifecycle(
+export const getParallelResponseLifecycle = (
   message: ParallelResponseStatusMessage | null,
   runStatus?: ChatStatus
-): ParallelResponseLifecycle {
+): ParallelResponseLifecycle => {
   if (!message) {
     if (runStatus === "error") {
       return "error";
@@ -33,12 +33,12 @@ export function getParallelResponseLifecycle(
     return "generating";
   }
   return "complete";
-}
+};
 
-export function getStatusLabel(
+export const getStatusLabel = (
   isSelected: boolean,
   lifecycle: ParallelResponseLifecycle
-): string {
+): string => {
   if (lifecycle !== "complete") {
     if (lifecycle === "stopped") {
       return "Stopped";
@@ -49,16 +49,16 @@ export function getStatusLabel(
     return "Generating...";
   }
   return isSelected ? "Selected" : "Task completed";
-}
+};
 
-export function getResponseAwareStatus(
+export const getResponseAwareStatus = (
   status: ChatStatus,
   message: ParallelResponseStatusMessage | null
-): ChatStatus {
+): ChatStatus => {
   const activeStreamId = message?.metadata.activeStreamId;
   if (!activeStreamId || status !== "ready") {
     return status;
   }
 
   return activeStreamId.startsWith("pending:") ? "submitted" : "streaming";
-}
+};

--- a/apps/chat/components/part/document-common.tsx
+++ b/apps/chat/components/part/document-common.tsx
@@ -146,7 +146,9 @@ const PureDocumentToolCall = ({
         </div>
       </div>
 
-      <div className="mt-1 animate-spin">{<Loader2 size={16} />}</div>
+      <div className="mt-1 animate-spin">
+        <Loader2 size={16} />
+      </div>
     </button>
   );
 };

--- a/apps/chat/components/part/document-preview.tsx
+++ b/apps/chat/components/part/document-preview.tsx
@@ -58,6 +58,105 @@ interface DocumentPreviewProps {
   type?: "create" | "update";
 }
 
+const LoadingSkeleton = ({
+  artifactKind: _artifactKind,
+}: {
+  artifactKind: ArtifactKind;
+}) => (
+  <div className="w-full">
+    <div className="bg-muted flex h-[57px] flex-row items-center justify-between gap-2 rounded-t-2xl border border-b-0 p-4">
+      <div className="flex flex-row items-center gap-3">
+        <div className="text-muted-foreground">
+          <div className="bg-muted-foreground/20 size-4 animate-pulse rounded-md" />
+        </div>
+        <div className="bg-muted-foreground/20 h-4 w-24 animate-pulse rounded-lg" />
+      </div>
+      <div>
+        <Maximize size={16} />
+      </div>
+    </div>
+
+    <div className="bg-muted overflow-y-scroll rounded-b-2xl border border-t-0 p-8 pt-4">
+      <InlineDocumentSkeleton />
+    </div>
+  </div>
+);
+
+const DocumentContent = ({ document }: { document: Document }) => {
+  const { artifact } = useArtifact();
+
+  const containerClassName = cn(
+    "bg-muted h-[257px] overflow-y-scroll rounded-b-2xl border border-t-0",
+    {
+      "p-4 sm:px-14 sm:py-16": document.kind === "text",
+      "p-0": document.kind === "code",
+    }
+  );
+
+  const commonProps = {
+    content: document.content ?? "",
+    isCurrentVersion: true,
+    currentVersionIndex: 0,
+    status: artifact.status,
+    saveContent: () => {
+      // No-op for preview mode
+    },
+  };
+
+  return (
+    <div className={containerClassName}>
+      {(() => {
+        if (document.kind === "text") {
+          return (
+            <Editor
+              {...commonProps}
+              onSaveContent={() => {
+                // No-op for preview mode
+              }}
+            />
+          );
+        }
+        if (document.kind === "code") {
+          return (
+            <div className="relative flex w-full flex-1">
+              <div className="absolute inset-0">
+                <CodeEditor
+                  {...commonProps}
+                  onSaveContent={() => {
+                    // No-op for preview mode
+                  }}
+                />
+              </div>
+            </div>
+          );
+        }
+        if (document.kind === "sheet") {
+          return (
+            <div className="relative flex size-full flex-1 p-4">
+              <div className="absolute inset-0">
+                <SpreadsheetEditor {...commonProps} />
+              </div>
+            </div>
+          );
+        }
+        if (document.kind === "image") {
+          return (
+            <ImageEditor
+              content={document.content ?? ""}
+              currentVersionIndex={0}
+              isCurrentVersion={true}
+              isInline={true}
+              status={artifact.status}
+              title={document.title}
+            />
+          );
+        }
+        return null;
+      })()}
+    </div>
+  );
+};
+
 export const DocumentPreview = ({
   isReadonly,
   output,
@@ -151,30 +250,6 @@ export const DocumentPreview = ({
     </div>
   );
 };
-
-const LoadingSkeleton = ({
-  artifactKind: _artifactKind,
-}: {
-  artifactKind: ArtifactKind;
-}) => (
-  <div className="w-full">
-    <div className="bg-muted flex h-[57px] flex-row items-center justify-between gap-2 rounded-t-2xl border border-b-0 p-4">
-      <div className="flex flex-row items-center gap-3">
-        <div className="text-muted-foreground">
-          <div className="bg-muted-foreground/20 size-4 animate-pulse rounded-md" />
-        </div>
-        <div className="bg-muted-foreground/20 h-4 w-24 animate-pulse rounded-lg" />
-      </div>
-      <div>
-        <Maximize size={16} />
-      </div>
-    </div>
-
-    <div className="bg-muted overflow-y-scroll rounded-b-2xl border border-t-0 p-8 pt-4">
-      <InlineDocumentSkeleton />
-    </div>
-  </div>
-);
 
 const PureHitboxLayer = ({
   hitboxRef,
@@ -297,78 +372,3 @@ const DocumentHeader = memo(PureDocumentHeader, (prevProps, nextProps) => {
 
   return true;
 });
-
-const DocumentContent = ({ document }: { document: Document }) => {
-  const { artifact } = useArtifact();
-
-  const containerClassName = cn(
-    "bg-muted h-[257px] overflow-y-scroll rounded-b-2xl border border-t-0",
-    {
-      "p-4 sm:px-14 sm:py-16": document.kind === "text",
-      "p-0": document.kind === "code",
-    }
-  );
-
-  const commonProps = {
-    content: document.content ?? "",
-    isCurrentVersion: true,
-    currentVersionIndex: 0,
-    status: artifact.status,
-    saveContent: () => {
-      // No-op for preview mode
-    },
-  };
-
-  return (
-    <div className={containerClassName}>
-      {(() => {
-        if (document.kind === "text") {
-          return (
-            <Editor
-              {...commonProps}
-              onSaveContent={() => {
-                // No-op for preview mode
-              }}
-            />
-          );
-        }
-        if (document.kind === "code") {
-          return (
-            <div className="relative flex w-full flex-1">
-              <div className="absolute inset-0">
-                <CodeEditor
-                  {...commonProps}
-                  onSaveContent={() => {
-                    // No-op for preview mode
-                  }}
-                />
-              </div>
-            </div>
-          );
-        }
-        if (document.kind === "sheet") {
-          return (
-            <div className="relative flex size-full flex-1 p-4">
-              <div className="absolute inset-0">
-                <SpreadsheetEditor {...commonProps} />
-              </div>
-            </div>
-          );
-        }
-        if (document.kind === "image") {
-          return (
-            <ImageEditor
-              content={document.content ?? ""}
-              currentVersionIndex={0}
-              isCurrentVersion={true}
-              isInline={true}
-              status={artifact.status}
-              title={document.title}
-            />
-          );
-        }
-        return null;
-      })()}
-    </div>
-  );
-};

--- a/apps/chat/components/research-tasks.tsx
+++ b/apps/chat/components/research-tasks.tsx
@@ -8,32 +8,18 @@ import type { ResearchUpdate } from "@/tools/platform/research-updates-schema";
 
 import { ResearchTask } from "./research-task";
 
-export const ResearchTasks = ({ updates }: { updates: ResearchUpdate[] }) => (
-  <div className="relative">
-    {updates.map((update, index) => (
-      <StepWrapper
-        isLast={index === updates.length - 1}
-        key={update.toolCallId}
-        update={update}
-      >
-        <ResearchTask
-          isRunning={
-            (update.type === "web" && update.status === "running") ||
-            (index === updates.length - 1 && update.type !== "completed")
-          }
-          minimal={false}
-          update={update}
-        />
-      </StepWrapper>
-    ))}
-  </div>
-);
+const icons: Record<ResearchUpdate["type"], React.ElementType> = {
+  completed: CircleCheck,
+  started: Dot,
+  thoughts: Sparkles,
+  web: FileText,
+  writing: Pencil,
+} as const;
 
-interface StepWrapperProps {
-  children: ReactNode;
-  isLast: boolean;
-  update: ResearchUpdate;
-}
+const StepTypeIcon = ({ update }: { update: ResearchUpdate }) => {
+  const Icon = icons[update.type];
+  return <Icon className="text-muted-foreground h-4 w-4" />;
+};
 
 const StepWrapper = ({ update, children, isLast }: StepWrapperProps) => (
   <div className="flex w-full flex-row items-stretch justify-start gap-2">
@@ -63,15 +49,29 @@ const StepWrapper = ({ update, children, isLast }: StepWrapperProps) => (
   </div>
 );
 
-const icons: Record<ResearchUpdate["type"], React.ElementType> = {
-  web: FileText,
-  started: Dot,
-  completed: CircleCheck,
-  thoughts: Sparkles,
-  writing: Pencil,
-} as const;
+export const ResearchTasks = ({ updates }: { updates: ResearchUpdate[] }) => (
+  <div className="relative">
+    {updates.map((update, index) => (
+      <StepWrapper
+        isLast={index === updates.length - 1}
+        key={update.toolCallId}
+        update={update}
+      >
+        <ResearchTask
+          isRunning={
+            (update.type === "web" && update.status === "running") ||
+            (index === updates.length - 1 && update.type !== "completed")
+          }
+          minimal={false}
+          update={update}
+        />
+      </StepWrapper>
+    ))}
+  </div>
+);
 
-const StepTypeIcon = ({ update }: { update: ResearchUpdate }) => {
-  const Icon = icons[update.type];
-  return <Icon className="text-muted-foreground h-4 w-4" />;
-};
+interface StepWrapperProps {
+  children: ReactNode;
+  isLast: boolean;
+  update: ResearchUpdate;
+}

--- a/apps/chat/components/settings/connectors-settings.tsx
+++ b/apps/chat/components/settings/connectors-settings.tsx
@@ -35,6 +35,186 @@ import { mcpConnectorsSettingsSearchParams } from "@/lib/nuqs/mcp-search-params"
 import type { McpConnectorsDialog } from "@/lib/nuqs/mcp-search-params";
 import { useTRPC } from "@/trpc/react";
 
+const CustomConnectorRow = ({
+  connector,
+  onConnect,
+  onUninstall,
+  onDisconnect,
+  isDisconnecting,
+}: {
+  connector: McpConnector;
+  onConnect: () => void;
+  onUninstall: () => void;
+  onDisconnect: () => void;
+  isDisconnecting: boolean;
+}) => {
+  const trpc = useTRPC();
+
+  const { data: authStatus } = useQuery({
+    ...trpc.mcp.checkAuth.queryOptions({ id: connector.id }),
+    staleTime: 30_000,
+  });
+
+  const { isLoading: isTestingConnection, data: connectionStatus } = useQuery({
+    ...trpc.mcp.testConnection.queryOptions({ id: connector.id }),
+    staleTime: 30_000,
+    retry: false,
+  });
+
+  const needsOAuth = connectionStatus?.needsAuth ?? false;
+  const isConnected = connectionStatus?.status === "connected";
+  const isIncompatible = connectionStatus?.status === "incompatible";
+
+  const statusText = (() => {
+    if (isTestingConnection) {
+      return "Checking connection…";
+    }
+    if (isIncompatible) {
+      return "Incompatible server";
+    }
+    if (needsOAuth) {
+      return "Authorization required";
+    }
+    if (isConnected) {
+      return "Connected";
+    }
+    return connectionStatus?.error ?? "Unable to reach server";
+  })();
+
+  const actionLabel = (() => {
+    if (isTestingConnection) {
+      return "Loading";
+    }
+    if (needsOAuth) {
+      return "Connect";
+    }
+    return "Configure";
+  })();
+
+  const href: `/settings/connectors/${string}` = `/settings/connectors/${connector.id}`;
+
+  const showOAuthButton = needsOAuth && !isIncompatible;
+  const showDetailsButton = !(needsOAuth || isIncompatible);
+
+  return (
+    <div className="flex items-center gap-4 py-3">
+      <div className="flex min-w-0 flex-1 items-center gap-3 overflow-hidden text-left">
+        <ConnectorHeader
+          isCustom
+          name={connector.name}
+          statusText={statusText}
+          type={connector.type}
+          url={connector.url}
+        />
+      </div>
+
+      <div className="flex shrink-0 items-center gap-2">
+        {isIncompatible ? (
+          <Badge className="gap-1" variant="destructive">
+            <AlertTriangle className="size-3" />
+            Error
+          </Badge>
+        ) : null}
+
+        {showOAuthButton ? (
+          <Button disabled={isTestingConnection} onClick={onConnect} size="sm">
+            {isTestingConnection ? (
+              <span className="inline-flex items-center gap-2">
+                <Loader2 className="size-4 animate-spin" />
+                Loading
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-2">
+                Connect
+                <ArrowUpRight className="-mr-1 size-4" />
+              </span>
+            )}
+          </Button>
+        ) : null}
+
+        {showDetailsButton ? (
+          <Button
+            asChild
+            disabled={isTestingConnection}
+            size="sm"
+            variant="outline"
+          >
+            <InternalLink href={href}>
+              {isTestingConnection ? (
+                <span className="inline-flex items-center gap-2">
+                  <Loader2 className="size-4 animate-spin" />
+                  Loading
+                </span>
+              ) : (
+                <span className="inline-flex items-center gap-2">
+                  {actionLabel}
+                </span>
+              )}
+            </InternalLink>
+          </Button>
+        ) : null}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button size="icon" variant="ghost">
+              <MoreHorizontal className="size-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {authStatus?.isAuthenticated ? (
+              <>
+                <DropdownMenuItem
+                  disabled={isDisconnecting}
+                  onClick={onDisconnect}
+                >
+                  Disconnect
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+              </>
+            ) : null}
+            {needsOAuth ? (
+              <>
+                <DropdownMenuItem
+                  onClick={(e) => {
+                    e.preventDefault();
+                    onConnect();
+                  }}
+                >
+                  Connect
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+              </>
+            ) : null}
+            <DropdownMenuItem
+              className="text-destructive focus:text-destructive"
+              onClick={onUninstall}
+            >
+              <Trash2 className="size-4" />
+              Uninstall
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+};
+
+const BuiltInConnectorRow = ({ connector }: { connector: McpConnector }) => {
+  const href: `/settings/connectors/${string}` = `/settings/connectors/${connector.id}`;
+  return (
+    <div className="flex w-full items-center gap-3 py-3 text-left">
+      <ConnectorHeader
+        isCustom={false}
+        name={connector.name}
+        type={connector.type}
+        url={connector.url}
+      />
+      <Button asChild size="sm" variant="outline">
+        <InternalLink href={href}>View</InternalLink>
+      </Button>
+    </div>
+  );
+};
+
 export const ConnectorsSettings = () => {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
@@ -227,185 +407,5 @@ export const ConnectorsSettings = () => {
         open={connectOpen}
       />
     </SettingsPageContent>
-  );
-};
-
-const CustomConnectorRow = ({
-  connector,
-  onConnect,
-  onUninstall,
-  onDisconnect,
-  isDisconnecting,
-}: {
-  connector: McpConnector;
-  onConnect: () => void;
-  onUninstall: () => void;
-  onDisconnect: () => void;
-  isDisconnecting: boolean;
-}) => {
-  const trpc = useTRPC();
-
-  const { data: authStatus } = useQuery({
-    ...trpc.mcp.checkAuth.queryOptions({ id: connector.id }),
-    staleTime: 30_000,
-  });
-
-  const { isLoading: isTestingConnection, data: connectionStatus } = useQuery({
-    ...trpc.mcp.testConnection.queryOptions({ id: connector.id }),
-    staleTime: 30_000,
-    retry: false,
-  });
-
-  const needsOAuth = connectionStatus?.needsAuth ?? false;
-  const isConnected = connectionStatus?.status === "connected";
-  const isIncompatible = connectionStatus?.status === "incompatible";
-
-  const statusText = (() => {
-    if (isTestingConnection) {
-      return "Checking connection…";
-    }
-    if (isIncompatible) {
-      return "Incompatible server";
-    }
-    if (needsOAuth) {
-      return "Authorization required";
-    }
-    if (isConnected) {
-      return "Connected";
-    }
-    return connectionStatus?.error ?? "Unable to reach server";
-  })();
-
-  const actionLabel = (() => {
-    if (isTestingConnection) {
-      return "Loading";
-    }
-    if (needsOAuth) {
-      return "Connect";
-    }
-    return "Configure";
-  })();
-
-  const href: `/settings/connectors/${string}` = `/settings/connectors/${connector.id}`;
-
-  const showOAuthButton = needsOAuth && !isIncompatible;
-  const showDetailsButton = !(needsOAuth || isIncompatible);
-
-  return (
-    <div className="flex items-center gap-4 py-3">
-      <div className="flex min-w-0 flex-1 items-center gap-3 overflow-hidden text-left">
-        <ConnectorHeader
-          isCustom
-          name={connector.name}
-          statusText={statusText}
-          type={connector.type}
-          url={connector.url}
-        />
-      </div>
-
-      <div className="flex shrink-0 items-center gap-2">
-        {isIncompatible ? (
-          <Badge className="gap-1" variant="destructive">
-            <AlertTriangle className="size-3" />
-            Error
-          </Badge>
-        ) : null}
-
-        {showOAuthButton ? (
-          <Button disabled={isTestingConnection} onClick={onConnect} size="sm">
-            {isTestingConnection ? (
-              <span className="inline-flex items-center gap-2">
-                <Loader2 className="size-4 animate-spin" />
-                Loading
-              </span>
-            ) : (
-              <span className="inline-flex items-center gap-2">
-                Connect
-                <ArrowUpRight className="-mr-1 size-4" />
-              </span>
-            )}
-          </Button>
-        ) : null}
-
-        {showDetailsButton ? (
-          <Button
-            asChild
-            disabled={isTestingConnection}
-            size="sm"
-            variant="outline"
-          >
-            <InternalLink href={href}>
-              {isTestingConnection ? (
-                <span className="inline-flex items-center gap-2">
-                  <Loader2 className="size-4 animate-spin" />
-                  Loading
-                </span>
-              ) : (
-                <span className="inline-flex items-center gap-2">
-                  {actionLabel}
-                </span>
-              )}
-            </InternalLink>
-          </Button>
-        ) : null}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button size="icon" variant="ghost">
-              <MoreHorizontal className="size-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {authStatus?.isAuthenticated ? (
-              <>
-                <DropdownMenuItem
-                  disabled={isDisconnecting}
-                  onClick={onDisconnect}
-                >
-                  Disconnect
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-              </>
-            ) : null}
-            {needsOAuth ? (
-              <>
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    e.preventDefault();
-                    onConnect();
-                  }}
-                >
-                  Connect
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-              </>
-            ) : null}
-            <DropdownMenuItem
-              className="text-destructive focus:text-destructive"
-              onClick={onUninstall}
-            >
-              <Trash2 className="size-4" />
-              Uninstall
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-    </div>
-  );
-};
-
-const BuiltInConnectorRow = ({ connector }: { connector: McpConnector }) => {
-  const href: `/settings/connectors/${string}` = `/settings/connectors/${connector.id}`;
-  return (
-    <div className="flex w-full items-center gap-3 py-3 text-left">
-      <ConnectorHeader
-        isCustom={false}
-        name={connector.name}
-        type={connector.type}
-        url={connector.url}
-      />
-      <Button asChild size="sm" variant="outline">
-        <InternalLink href={href}>View</InternalLink>
-      </Button>
-    </div>
   );
 };

--- a/apps/chat/components/settings/mcp-create-dialog.tsx
+++ b/apps/chat/components/settings/mcp-create-dialog.tsx
@@ -273,7 +273,7 @@ export const McpCreateDialog = ({
             <p className="text-muted-foreground text-xs leading-relaxed">
               Only use connectors from developers you trust. {appName} does not
               control which tools developers make available and cannot verify
-              that they will work as intended or that they won't change.
+              that they will work as intended or that they won&apos;t change.
             </p>
 
             <DialogFooter>

--- a/apps/chat/components/settings/mcp-details-page.tsx
+++ b/apps/chat/components/settings/mcp-details-page.tsx
@@ -55,6 +55,143 @@ const formatMcpError = (message: string): string => {
   return message;
 };
 
+const DetailsSection = ({
+  title,
+  icon,
+  items,
+}: {
+  title: string;
+  icon: React.ReactNode;
+  items: string[];
+}) => {
+  const count = items.length;
+
+  return (
+    <div className="bg-card rounded-lg border p-3">
+      <div className="flex items-center gap-2">
+        <div className="text-muted-foreground">{icon}</div>
+        <span className="text-sm font-medium">{title}</span>
+        <span className="text-muted-foreground text-xs">({count})</span>
+      </div>
+      <Separator className="my-3" />
+      {count === 0 ? (
+        <p className="text-muted-foreground text-xs italic">None available</p>
+      ) : (
+        <div className="flex flex-wrap gap-1.5">
+          {items.map((name) => (
+            <span
+              className="bg-muted rounded-md px-2 py-1 font-mono text-xs"
+              key={name}
+              title={name}
+            >
+              {name}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const DiscoveryContent = ({
+  isLoading,
+  showConnectButton,
+  onConnect,
+  isIncompatible,
+  connectionError,
+  discoveryError,
+  needsOAuth,
+  showDiscovery,
+  discovery,
+}: {
+  isLoading: boolean;
+  showConnectButton: boolean;
+  onConnect: () => void;
+  isIncompatible: boolean;
+  connectionError?: string;
+  discoveryError: { message: string } | null;
+  needsOAuth: boolean;
+  showDiscovery: boolean;
+  discovery: {
+    tools: { name: string }[];
+    resources: { name: string }[];
+    prompts: { name: string }[];
+  } | null;
+}) => {
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="text-muted-foreground size-6 animate-spin" />
+      </div>
+    );
+  }
+
+  if (showConnectButton) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-12 text-center">
+        <p className="text-sm font-medium">Authorization required</p>
+        <p className="text-muted-foreground max-w-xs text-xs">
+          Connect this connector to access its tools and resources.
+        </p>
+        <Button onClick={onConnect}>Connect</Button>
+      </div>
+    );
+  }
+
+  if (isIncompatible) {
+    return (
+      <div className="flex flex-col items-center gap-2 py-12 text-center">
+        <AlertCircle className="text-destructive size-6" />
+        <p className="text-sm font-medium">Incompatible server</p>
+        <p className="text-muted-foreground max-w-xs text-xs">
+          {connectionError ??
+            "This server requires pre-configured OAuth credentials."}
+        </p>
+      </div>
+    );
+  }
+
+  if (discoveryError && !needsOAuth) {
+    return (
+      <div className="flex flex-col items-center gap-2 py-12 text-center">
+        <AlertCircle className="text-destructive size-6" />
+        <p className="text-muted-foreground text-sm">
+          Failed to connect to MCP server
+        </p>
+        <p className="text-muted-foreground max-w-xs text-xs">
+          {formatMcpError(discoveryError.message)}
+        </p>
+      </div>
+    );
+  }
+
+  if (showDiscovery && discovery) {
+    return (
+      <ScrollArea className="max-h-[60vh]">
+        <div className="space-y-4">
+          <DetailsSection
+            icon={<Wrench className="size-4" />}
+            items={discovery.tools.map((t) => t.name)}
+            title="Tools"
+          />
+          <DetailsSection
+            icon={<FileText className="size-4" />}
+            items={discovery.resources.map((r) => r.name)}
+            title="Resources"
+          />
+          <DetailsSection
+            icon={<BookText className="size-4" />}
+            items={discovery.prompts.map((p) => p.name)}
+            title="Prompts"
+          />
+        </div>
+      </ScrollArea>
+    );
+  }
+
+  return null;
+};
+
 export const McpDetailsPage = ({ connectorId }: { connectorId: string }) => {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
@@ -320,142 +457,5 @@ export const McpDetailsPage = ({ connectorId }: { connectorId: string }) => {
         open={connectOpen}
       />
     </SettingsPageContent>
-  );
-};
-
-const DiscoveryContent = ({
-  isLoading,
-  showConnectButton,
-  onConnect,
-  isIncompatible,
-  connectionError,
-  discoveryError,
-  needsOAuth,
-  showDiscovery,
-  discovery,
-}: {
-  isLoading: boolean;
-  showConnectButton: boolean;
-  onConnect: () => void;
-  isIncompatible: boolean;
-  connectionError?: string;
-  discoveryError: { message: string } | null;
-  needsOAuth: boolean;
-  showDiscovery: boolean;
-  discovery: {
-    tools: { name: string }[];
-    resources: { name: string }[];
-    prompts: { name: string }[];
-  } | null;
-}) => {
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-12">
-        <Loader2 className="text-muted-foreground size-6 animate-spin" />
-      </div>
-    );
-  }
-
-  if (showConnectButton) {
-    return (
-      <div className="flex flex-col items-center gap-4 py-12 text-center">
-        <p className="text-sm font-medium">Authorization required</p>
-        <p className="text-muted-foreground max-w-xs text-xs">
-          Connect this connector to access its tools and resources.
-        </p>
-        <Button onClick={onConnect}>Connect</Button>
-      </div>
-    );
-  }
-
-  if (isIncompatible) {
-    return (
-      <div className="flex flex-col items-center gap-2 py-12 text-center">
-        <AlertCircle className="text-destructive size-6" />
-        <p className="text-sm font-medium">Incompatible server</p>
-        <p className="text-muted-foreground max-w-xs text-xs">
-          {connectionError ??
-            "This server requires pre-configured OAuth credentials."}
-        </p>
-      </div>
-    );
-  }
-
-  if (discoveryError && !needsOAuth) {
-    return (
-      <div className="flex flex-col items-center gap-2 py-12 text-center">
-        <AlertCircle className="text-destructive size-6" />
-        <p className="text-muted-foreground text-sm">
-          Failed to connect to MCP server
-        </p>
-        <p className="text-muted-foreground max-w-xs text-xs">
-          {formatMcpError(discoveryError.message)}
-        </p>
-      </div>
-    );
-  }
-
-  if (showDiscovery && discovery) {
-    return (
-      <ScrollArea className="max-h-[60vh]">
-        <div className="space-y-4">
-          <DetailsSection
-            icon={<Wrench className="size-4" />}
-            items={discovery.tools.map((t) => t.name)}
-            title="Tools"
-          />
-          <DetailsSection
-            icon={<FileText className="size-4" />}
-            items={discovery.resources.map((r) => r.name)}
-            title="Resources"
-          />
-          <DetailsSection
-            icon={<BookText className="size-4" />}
-            items={discovery.prompts.map((p) => p.name)}
-            title="Prompts"
-          />
-        </div>
-      </ScrollArea>
-    );
-  }
-
-  return null;
-};
-
-const DetailsSection = ({
-  title,
-  icon,
-  items,
-}: {
-  title: string;
-  icon: React.ReactNode;
-  items: string[];
-}) => {
-  const count = items.length;
-
-  return (
-    <div className="bg-card rounded-lg border p-3">
-      <div className="flex items-center gap-2">
-        <div className="text-muted-foreground">{icon}</div>
-        <span className="text-sm font-medium">{title}</span>
-        <span className="text-muted-foreground text-xs">({count})</span>
-      </div>
-      <Separator className="my-3" />
-      {count === 0 ? (
-        <p className="text-muted-foreground text-xs italic">None available</p>
-      ) : (
-        <div className="flex flex-wrap gap-1.5">
-          {items.map((name) => (
-            <span
-              className="bg-muted rounded-md px-2 py-1 font-mono text-xs"
-              key={name}
-              title={name}
-            >
-              {name}
-            </span>
-          ))}
-        </div>
-      )}
-    </div>
   );
 };


### PR DESCRIPTION
Clear 51 component lint diagnostics across 18 files: convert seven remaining helper declarations, place pure helpers before their callers, sort nine named-field Intl/context/lookup records, and fix four conditional blocks, two redundant JSX wrappers, and one escaped apostrophe.

Strict diagnostics in these files drop from 199 to 148. Function bodies, parameters, property values, hook dependencies, rendering, and the relative order of non-function module initializers are preserved. CVA/style records, mutation callback ordering, and memo/context initialization remain unchanged.

This source-only PR leaves the shared baseline for the coordinated final cleanup.

Validation:
- `bun lint` and `bun test:types` pass.
- 47 unit-test files / 193 tests pass.
- All seven Playwright tests pass, including three visual suites, without retries or snapshot updates.
- Emitted AST comparison verifies body/parameter/property-value equivalence and unchanged non-function module initialization order across all 18 files.
- Browser home screenshot and React tree inspected; Next MCP compilation/runtime errors empty.

## Summary by Sourcery

Enhancements:
- Reduce component lint diagnostics across 18 files by standardizing helper declarations, ordering helpers before callers, normalizing record field order, and simplifying JSX and conditional syntax without changing runtime behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears 51 strict lint diagnostics across 18 chat component files by standardizing helper declarations, declaration order, and syntax without changing behavior.

- Converts remaining helper function declarations to `const` arrow functions.
- Moves pure helpers above their callers and sorts named-field `Intl`, context, and lookup records.
- Adds braces to single-statement conditionals, removes redundant JSX wrappers, and escapes an apostrophe.
- Strict diagnostics in these files drop from 199 to 148.
- This source-only change leaves the shared baseline for the coordinated final cleanup.

**Validation**
- `bun lint`, `bun test:types`, 193 unit tests, and all 7 Playwright tests pass without retries or snapshot updates.
- AST comparison confirms unchanged function bodies, parameters, property values, hook dependencies, and non-function module initialization order.

<sup>Written for commit 4414b7feb6828fb8b75576cbc63f91577b535cf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

