### PR TITLE
chore: clean page text and provider syntax

### DIFF
--- a/apps/chat/app/layout.tsx
+++ b/apps/chat/app/layout.tsx
@@ -25,7 +25,8 @@ export const metadata: Metadata = {
 };
 
 export const viewport = {
-  maximumScale: 1, // Disable auto-zoom on mobile Safari
+  // Disable auto-zoom on mobile Safari
+  maximumScale: 1,
   interactiveWidget: "resizes-content" as const,
 };
 

--- a/apps/chat/app/privacy/page.tsx
+++ b/apps/chat/app/privacy/page.tsx
@@ -125,7 +125,7 @@ const PrivacyPage = () => {
         <li>Withdraw consent where applicable</li>
       </ul>
 
-      <h2>Children's Privacy</h2>
+      <h2>Children&apos;s Privacy</h2>
       <p>
         Our service is not directed to children under the age of
         {` ${config.legal.minimumAge}`}. We do not knowingly collect personal
@@ -139,7 +139,7 @@ const PrivacyPage = () => {
       <p>
         We may update our Privacy Policy from time to time. We will notify you
         of any changes by posting the new Privacy Policy on this page and
-        updating the "Last updated" date.
+        updating the &quot;Last updated&quot; date.
       </p>
 
       <h2>Contact Us</h2>

--- a/apps/chat/app/terms/page.tsx
+++ b/apps/chat/app/terms/page.tsx
@@ -234,8 +234,9 @@ const TermsPage = () => {
 
       <h2>11. Disclaimers</h2>
       <p>
-        {config.appName} is provided "as is" and "as available" without any
-        warranties of any kind, either express or implied.
+        {config.appName} is provided &quot;as is&quot; and &quot;as
+        available&quot; without any warranties of any kind, either express or
+        implied.
       </p>
 
       <h2>12. Termination</h2>

--- a/apps/chat/lib/editor/config.ts
+++ b/apps/chat/lib/editor/config.ts
@@ -59,7 +59,8 @@ export const handleEditorChange = ({
   });
 
   // Check if this should be debounced (similar to ProseMirror's no-debounce meta)
-  const shouldDebounce = true; // Default to debounced saving
+  // Default to debounced saving
+  const shouldDebounce = true;
 
   onSaveContent(updatedContent, shouldDebounce);
 };

--- a/apps/chat/providers/chat-input-provider.tsx
+++ b/apps/chat/providers/chat-input-provider.tsx
@@ -51,8 +51,10 @@ interface ChatInputProviderProps {
   initialTool?: UiToolName | null;
   isProjectContext?: boolean;
   localStorageEnabled?: boolean;
-  overrideModelId?: AppModelId; // For message editing where we want to use the original model
-  overrideModelSelection?: SelectedModelValue; // For message editing with multi-model selection
+  // For message editing where we want to use the original model
+  overrideModelId?: AppModelId;
+  // For message editing with multi-model selection
+  overrideModelSelection?: SelectedModelValue;
 }
 
 export const ChatInputProvider = ({

--- a/apps/chat/providers/session-provider.tsx
+++ b/apps/chat/providers/session-provider.tsx
@@ -41,7 +41,7 @@ export const SessionProvider = ({
   // undefined = not seeded from the server tree yet
   const [serverSession, setServerSession] = useState<
     Session | null | undefined
-  >(undefined);
+  >();
   const isSeeded = serverSession !== undefined;
 
   const value = useMemo<SessionContextValue>(() => {
@@ -59,7 +59,7 @@ export const SessionProvider = ({
     // seed while the client fetch is still pending or failed (e.g. blocked
     // get-session / trustedOrigins mismatch).
     const effective =
-      isClientPending || clientError != null
+      isClientPending || (clientError !== null && clientError !== undefined)
         ? (clientSession ?? seededSession)
         : clientSession;
 

--- a/apps/chat/trpc/react.tsx
+++ b/apps/chat/trpc/react.tsx
@@ -6,7 +6,7 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { createTRPCClient, httpBatchLink, loggerLink } from "@trpc/client";
 import { createTRPCContext } from "@trpc/tanstack-react-query";
 import { useState } from "react";
-import SuperJSON from "superjson";
+import superjson from "superjson";
 
 import { getBaseUrl } from "@/lib/url";
 import type { AppRouter } from "@/trpc/routers/_app";
@@ -60,7 +60,7 @@ export const TRPCReactProvider = (props: { children: React.ReactNode }) => {
             headers.set("x-trpc-source", "nextjs-react");
             return headers;
           },
-          transformer: SuperJSON,
+          transformer: superjson,
         }),
       ],
     })

--- a/apps/chat/trpc/server.tsx
+++ b/apps/chat/trpc/server.tsx
@@ -1,4 +1,5 @@
-import "server-only"; // <-- ensure this file cannot be imported from the client
+// Ensure this file cannot be imported from the client.
+import "server-only";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { createTRPCOptionsProxy } from "@trpc/tanstack-react-query";
 import type { ResolverDef, TRPCQueryOptions } from "@trpc/tanstack-react-query";

--- a/apps/site/app/threads/page.tsx
+++ b/apps/site/app/threads/page.tsx
@@ -179,14 +179,12 @@ const ThreadsPage = () => (
                   {"\n\n"}
                   <span className="text-foreground">chat.messages;</span>
                   <span className="text-muted-foreground">
-                    {" "}
-                    {"// selected path"}
+                    {" // selected path"}
                   </span>
                   {"\n"}
                   <span className="text-foreground">chat.tree;</span>
                   <span className="text-muted-foreground">
-                    {" "}
-                    {"// complete tree"}
+                    {" // complete tree"}
                   </span>
                 </code>
               </pre>


### PR DESCRIPTION
Clear 18 lint findings in page text, comments, session state syntax, and the SuperJSON import binding. JSX entities preserve the displayed policy text; the site code example combines adjacent strings without changing its rendered comment. Session checks still distinguish null and undefined exactly as before.

Validation: `bun lint`, `bun test:types`, 193 unit tests, three Playwright visual tests, and the site interaction/capture suite passed. Six comment/entity-only files emit byte-identical JavaScript. The seven-rule focused audit is clean across all nine files. Privacy rendering and the site capture were inspected; Next.js reported no compilation or runtime errors. No snapshot baselines were updated.

Lint exemption pruning is deferred to the final independent baseline PR after the parallel source changes merge.

## Summary by Sourcery

Clean up lint findings across page text, comments, session state handling, and provider syntax without changing application behavior.

Enhancements:
- Clean up JSX text and comments to satisfy lint rules while preserving rendered page content and behavior.
- Clarify session state initialization and null/undefined error handling without changing session semantics.
- Normalize the SuperJSON import binding and improve formatting of provider configuration and site code examples.

Chores:
- Defer removal of lint exemptions to the final independent baseline pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up 18 lint findings across page text, comments, and provider syntax with no behavior changes.

- Privacy and terms page text now uses JSX entities; the rendered policy text is unchanged.
- The site code example joins adjacent strings without altering its rendered comment.
- Session provider still distinguishes null and undefined exactly as before, and `useState()` matches the prior explicit `useState(undefined)` initializer.
- `superjson` is now imported against its default export, matching `package.json`.
- Lint-exemption pruning is deferred to the baseline PR that will follow after the parallel source changes merge.

<sup>Written for commit 0474f9d2c83a33f55a5c22bed9c479579ce12cb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

