### PR TITLE
refactor: sort component records and finish safe ordering cleanup

### DIFF
--- a/apps/chat/components/ai-elements/code-block.tsx
+++ b/apps/chat/components/ai-elements/code-block.tsx
@@ -27,8 +27,7 @@ const lineNumberTransformer: ShikiTransformer = {
   name: "line-numbers",
   line(node, line) {
     node.children.unshift({
-      type: "element",
-      tagName: "span",
+      children: [{ type: "text", value: String(line) }],
       properties: {
         className: [
           "inline-block",
@@ -39,7 +38,8 @@ const lineNumberTransformer: ShikiTransformer = {
           "text-muted-foreground",
         ],
       },
-      children: [{ type: "text", value: String(line) }],
+      tagName: "span",
+      type: "element",
     });
   },
 };

--- a/apps/chat/components/ai-elements/message.tsx
+++ b/apps/chat/components/ai-elements/message.tsx
@@ -168,12 +168,12 @@ export const MessageBranch = ({
   };
 
   const contextValue: MessageBranchContextType = {
-    currentBranch,
-    totalBranches: branches.length,
-    goToPrevious,
-    goToNext,
     branches,
+    currentBranch,
+    goToNext,
+    goToPrevious,
     setBranches,
+    totalBranches: branches.length,
   };
 
   return (

--- a/apps/chat/components/ai-elements/prompt-input.tsx
+++ b/apps/chat/components/ai-elements/prompt-input.tsx
@@ -160,7 +160,7 @@ export const PromptInputProvider = ({
   const openRef = useRef<() => void>(() => {});
 
   const add = useCallback((files: File[] | FileList) => {
-    const incoming = Array.from(files);
+    const incoming = [...files];
     if (incoming.length === 0) {
       return;
     }
@@ -205,12 +205,12 @@ export const PromptInputProvider = ({
 
   const attachments = useMemo<AttachmentsContext>(
     () => ({
-      files: attachements,
       add,
-      remove,
       clear,
-      openFileDialog,
       fileInputRef,
+      files: attachements,
+      openFileDialog,
+      remove,
     }),
     [attachements, add, remove, clear, openFileDialog]
   );
@@ -225,13 +225,13 @@ export const PromptInputProvider = ({
 
   const controller = useMemo<PromptInputControllerProps>(
     () => ({
-      textInput: {
-        value: textInput,
-        setInput: setTextInput,
-        clear: clearInput,
-      },
-      attachments,
       __registerFileInput,
+      attachments,
+      textInput: {
+        clear: clearInput,
+        setInput: setTextInput,
+        value: textInput,
+      },
     }),
     [textInput, clearInput, attachments, __registerFileInput]
   );
@@ -499,7 +499,7 @@ export const PromptInput = ({
 
   const addLocal = useCallback(
     (fileList: File[] | FileList) => {
-      const incoming = Array.from(fileList);
+      const incoming = [...fileList];
       const accepted = incoming.filter((f) => matchesAccept(f));
       if (incoming.length && accepted.length === 0) {
         onError?.({
@@ -673,12 +673,12 @@ export const PromptInput = ({
 
   const ctx = useMemo<AttachmentsContext>(
     () => ({
-      files: files.map((item) => ({ ...item, id: item.id })),
       add,
-      remove,
       clear,
-      openFileDialog,
       fileInputRef: inputRef,
+      files: files.map((item) => ({ ...item, id: item.id })),
+      openFileDialog,
+      remove,
     }),
     [files, add, remove, clear, openFileDialog]
   );
@@ -713,7 +713,13 @@ export const PromptInput = ({
       })
     ).then((convertedFiles: FileUIPart[]) => {
       try {
-        const result = onSubmit({ text, files: convertedFiles }, event);
+        const result = onSubmit(
+          {
+            files: convertedFiles,
+            text,
+          },
+          event
+        );
 
         // Handle both sync and async onSubmit
         if (result instanceof Promise) {
@@ -860,11 +866,11 @@ export const PromptInputTextarea = ({
 
   const controlledProps = controller
     ? {
-        value: controller.textInput.value,
         onChange: (e: ChangeEvent<HTMLTextAreaElement>) => {
           controller.textInput.setInput(e.currentTarget.value);
           onChange?.(e);
         },
+        value: controller.textInput.value,
       }
     : {
         onChange,

--- a/apps/chat/components/ai-elements/reasoning.tsx
+++ b/apps/chat/components/ai-elements/reasoning.tsx
@@ -55,13 +55,13 @@ export const Reasoning = memo(
     ...props
   }: ReasoningProps) => {
     const [isOpen, setIsOpen] = useControllableState({
-      prop: open,
       defaultProp: defaultOpen,
       onChange: onOpenChange,
+      prop: open,
     });
     const [duration, setDuration] = useControllableState({
-      prop: durationProp,
       defaultProp: 0,
+      prop: durationProp,
     });
 
     const [hasAutoClosed, setHasAutoClosed] = useState(false);
@@ -98,7 +98,12 @@ export const Reasoning = memo(
 
     return (
       <ReasoningContext.Provider
-        value={{ isStreaming, isOpen, setIsOpen, duration }}
+        value={{
+          duration,
+          isOpen,
+          isStreaming,
+          setIsOpen,
+        }}
       >
         <Collapsible
           className={cn("not-prose mb-4", className)}

--- a/apps/chat/components/ai-elements/tool.tsx
+++ b/apps/chat/components/ai-elements/tool.tsx
@@ -40,23 +40,23 @@ export type ToolHeaderProps = {
 
 export const getStatusBadge = (status: ToolUIPart["state"]) => {
   const labels: Record<ToolUIPart["state"], string> = {
-    "input-streaming": "Pending",
-    "input-available": "Running",
     "approval-requested": "Awaiting Approval",
     "approval-responded": "Responded",
+    "input-available": "Running",
+    "input-streaming": "Pending",
     "output-available": "Completed",
-    "output-error": "Error",
     "output-denied": "Denied",
+    "output-error": "Error",
   };
 
   const icons: Record<ToolUIPart["state"], ReactNode> = {
-    "input-streaming": <CircleIcon className="size-4" />,
-    "input-available": <ClockIcon className="size-4 animate-pulse" />,
     "approval-requested": <ClockIcon className="size-4 text-yellow-600" />,
     "approval-responded": <CheckCircleIcon className="size-4 text-blue-600" />,
+    "input-available": <ClockIcon className="size-4 animate-pulse" />,
+    "input-streaming": <CircleIcon className="size-4" />,
     "output-available": <CheckCircleIcon className="size-4 text-green-600" />,
-    "output-error": <XCircleIcon className="size-4 text-red-600" />,
     "output-denied": <XCircleIcon className="size-4 text-orange-600" />,
+    "output-error": <XCircleIcon className="size-4 text-red-600" />,
   };
 
   return (

--- a/apps/chat/components/artifact-actions.tsx
+++ b/apps/chat/components/artifact-actions.tsx
@@ -70,13 +70,13 @@ const TypedArtifactActions = <M extends ArtifactMetadata>({
 
   const actionContext: ArtifactActionContext<M> = {
     content: artifact.content,
-    handleVersionChange,
     currentVersionIndex,
+    handleVersionChange,
     isCurrentVersion,
-    mode,
-    metadata,
-    setMetadata,
     isReadonly,
+    metadata,
+    mode,
+    setMetadata,
   };
 
   function isActionDisabled(action: {
@@ -122,7 +122,7 @@ const TypedArtifactActions = <M extends ArtifactMetadata>({
 
                       try {
                         await Promise.resolve(action.onClick(actionContext));
-                      } catch (_error) {
+                      } catch {
                         toast.error("Failed to execute action");
                       } finally {
                         setIsLoading(false);
@@ -146,7 +146,7 @@ const TypedArtifactActions = <M extends ArtifactMetadata>({
 
                     try {
                       await Promise.resolve(action.onClick(actionContext));
-                    } catch (_error) {
+                    } catch {
                       toast.error("Failed to execute action");
                     } finally {
                       setIsLoading(false);

--- a/apps/chat/components/artifact-panel.tsx
+++ b/apps/chat/components/artifact-panel.tsx
@@ -151,10 +151,10 @@ const PureArtifactPanel = ({
       ) {
         setIsContentDirty(true);
         saveDocumentMutation.mutate({
-          id: lastDocument.id,
-          title: lastDocument.title,
           content: updatedContent,
+          id: lastDocument.id,
           kind: lastDocument.kind,
+          title: lastDocument.title,
         });
       }
     },
@@ -267,10 +267,10 @@ const PureArtifactPanel = ({
         case "text": {
           textArtifact.initialize?.({
             documentId: artifact.documentId,
+            isAuthenticated,
+            queryClient,
             setMetadata,
             trpc,
-            queryClient,
-            isAuthenticated,
           });
           break;
         }

--- a/apps/chat/components/attachment-list.tsx
+++ b/apps/chat/components/attachment-list.tsx
@@ -283,9 +283,9 @@ export const AttachmentList = ({
       {uploadQueue.map((filename) => (
         <AttachmentItem
           attachment={{
-            url: "",
-            name: filename,
             contentType: "",
+            name: filename,
+            url: "",
           }}
           isUploading={true}
           key={filename}

--- a/apps/chat/components/chat-features-definitions.ts
+++ b/apps/chat/components/chat-features-definitions.ts
@@ -11,20 +11,56 @@ interface ToolDefinition {
 }
 
 export const toolDefinitions: Record<UiToolName, ToolDefinition> = {
-  webSearch: { name: "Web Search", icon: GlobeIcon, shortName: "Search" },
+  webSearch: {
+    icon: GlobeIcon,
+    name: "Web Search",
+    shortName: "Search",
+  },
   deepResearch: {
-    name: "Deep Research",
     icon: Telescope,
+    name: "Deep Research",
     shortName: "Research",
   },
-  generateImage: { name: "Create an image", icon: Images, shortName: "Image" },
-  generateVideo: { name: "Create a video", icon: Video, shortName: "Video" },
-  createTextDocument: { name: "Canvas", icon: Edit3, shortName: "Canvas" },
-  createCodeDocument: { name: "Canvas", icon: Edit3, shortName: "Canvas" },
-  createSheetDocument: { name: "Canvas", icon: Edit3, shortName: "Canvas" },
-  editTextDocument: { name: "Canvas", icon: Edit3, shortName: "Canvas" },
-  editCodeDocument: { name: "Canvas", icon: Edit3, shortName: "Canvas" },
-  editSheetDocument: { name: "Canvas", icon: Edit3, shortName: "Canvas" },
+  generateImage: {
+    icon: Images,
+    name: "Create an image",
+    shortName: "Image",
+  },
+  generateVideo: {
+    icon: Video,
+    name: "Create a video",
+    shortName: "Video",
+  },
+  createTextDocument: {
+    icon: Edit3,
+    name: "Canvas",
+    shortName: "Canvas",
+  },
+  createCodeDocument: {
+    icon: Edit3,
+    name: "Canvas",
+    shortName: "Canvas",
+  },
+  createSheetDocument: {
+    icon: Edit3,
+    name: "Canvas",
+    shortName: "Canvas",
+  },
+  editTextDocument: {
+    icon: Edit3,
+    name: "Canvas",
+    shortName: "Canvas",
+  },
+  editCodeDocument: {
+    icon: Edit3,
+    name: "Canvas",
+    shortName: "Canvas",
+  },
+  editSheetDocument: {
+    icon: Edit3,
+    name: "Canvas",
+    shortName: "Canvas",
+  },
 };
 
 /**

--- a/apps/chat/components/chat-sync.tsx
+++ b/apps/chat/components/chat-sync.tsx
@@ -95,13 +95,14 @@ export const ChatSync = ({
   const { resumeStream } = useChat<ChatMessage>({
     experimental_throttle: 100,
     thread,
-    onFinish: ({ message }) =>
-      completionQueueRef.current.waitForIdle().then(() => {
+    onFinish: ({ message }) => {
+      return completionQueueRef.current.waitForIdle().then(() => {
         saveChatMessage({
           chatId: id,
           message,
         });
-      }),
+      });
+    },
     transport,
     onData: (dataPart) => {
       completionQueueRef.current.enqueue(() =>

--- a/apps/chat/components/chat-sync.tsx
+++ b/apps/chat/components/chat-sync.tsx
@@ -95,11 +95,13 @@ export const ChatSync = ({
   const { resumeStream } = useChat<ChatMessage>({
     experimental_throttle: 100,
     thread,
-    onFinish: ({ message }) => {
-      return completionQueueRef.current.waitForIdle().then(() => {
-        saveChatMessage({ message, chatId: id });
-      });
-    },
+    onFinish: ({ message }) =>
+      completionQueueRef.current.waitForIdle().then(() => {
+        saveChatMessage({
+          chatId: id,
+          message,
+        });
+      }),
     transport,
     onData: (dataPart) => {
       completionQueueRef.current.enqueue(() =>

--- a/apps/chat/components/code-editor.tsx
+++ b/apps/chat/components/code-editor.tsx
@@ -61,8 +61,8 @@ const PureCodeEditor = ({
       });
 
       editorRef.current = new EditorView({
-        state: startState,
         parent: containerRef.current,
+        state: startState,
       });
     }
 
@@ -116,8 +116,8 @@ const PureCodeEditor = ({
         const transaction = editorRef.current.state.update({
           changes: {
             from: 0,
-            to: currentContent.length,
             insert: content,
+            to: currentContent.length,
           },
           annotations: [Transaction.remote.of(true)],
         });

--- a/apps/chat/components/connectors-dropdown.tsx
+++ b/apps/chat/components/connectors-dropdown.tsx
@@ -115,7 +115,10 @@ const PureConnectorsDropdown = () => {
                 checked={connector.enabled}
                 className="scale-75"
                 onCheckedChange={(enabled) =>
-                  toggleEnabled({ id: connector.id, enabled })
+                  toggleEnabled({
+                    enabled,
+                    id: connector.id,
+                  })
                 }
                 onClick={(e) => e.stopPropagation()}
               />

--- a/apps/chat/components/data-stream-handler.tsx
+++ b/apps/chat/components/data-stream-handler.tsx
@@ -93,9 +93,9 @@ const processArtifactStreamPart = ({
     }
     case "text": {
       textArtifact.onStreamPart?.({
-        streamPart: delta,
         setArtifact,
         setMetadata,
+        streamPart: delta,
       });
       break;
     }
@@ -142,8 +142,8 @@ export const DataStreamHandler = () => {
       handleResearchUpdate({ delta, setSelectedTool });
 
       processArtifactStreamPart({
-        delta,
         artifact,
+        delta,
         setArtifact,
         setMetadata,
       });

--- a/apps/chat/components/device-login-page.tsx
+++ b/apps/chat/components/device-login-page.tsx
@@ -63,7 +63,10 @@ export const DeviceLoginPage = () => {
 
       await authClient.electron.transferUser({
         fetchOptions: {
-          query,
+          onError: () => {
+            transferStartedRef.current = false;
+            setState("waiting-for-app");
+          },
           onSuccess: () => {
             window.history.replaceState(
               {},
@@ -72,10 +75,7 @@ export const DeviceLoginPage = () => {
             );
             setState("waiting-for-app");
           },
-          onError: () => {
-            transferStartedRef.current = false;
-            setState("waiting-for-app");
-          },
+          query,
         },
       });
     };
@@ -102,7 +102,10 @@ export const DeviceLoginPage = () => {
         authClient.electron
           .transferUser({
             fetchOptions: {
-              query,
+              onError: () => {
+                transferStartedRef.current = false;
+                setState("waiting-for-app");
+              },
               onSuccess: () => {
                 window.history.replaceState(
                   {},
@@ -111,10 +114,7 @@ export const DeviceLoginPage = () => {
                 );
                 setState("waiting-for-app");
               },
-              onError: () => {
-                transferStartedRef.current = false;
-                setState("waiting-for-app");
-              },
+              query,
             },
           })
           .catch(() => {

--- a/apps/chat/components/diffview.tsx
+++ b/apps/chat/components/diffview.tsx
@@ -11,9 +11,9 @@ import { useEffect } from "react";
 import { createEditorConfig } from "@/lib/editor/config";
 
 const DiffType = {
-  Unchanged: 0,
   Deleted: -1,
   Inserted: 1,
+  Unchanged: 0,
 };
 
 // Define diff types

--- a/apps/chat/components/electron-auth-handler.tsx
+++ b/apps/chat/components/electron-auth-handler.tsx
@@ -21,8 +21,8 @@ export const ElectronAuthHandler = () => {
   const isDesktopAppEnabled = config.desktopApp.enabled;
   const router = useRouter();
   const [authState, setAuthState] = useState<ElectronRendererAuthState>({
-    status: "idle",
     message: null,
+    status: "idle",
   });
 
   useEffect(() => {

--- a/apps/chat/components/feedback-actions.tsx
+++ b/apps/chat/components/feedback-actions.tsx
@@ -62,9 +62,9 @@ export const FeedbackActions = ({
                   type: "down" as const,
                 }),
                 {
+                  error: "Failed to downvote response.",
                   loading: "Downvoting Response...",
                   success: "Downvoted Response!",
-                  error: "Failed to downvote response.",
                 }
               );
             }}
@@ -85,9 +85,9 @@ export const FeedbackActions = ({
                   type: "up" as const,
                 }),
                 {
+                  error: "Failed to upvote response.",
                   loading: "Upvoting Response...",
                   success: "Upvoted Response!",
-                  error: "Failed to upvote response.",
                 }
               );
             }}

--- a/apps/chat/components/followup-suggestions.tsx
+++ b/apps/chat/components/followup-suggestions.tsx
@@ -38,15 +38,15 @@ const FollowUpSuggestions = ({
         role: "user",
         parts: [
           {
-            type: "text",
             text: suggestion,
+            type: "text",
           },
         ],
         metadata: {
+          activeStreamId: null,
           createdAt: new Date(),
           parentMessageId,
           selectedModel: selectedModelId,
-          activeStreamId: null,
           selectedTool: (selectedTool as UiToolName | null) || undefined,
         },
       };

--- a/apps/chat/components/header-breadcrumb.tsx
+++ b/apps/chat/components/header-breadcrumb.tsx
@@ -43,6 +43,85 @@ interface HeaderBreadcrumbProps {
   user?: Session["user"];
 }
 
+interface ChatBreadcrumbProps {
+  canManageChat: boolean;
+  chatLabel: string;
+  chatTitleDraft: string;
+  handleChatInputKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
+  handleChatRename: () => Promise<void> | void;
+  isChatEditing: boolean;
+  isPinned: boolean;
+  onChatTitleChange: (value: string) => void;
+  onShare: () => void;
+  onTogglePin: () => void;
+  openChatDeleteDialog: () => void;
+  showShare?: boolean;
+  startChatRename: () => void;
+}
+
+const PureChatBreadcrumb = memo(
+  ({
+    canManageChat,
+    chatLabel,
+    chatTitleDraft,
+    handleChatInputKeyDown,
+    handleChatRename,
+    isChatEditing,
+    isPinned,
+    onChatTitleChange,
+    onShare,
+    onTogglePin,
+    openChatDeleteDialog,
+    showShare,
+    startChatRename: startChatRenameProp,
+  }: ChatBreadcrumbProps) => {
+    if (isChatEditing) {
+      return (
+        <Input
+          autoFocus
+          className="bg-background h-7 w-[220px] px-2 py-1 text-sm"
+          maxLength={255}
+          onBlur={handleChatRename}
+          onChange={(event) => onChatTitleChange(event.target.value)}
+          onKeyDown={handleChatInputKeyDown}
+          value={chatTitleDraft}
+        />
+      );
+    }
+
+    if (canManageChat) {
+      return (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              className="group text-foreground hover:bg-muted focus-visible:ring-ring flex min-w-0 items-center gap-1.5 rounded-md border border-transparent bg-transparent px-2 py-1 text-sm font-medium transition focus-visible:ring-1 focus-visible:outline-none"
+              type="button"
+            >
+              <span className="truncate">{chatLabel}</span>
+              <ChevronDown
+                aria-hidden
+                className="text-muted-foreground size-4 shrink-0"
+              />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <ChatMenuItems
+              isPinned={isPinned}
+              onDelete={openChatDeleteDialog}
+              onRename={startChatRenameProp}
+              onShare={onShare}
+              onTogglePin={onTogglePin}
+              showShare={showShare}
+            />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+    }
+
+    return <BreadcrumbPage>{chatLabel}</BreadcrumbPage>;
+  }
+);
+
 export const HeaderBreadcrumb = ({
   chat,
   chatId,
@@ -179,85 +258,6 @@ export const HeaderBreadcrumb = ({
     </>
   );
 };
-
-interface ChatBreadcrumbProps {
-  canManageChat: boolean;
-  chatLabel: string;
-  chatTitleDraft: string;
-  handleChatInputKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
-  handleChatRename: () => Promise<void> | void;
-  isChatEditing: boolean;
-  isPinned: boolean;
-  onChatTitleChange: (value: string) => void;
-  onShare: () => void;
-  onTogglePin: () => void;
-  openChatDeleteDialog: () => void;
-  showShare?: boolean;
-  startChatRename: () => void;
-}
-
-const PureChatBreadcrumb = memo(
-  ({
-    canManageChat,
-    chatLabel,
-    chatTitleDraft,
-    handleChatInputKeyDown,
-    handleChatRename,
-    isChatEditing,
-    isPinned,
-    onChatTitleChange,
-    onShare,
-    onTogglePin,
-    openChatDeleteDialog,
-    showShare,
-    startChatRename: startChatRenameProp,
-  }: ChatBreadcrumbProps) => {
-    if (isChatEditing) {
-      return (
-        <Input
-          autoFocus
-          className="bg-background h-7 w-[220px] px-2 py-1 text-sm"
-          maxLength={255}
-          onBlur={handleChatRename}
-          onChange={(event) => onChatTitleChange(event.target.value)}
-          onKeyDown={handleChatInputKeyDown}
-          value={chatTitleDraft}
-        />
-      );
-    }
-
-    if (canManageChat) {
-      return (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              className="group text-foreground hover:bg-muted focus-visible:ring-ring flex min-w-0 items-center gap-1.5 rounded-md border border-transparent bg-transparent px-2 py-1 text-sm font-medium transition focus-visible:ring-1 focus-visible:outline-none"
-              type="button"
-            >
-              <span className="truncate">{chatLabel}</span>
-              <ChevronDown
-                aria-hidden
-                className="text-muted-foreground size-4 shrink-0"
-              />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <ChatMenuItems
-              isPinned={isPinned}
-              onDelete={openChatDeleteDialog}
-              onRename={startChatRenameProp}
-              onShare={onShare}
-              onTogglePin={onTogglePin}
-              showShare={showShare}
-            />
-          </DropdownMenuContent>
-        </DropdownMenu>
-      );
-    }
-
-    return <BreadcrumbPage>{chatLabel}</BreadcrumbPage>;
-  }
-);
 
 PureChatBreadcrumb.displayName = "InnerChatBreadcrumb";
 

--- a/apps/chat/components/lexical-chat-input.tsx
+++ b/apps/chat/components/lexical-chat-input.tsx
@@ -30,26 +30,28 @@ const EnterKeySubmitPlugin = ({
 }) => {
   const [editor] = useLexicalComposerContext();
 
-  useEffect(() => {
-    return editor.registerCommand(
-      KEY_ENTER_COMMAND,
-      (event: KeyboardEvent) => {
-        // Call the custom handler if provided
-        if (onEnterSubmit) {
-          const handled = onEnterSubmit(event);
-          if (handled) {
-            // Prevent the default Enter behavior immediately
-            event.preventDefault();
-            // Prevent default Enter behavior (adding newline)
-            return true;
+  useEffect(
+    () =>
+      editor.registerCommand(
+        KEY_ENTER_COMMAND,
+        (event: KeyboardEvent) => {
+          // Call the custom handler if provided
+          if (onEnterSubmit) {
+            const handled = onEnterSubmit(event);
+            if (handled) {
+              // Prevent the default Enter behavior immediately
+              event.preventDefault();
+              // Prevent default Enter behavior (adding newline)
+              return true;
+            }
           }
-        }
-        // Allow default behavior for non-submit cases (Shift+Enter, etc.)
-        return false;
-      },
-      COMMAND_PRIORITY_HIGH
-    );
-  }, [editor, onEnterSubmit]);
+          // Allow default behavior for non-submit cases (Shift+Enter, etc.)
+          return false;
+        },
+        COMMAND_PRIORITY_HIGH
+      ),
+    [editor, onEnterSubmit]
+  );
 
   return null;
 };
@@ -89,11 +91,11 @@ interface LexicalChatInputProps {
 }
 
 const theme = {
-  root: "lexical-root",
   ltr: "ltr",
-  rtl: "rtl",
-  placeholder: "editor-placeholder",
   paragraph: "editor-paragraph",
+  placeholder: "editor-placeholder",
+  root: "lexical-root",
+  rtl: "rtl",
 };
 
 const onError = (error: Error) => {
@@ -121,9 +123,9 @@ export const LexicalChatInput = ({
 
   const initialConfig: InitialConfigType = {
     namespace: "LexicalChatInput",
-    theme,
-    onError,
     nodes: [],
+    onError,
+    theme,
   };
 
   const handleChange = useCallback(
@@ -142,17 +144,17 @@ export const LexicalChatInput = ({
   useImperativeHandle(
     ref,
     () => ({
-      focus: () => {
-        if (editor) {
-          editor.focus();
-        }
-      },
       clear: () => {
         if (editor) {
           editor.update(() => {
             const root = $getRoot();
             root.clear();
           });
+        }
+      },
+      focus: () => {
+        if (editor) {
+          editor.focus();
         }
       },
       getValue: () => {

--- a/apps/chat/components/message-parts.tsx
+++ b/apps/chat/components/message-parts.tsx
@@ -78,17 +78,15 @@ const PureMessageParts = ({
 }: MessagePartsProps) => {
   const types = useMessagePartTypesById(messageId);
 
-  return types.map((t, i) => {
-    return (
-      <MessagePart
-        isLoading={isLoading && i === types.length - 1}
-        isReadonly={isReadonly}
-        key={`message-${messageId}-${t}-${i}`}
-        messageId={messageId}
-        partIdx={i}
-      />
-    );
-  });
+  return types.map((t, i) => (
+    <MessagePart
+      isLoading={isLoading && i === types.length - 1}
+      isReadonly={isReadonly}
+      key={`message-${messageId}-${t}-${i}`}
+      messageId={messageId}
+      partIdx={i}
+    />
+  ));
 };
 
 export const MessageParts = memo(PureMessageParts);

--- a/apps/chat/components/multimodal-input.tsx
+++ b/apps/chat/components/multimodal-input.tsx
@@ -97,6 +97,157 @@ const getAcceptFiles = (acceptedTypes: Record<string, string[]>): string =>
 const getAcceptAll = (acceptedTypes: Record<string, string[]>): string =>
   Object.values(acceptedTypes).flat().join(",");
 
+const PureAttachmentsButton = ({
+  fileInputRef,
+  status,
+  acceptAll,
+  acceptImages,
+  acceptFiles,
+}: {
+  fileInputRef: MutableRefObject<HTMLInputElement | null>;
+  status: UseChatHelpers<ChatMessage>["status"];
+  acceptAll: string;
+  acceptImages: string;
+  acceptFiles: string;
+}) => {
+  const { data: session } = useSession();
+  const isMobile = useIsMobile();
+  const isAnonymous = !session?.user;
+  const [showLoginPopover, setShowLoginPopover] = useState(false);
+
+  const triggerFileInput = useCallback(
+    (accept: string, capture?: "environment" | "user") => {
+      const input = fileInputRef.current;
+      if (!input) {
+        return;
+      }
+      input.accept = accept;
+      if (capture) {
+        input.capture = capture;
+      } else {
+        input.removeAttribute("capture");
+      }
+      input.click();
+    },
+    [fileInputRef]
+  );
+
+  const handleDesktopClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    if (isAnonymous) {
+      setShowLoginPopover(true);
+      return;
+    }
+    triggerFileInput(acceptAll);
+  };
+
+  // Mobile: dropdown with separate options
+  if (isMobile) {
+    if (isAnonymous) {
+      return (
+        <Popover onOpenChange={setShowLoginPopover} open={showLoginPopover}>
+          <PopoverTrigger asChild>
+            <PromptInputButton
+              className="size-8"
+              data-testid="attachments-button"
+              disabled={status !== "ready"}
+              onClick={() => setShowLoginPopover(true)}
+              variant="ghost"
+            >
+              <PlusIcon className="size-4" />
+            </PromptInputButton>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-80 p-0">
+            <LoginPrompt
+              description="You can attach images and PDFs to your messages for the AI to analyze."
+              title="Sign in to attach files"
+            />
+          </PopoverContent>
+        </Popover>
+      );
+    }
+
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <PromptInputButton
+            className="size-8"
+            data-testid="attachments-button"
+            disabled={status !== "ready"}
+            variant="ghost"
+          >
+            <PlusIcon className="size-4" />
+          </PromptInputButton>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuItem onClick={() => triggerFileInput(acceptImages)}>
+            <ImageIcon />
+            Add photos
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => triggerFileInput(acceptImages, "environment")}
+          >
+            <CameraIcon />
+            Take photo
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => triggerFileInput(acceptFiles)}>
+            <FileIcon />
+            Add files
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  }
+
+  // Desktop: single button with tooltip
+  return (
+    <Popover onOpenChange={setShowLoginPopover} open={showLoginPopover}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <PromptInputButton
+              className="size-8 @[500px]:size-10"
+              data-testid="attachments-button"
+              disabled={status !== "ready"}
+              onClick={handleDesktopClick}
+              variant="ghost"
+            >
+              <PlusIcon className="size-4" />
+            </PromptInputButton>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Add Files</TooltipContent>
+      </Tooltip>
+      <PopoverContent align="end" className="w-80 p-0">
+        <LoginPrompt
+          description="You can attach images and PDFs to your messages for the AI to analyze."
+          title="Sign in to attach files"
+        />
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+const AttachmentsButton = memo(PureAttachmentsButton);
+
+const ComposerContext = createContext<{
+  autoFocus: boolean;
+  isEditMode: boolean;
+  isModelDisallowedForAnonymous: boolean;
+  parentMessageId: string | null;
+  status: UseChatHelpers<ChatMessage>["status"];
+  submission: { enabled: boolean; message?: string };
+  submitForm: () => void;
+  onStop: () => void;
+  onPaste: (event: ClipboardEvent) => Promise<void>;
+  fileInputRef: RefObject<HTMLInputElement | null>;
+  acceptAll: string;
+  acceptFiles: string;
+  acceptImages: string;
+  uploadQueue: string[];
+  removeAttachment: (attachment: Attachment) => void;
+} | null>(null);
+
 const PureMultimodalInput = ({
   children,
   chatId,
@@ -429,8 +580,8 @@ const PureMultimodalInput = ({
 
       try {
         const response = await fetch("/api/files/upload", {
-          method: "POST",
           body: formData,
+          method: "POST",
         });
 
         if (response.ok) {
@@ -439,9 +590,9 @@ const PureMultimodalInput = ({
           const { url, pathname, contentType } = data;
 
           return {
-            url,
-            name: pathname,
             contentType,
+            name: pathname,
+            url,
           };
         }
         const { error } = (await response.json()) as { error?: string };
@@ -455,7 +606,7 @@ const PureMultimodalInput = ({
 
   const handleFileChange = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
-      const files = Array.from(event.target.files || []);
+      const files = [...(event.target.files || [])];
       const validFiles = await processFiles(files);
 
       if (validFiles.length === 0) {
@@ -500,7 +651,7 @@ const PureMultimodalInput = ({
         return;
       }
 
-      const files = Array.from(clipboardData.files);
+      const files = [...clipboardData.files];
       if (files.length === 0) {
         return;
       }
@@ -689,21 +840,21 @@ const PureMultimodalInput = ({
 
           <ComposerContext.Provider
             value={{
-              autoFocus,
-              isEditMode,
-              isModelDisallowedForAnonymous,
-              parentMessageId,
-              status: responseAwareStatus,
-              submission,
-              submitForm,
-              onStop: handleStop,
-              onPaste: handlePaste,
-              fileInputRef,
               acceptAll,
               acceptFiles,
               acceptImages,
-              uploadQueue,
+              autoFocus,
+              fileInputRef,
+              isEditMode,
+              isModelDisallowedForAnonymous,
+              onPaste: handlePaste,
+              onStop: handleStop,
+              parentMessageId,
               removeAttachment,
+              status: responseAwareStatus,
+              submission,
+              submitForm,
+              uploadQueue,
             }}
           >
             {children}
@@ -713,157 +864,6 @@ const PureMultimodalInput = ({
     </div>
   );
 };
-
-const PureAttachmentsButton = ({
-  fileInputRef,
-  status,
-  acceptAll,
-  acceptImages,
-  acceptFiles,
-}: {
-  fileInputRef: MutableRefObject<HTMLInputElement | null>;
-  status: UseChatHelpers<ChatMessage>["status"];
-  acceptAll: string;
-  acceptImages: string;
-  acceptFiles: string;
-}) => {
-  const { data: session } = useSession();
-  const isMobile = useIsMobile();
-  const isAnonymous = !session?.user;
-  const [showLoginPopover, setShowLoginPopover] = useState(false);
-
-  const triggerFileInput = useCallback(
-    (accept: string, capture?: "environment" | "user") => {
-      const input = fileInputRef.current;
-      if (!input) {
-        return;
-      }
-      input.accept = accept;
-      if (capture) {
-        input.capture = capture;
-      } else {
-        input.removeAttribute("capture");
-      }
-      input.click();
-    },
-    [fileInputRef]
-  );
-
-  const handleDesktopClick = (event: MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
-    if (isAnonymous) {
-      setShowLoginPopover(true);
-      return;
-    }
-    triggerFileInput(acceptAll);
-  };
-
-  // Mobile: dropdown with separate options
-  if (isMobile) {
-    if (isAnonymous) {
-      return (
-        <Popover onOpenChange={setShowLoginPopover} open={showLoginPopover}>
-          <PopoverTrigger asChild>
-            <PromptInputButton
-              className="size-8"
-              data-testid="attachments-button"
-              disabled={status !== "ready"}
-              onClick={() => setShowLoginPopover(true)}
-              variant="ghost"
-            >
-              <PlusIcon className="size-4" />
-            </PromptInputButton>
-          </PopoverTrigger>
-          <PopoverContent align="start" className="w-80 p-0">
-            <LoginPrompt
-              description="You can attach images and PDFs to your messages for the AI to analyze."
-              title="Sign in to attach files"
-            />
-          </PopoverContent>
-        </Popover>
-      );
-    }
-
-    return (
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <PromptInputButton
-            className="size-8"
-            data-testid="attachments-button"
-            disabled={status !== "ready"}
-            variant="ghost"
-          >
-            <PlusIcon className="size-4" />
-          </PromptInputButton>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start">
-          <DropdownMenuItem onClick={() => triggerFileInput(acceptImages)}>
-            <ImageIcon />
-            Add photos
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            onClick={() => triggerFileInput(acceptImages, "environment")}
-          >
-            <CameraIcon />
-            Take photo
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => triggerFileInput(acceptFiles)}>
-            <FileIcon />
-            Add files
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    );
-  }
-
-  // Desktop: single button with tooltip
-  return (
-    <Popover onOpenChange={setShowLoginPopover} open={showLoginPopover}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <PopoverTrigger asChild>
-            <PromptInputButton
-              className="size-8 @[500px]:size-10"
-              data-testid="attachments-button"
-              disabled={status !== "ready"}
-              onClick={handleDesktopClick}
-              variant="ghost"
-            >
-              <PlusIcon className="size-4" />
-            </PromptInputButton>
-          </PopoverTrigger>
-        </TooltipTrigger>
-        <TooltipContent>Add Files</TooltipContent>
-      </Tooltip>
-      <PopoverContent align="end" className="w-80 p-0">
-        <LoginPrompt
-          description="You can attach images and PDFs to your messages for the AI to analyze."
-          title="Sign in to attach files"
-        />
-      </PopoverContent>
-    </Popover>
-  );
-};
-
-const AttachmentsButton = memo(PureAttachmentsButton);
-
-const ComposerContext = createContext<{
-  autoFocus: boolean;
-  isEditMode: boolean;
-  isModelDisallowedForAnonymous: boolean;
-  parentMessageId: string | null;
-  status: UseChatHelpers<ChatMessage>["status"];
-  submission: { enabled: boolean; message?: string };
-  submitForm: () => void;
-  onStop: () => void;
-  onPaste: (event: ClipboardEvent) => Promise<void>;
-  fileInputRef: RefObject<HTMLInputElement | null>;
-  acceptAll: string;
-  acceptFiles: string;
-  acceptImages: string;
-  uploadQueue: string[];
-  removeAttachment: (attachment: Attachment) => void;
-} | null>(null);
 
 const useComposer = () => {
   const context = useContext(ComposerContext);

--- a/apps/chat/components/parallel-response-cards.tsx
+++ b/apps/chat/components/parallel-response-cards.tsx
@@ -81,37 +81,39 @@ const PureParallelResponseCards = ({ messageId }: { messageId: string }) => {
         : null;
 
       return {
+        message: actualMessage ?? null,
         modelId,
         parallelIndex,
-        message: actualMessage ?? null,
         run: parallelGroupInfo?.runsByParallelIndex[parallelIndex],
       };
     });
   }, [message, parallelGroupInfo]);
 
-  const sortedCardSlots = useMemo(() => {
-    return [...cardSlots].sort((left, right) => {
-      const leftOrder = getModelOrderIndex(
-        getEffectiveModelId(left.message, left.modelId),
-        models
-      );
-      const rightOrder = getModelOrderIndex(
-        getEffectiveModelId(right.message, right.modelId),
-        models
-      );
+  const sortedCardSlots = useMemo(
+    () =>
+      [...cardSlots].sort((left, right) => {
+        const leftOrder = getModelOrderIndex(
+          getEffectiveModelId(left.message, left.modelId),
+          models
+        );
+        const rightOrder = getModelOrderIndex(
+          getEffectiveModelId(right.message, right.modelId),
+          models
+        );
 
-      if (leftOrder !== rightOrder) {
-        return leftOrder - rightOrder;
-      }
+        if (leftOrder !== rightOrder) {
+          return leftOrder - rightOrder;
+        }
 
-      const leftMessageId =
-        left.message?.id ?? `${left.modelId}:${left.parallelIndex}`;
-      const rightMessageId =
-        right.message?.id ?? `${right.modelId}:${right.parallelIndex}`;
+        const leftMessageId =
+          left.message?.id ?? `${left.modelId}:${left.parallelIndex}`;
+        const rightMessageId =
+          right.message?.id ?? `${right.modelId}:${right.parallelIndex}`;
 
-      return leftMessageId.localeCompare(rightMessageId);
-    });
-  }, [cardSlots, models]);
+        return leftMessageId.localeCompare(rightMessageId);
+      }),
+    [cardSlots, models]
+  );
 
   const selectedParallelIndex = useMemo(() => {
     if (pendingParallelIndex !== null) {

--- a/apps/chat/components/part/document-common.tsx
+++ b/apps/chat/components/part/document-common.tsx
@@ -76,13 +76,13 @@ const PureDocumentToolResult = ({
       className="bg-background flex w-fit cursor-pointer flex-row items-center gap-3 rounded-xl border px-3 py-2"
       onClick={() => {
         setArtifact({
-          documentId: result.id,
-          kind: result.kind,
           content: "",
-          title: result.title,
-          messageId,
+          documentId: result.id,
           isVisible: true,
+          kind: result.kind,
+          messageId,
           status: "idle",
+          title: result.title,
         });
       }}
       type="button"

--- a/apps/chat/components/part/document-preview.tsx
+++ b/apps/chat/components/part/document-preview.tsx
@@ -58,100 +58,6 @@ interface DocumentPreviewProps {
   type?: "create" | "update";
 }
 
-export const DocumentPreview = ({
-  isReadonly,
-  output,
-  input,
-  messageId,
-  type = "create",
-  isLastArtifact = true,
-}: DocumentPreviewProps) => {
-  const { artifact, setArtifact } = useArtifact();
-  const { data: documents, isLoading: isDocumentsFetching } = useDocuments(
-    output?.documentId || "",
-    output?.documentId === "init" || artifact.status === "streaming"
-  );
-
-  const previewDocument = useMemo(() => documents?.[0], [documents]);
-  const hitboxRef = useRef<HTMLDivElement | null>(null);
-
-  // Show collapsed view if artifact panel is visible OR this is not the last artifact
-  if (artifact.isVisible || !isLastArtifact) {
-    if (output) {
-      return (
-        <DocumentToolResult
-          isReadonly={isReadonly}
-          messageId={messageId}
-          result={{
-            id: output.documentId,
-            title: output.title || artifact.title,
-            kind: output.kind,
-          }}
-          type={type}
-        />
-      );
-    }
-
-    if (input) {
-      return (
-        <DocumentToolCall
-          args={{ title: input.title }}
-          isReadonly={isReadonly}
-          type={type}
-        />
-      );
-    }
-  }
-
-  if (isDocumentsFetching) {
-    return (
-      <LoadingSkeleton
-        artifactKind={output?.kind ?? input?.kind ?? artifact.kind}
-      />
-    );
-  }
-
-  const document: Document | null = (() => {
-    if (previewDocument) {
-      return previewDocument;
-    }
-    if (artifact.status === "streaming") {
-      return {
-        title: artifact.title,
-        kind: artifact.kind,
-        content: artifact.content,
-        id: artifact.documentId,
-        createdAt: new Date(),
-        userId: "noop",
-        messageId: "noop",
-      };
-    }
-    return null;
-  })();
-
-  if (!document) {
-    return <LoadingSkeleton artifactKind={artifact.kind} />;
-  }
-
-  return (
-    <div className="relative w-full cursor-pointer">
-      <HitboxLayer
-        hitboxRef={hitboxRef}
-        messageId={messageId}
-        output={output}
-        setArtifact={setArtifact}
-      />
-      <DocumentHeader
-        isStreaming={artifact.status === "streaming"}
-        kind={document.kind}
-        title={document.title}
-        type={type}
-      />
-      <DocumentContent document={document} />
-    </div>
-  );
-};
-
 const LoadingSkeleton = ({
   artifactKind: _artifactKind,
 }: {
@@ -301,6 +207,100 @@ const DocumentHeader = memo(PureDocumentHeader, (prevProps, nextProps) => {
   return true;
 });
 
+export const DocumentPreview = ({
+  isReadonly,
+  output,
+  input,
+  messageId,
+  type = "create",
+  isLastArtifact = true,
+}: DocumentPreviewProps) => {
+  const { artifact, setArtifact } = useArtifact();
+  const { data: documents, isLoading: isDocumentsFetching } = useDocuments(
+    output?.documentId || "",
+    output?.documentId === "init" || artifact.status === "streaming"
+  );
+
+  const previewDocument = useMemo(() => documents?.[0], [documents]);
+  const hitboxRef = useRef<HTMLDivElement | null>(null);
+
+  // Show collapsed view if artifact panel is visible OR this is not the last artifact
+  if (artifact.isVisible || !isLastArtifact) {
+    if (output) {
+      return (
+        <DocumentToolResult
+          isReadonly={isReadonly}
+          messageId={messageId}
+          result={{
+            id: output.documentId,
+            kind: output.kind,
+            title: output.title || artifact.title,
+          }}
+          type={type}
+        />
+      );
+    }
+
+    if (input) {
+      return (
+        <DocumentToolCall
+          args={{ title: input.title }}
+          isReadonly={isReadonly}
+          type={type}
+        />
+      );
+    }
+  }
+
+  if (isDocumentsFetching) {
+    return (
+      <LoadingSkeleton
+        artifactKind={output?.kind ?? input?.kind ?? artifact.kind}
+      />
+    );
+  }
+
+  const document: Document | null = (() => {
+    if (previewDocument) {
+      return previewDocument;
+    }
+    if (artifact.status === "streaming") {
+      return {
+        content: artifact.content,
+        createdAt: new Date(),
+        id: artifact.documentId,
+        kind: artifact.kind,
+        messageId: "noop",
+        title: artifact.title,
+        userId: "noop",
+      };
+    }
+    return null;
+  })();
+
+  if (!document) {
+    return <LoadingSkeleton artifactKind={artifact.kind} />;
+  }
+
+  return (
+    <div className="relative w-full cursor-pointer">
+      <HitboxLayer
+        hitboxRef={hitboxRef}
+        messageId={messageId}
+        output={output}
+        setArtifact={setArtifact}
+      />
+      <DocumentHeader
+        isStreaming={artifact.status === "streaming"}
+        kind={document.kind}
+        title={document.title}
+        type={type}
+      />
+      <DocumentContent document={document} />
+    </div>
+  );
+};
+
 const DocumentContent = ({ document }: { document: Document }) => {
   const { artifact } = useArtifact();
 
@@ -314,12 +314,12 @@ const DocumentContent = ({ document }: { document: Document }) => {
 
   const commonProps = {
     content: document.content ?? "",
-    isCurrentVersion: true,
     currentVersionIndex: 0,
-    status: artifact.status,
+    isCurrentVersion: true,
     saveContent: () => {
       // No-op for preview mode
     },
+    status: artifact.status,
   };
 
   return (

--- a/apps/chat/components/part/document-tool.tsx
+++ b/apps/chat/components/part/document-tool.tsx
@@ -78,7 +78,11 @@ const PureDocumentTool = ({
   ) {
     return (
       <DocumentPreview
-        input={{ title: inputTitle, kind, content: inputContent }}
+        input={{
+          content: inputContent,
+          kind,
+          title: inputTitle,
+        }}
         isLastArtifact={isLastArtifact}
         isReadonly={isReadonly}
         messageId={messageId}
@@ -86,8 +90,8 @@ const PureDocumentTool = ({
           tool.output
             ? {
                 documentId: tool.output.documentId,
-                title: inputTitle,
                 kind,
+                title: inputTitle,
               }
             : undefined
         }

--- a/apps/chat/components/part/tool-part.tsx
+++ b/apps/chat/components/part/tool-part.tsx
@@ -71,9 +71,9 @@ export const ToolPart = ({ part, messageId, isReadonly }: ToolPartProps) => {
 
   if (isInstalledToolType(type)) {
     return renderInstalledTool({
-      part,
-      messageId,
       isReadonly,
+      messageId,
+      part,
     });
   }
 

--- a/apps/chat/components/project-chat-item.tsx
+++ b/apps/chat/components/project-chat-item.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { ShareMenuItem } from "@/components/upgrade-cta/share-menu-item";
 import type { UIChat } from "@/lib/types/ui-chat";
+
 export const ProjectChatItem = ({
   chat,
   onDelete,

--- a/apps/chat/components/project-details-dialog.tsx
+++ b/apps/chat/components/project-details-dialog.tsx
@@ -67,7 +67,11 @@ export const ProjectDetailsDialog = ({
 
     if (mode === "create") {
       if (trimmedName) {
-        onSubmit({ name: trimmedName, icon: finalIcon, color: finalColor });
+        onSubmit({
+          color: finalColor,
+          icon: finalIcon,
+          name: trimmedName,
+        });
         setName("");
         setIcon(null);
         setColor(null);
@@ -79,9 +83,9 @@ export const ProjectDetailsDialog = ({
         finalColor !== (initialColor ?? DEFAULT_PROJECT_COLOR);
       if (hasChanges) {
         await onSubmit({
-          name: trimmedName,
-          icon: finalIcon,
           color: finalColor,
+          icon: finalIcon,
+          name: trimmedName,
         });
       }
       onOpenChange(false);

--- a/apps/chat/components/project-home.tsx
+++ b/apps/chat/components/project-home.tsx
@@ -93,9 +93,9 @@ export const ProjectHome = ({
     await renameProjectMutation.mutateAsync({
       id: projectId,
       updates: {
-        name: data.name,
         icon: data.icon,
         iconColor: data.color,
+        name: data.name,
       },
     });
     queryClient.invalidateQueries({

--- a/apps/chat/components/research-progress.tsx
+++ b/apps/chat/components/research-progress.tsx
@@ -11,10 +11,10 @@ import { ResearchTasks } from "./research-tasks";
 
 // Add the updateName mapping (consider moving to a shared util later)
 const updateName = {
-  web: "Web Search",
-  started: "Started",
   completed: "Completed",
+  started: "Started",
   thoughts: "Thoughts",
+  web: "Web Search",
   writing: "Writing",
 } as const;
 

--- a/apps/chat/components/research-task.tsx
+++ b/apps/chat/components/research-task.tsx
@@ -15,86 +15,84 @@ export const ResearchTask = ({
   update: ResearchUpdate;
   minimal: boolean;
   isRunning: boolean;
-}) => {
-  return (
-    <div className="group">
-      {!minimal && (
-        <div className="flex items-center gap-2">
-          <UpdateTitle isRunning={isRunning} title={update.title} />
-        </div>
-      )}
-      <motion.div
-        animate={{
-          height: "auto",
-          opacity: 1,
-          transition: {
-            height: { duration: 0.2, ease: "easeOut" },
-            opacity: { duration: 0.15, delay: 0.05 },
-          },
-        }}
-        exit={{
-          height: 0,
-          opacity: 0,
-          transition: {
-            height: { duration: 0.2, ease: "easeIn" },
-            opacity: { duration: 0.1 },
-          },
-        }}
-        initial={{ height: 0, opacity: 0 }}
-      >
-        <div className="space-y-2 py-2 pr-2">
-          {update.type === "web" && update.queries && (
+}) => (
+  <div className="group">
+    {!minimal && (
+      <div className="flex items-center gap-2">
+        <UpdateTitle isRunning={isRunning} title={update.title} />
+      </div>
+    )}
+    <motion.div
+      animate={{
+        height: "auto",
+        opacity: 1,
+        transition: {
+          height: { duration: 0.2, ease: "easeOut" },
+          opacity: { duration: 0.15, delay: 0.05 },
+        },
+      }}
+      exit={{
+        height: 0,
+        opacity: 0,
+        transition: {
+          height: { duration: 0.2, ease: "easeIn" },
+          opacity: { duration: 0.1 },
+        },
+      }}
+      initial={{ height: 0, opacity: 0 }}
+    >
+      <div className="space-y-2 py-2 pr-2">
+        {update.type === "web" && update.queries && (
+          <div className="flex flex-wrap gap-2">
+            {update.queries.map((query) => (
+              <Badge
+                className="bg-muted flex items-center gap-1"
+                key={query}
+                variant="outline"
+              >
+                <SearchIcon className="size-3.5" />
+                {/* // TODO: Make this size width responsive or accomodate long text in another manner */}
+                <span className="max-w-[300px] truncate">{query}</span>
+              </Badge>
+            ))}
+          </div>
+        )}
+        {/* Search Results: Show only when completed and results exist */}
+        {update.type === "web" &&
+          update.status === "completed" &&
+          update.results && (
             <div className="flex flex-wrap gap-2">
-              {update.queries.map((query) => (
-                <Badge
-                  className="bg-muted flex items-center gap-1"
-                  key={query}
-                  variant="outline"
-                >
-                  <SearchIcon className="size-3.5" />
-                  {/* // TODO: Make this size width responsive or accomodate long text in another manner */}
-                  <span className="max-w-[300px] truncate">{query}</span>
-                </Badge>
-              ))}
+              {update.type === "web" &&
+                update.results.map((result) => (
+                  <WebSourceBadge key={result.url} result={result} />
+                ))}
             </div>
           )}
-          {/* Search Results: Show only when completed and results exist */}
-          {update.type === "web" &&
-            update.status === "completed" &&
-            update.results && (
-              <div className="flex flex-wrap gap-2">
-                {update.type === "web" &&
-                  update.results.map((result) => (
-                    <WebSourceBadge key={result.url} result={result} />
-                  ))}
-              </div>
-            )}
-          {/* Search Loading State */}
-          {update.type === "web" && update.status === "running" && (
-            <div className="py-2">
-              <div className="flex items-center gap-3">
-                <Loader2 className="text-muted-foreground size-4 animate-spin" />
-                <p className="text-xsize-neutral-500">Searching the web...</p>
-              </div>
+        {/* Search Loading State */}
+        {update.type === "web" && update.status === "running" && (
+          <div className="py-2">
+            <div className="flex items-center gap-3">
+              <Loader2 className="text-muted-foreground size-4 animate-spin" />
+              <p className="text-xsize-neutral-500">Searching the web...</p>
             </div>
-          )}
-          {/* {Thoughts} */}
-          {update.type === "thoughts" && (
-            <div className="space-y-2">
-              <p className="text-foreground text-sm font-light">
-                {update.message}
-              </p>
-            </div>
-          )}
-          {update.type === "writing" && update.message && (
-            <div className="space-y-2">
-              <p className="text-foreground text-sm font-light">
-                {update.message}
-              </p>
-            </div>
-          )}
-        </div>
-      </motion.div>
-    </div>
-  );
-};
+          </div>
+        )}
+        {/* {Thoughts} */}
+        {update.type === "thoughts" && (
+          <div className="space-y-2">
+            <p className="text-foreground text-sm font-light">
+              {update.message}
+            </p>
+          </div>
+        )}
+        {update.type === "writing" && update.message && (
+          <div className="space-y-2">
+            <p className="text-foreground text-sm font-light">
+              {update.message}
+            </p>
+          </div>
+        )}
+      </div>
+    </motion.div>
+  </div>
+);

--- a/apps/chat/components/settings/connectors-settings.tsx
+++ b/apps/chat/components/settings/connectors-settings.tsx
@@ -116,8 +116,8 @@ export const ConnectorsSettings = () => {
       connectorId?: string | null;
     }) => {
       setQs({
-        dialog,
         connectorId: connectorId ?? null,
+        dialog,
       });
     },
     [setQs]
@@ -133,7 +133,10 @@ export const ConnectorsSettings = () => {
 
   const handleOpenConnectDialog = useCallback(
     (connectorId: string) => {
-      setDialogState({ dialog: "connect", connectorId });
+      setDialogState({
+        connectorId,
+        dialog: "connect",
+      });
     },
     [setDialogState]
   );

--- a/apps/chat/components/settings/mcp-create-dialog.tsx
+++ b/apps/chat/components/settings/mcp-create-dialog.tsx
@@ -81,10 +81,10 @@ export const McpCreateDialog = ({
     resolver: zodResolver(mcpConnectorFormSchema),
     defaultValues: {
       name: "",
-      url: "",
-      type: "http",
       oauthClientId: "",
       oauthClientSecret: "",
+      type: "http",
+      url: "",
     },
   });
 
@@ -95,10 +95,10 @@ export const McpCreateDialog = ({
 
     form.reset({
       name: "",
-      url: "",
-      type: "http",
       oauthClientId: "",
       oauthClientSecret: "",
+      type: "http",
+      url: "",
     });
 
     setAdvancedOpen(false);
@@ -123,10 +123,10 @@ export const McpCreateDialog = ({
 
     await createConnector({
       name: trimmed.name,
-      url: trimmed.url,
-      type: trimmed.type,
       oauthClientId: trimmed.oauthClientId,
       oauthClientSecret: trimmed.oauthClientSecret,
+      type: trimmed.type,
+      url: trimmed.url,
     });
     toast.success("Connector added");
     queryClient.invalidateQueries({ queryKey });

--- a/apps/chat/components/settings/mcp-details-page.tsx
+++ b/apps/chat/components/settings/mcp-details-page.tsx
@@ -211,7 +211,10 @@ export const McpDetailsPage = ({ connectorId }: { connectorId: string }) => {
       if (!connector) {
         return;
       }
-      toggleEnabled({ id: connector.id, enabled });
+      toggleEnabled({
+        enabled,
+        id: connector.id,
+      });
     },
     [connector, toggleEnabled]
   );

--- a/apps/chat/components/settings/models-table.tsx
+++ b/apps/chat/components/settings/models-table.tsx
@@ -112,8 +112,8 @@ export const ModelsTable = ({
   const handleToggle = useCallback(
     (modelId: string, currentlyEnabled: boolean) => {
       setModelEnabled({
-        modelId,
         enabled: !currentlyEnabled,
+        modelId,
       });
     },
     [setModelEnabled]

--- a/apps/chat/components/settings/settings-nav.tsx
+++ b/apps/chat/components/settings/settings-nav.tsx
@@ -17,15 +17,23 @@ type SettingsNavItem = {
 
 const getNavItems = (): SettingsNavItem[] => {
   const items: SettingsNavItem[] = [
-    { href: "/settings", label: "General", icon: Settings },
-    { href: "/settings/models", label: "Models", icon: Cpu },
+    {
+      href: "/settings",
+      icon: Settings,
+      label: "General",
+    },
+    {
+      href: "/settings/models",
+      icon: Cpu,
+      label: "Models",
+    },
   ];
 
   if (config.ai.tools.mcp.enabled) {
     items.push({
       href: "/settings/connectors",
-      label: "Connectors",
       icon: Plug,
+      label: "Connectors",
     });
   }
 

--- a/apps/chat/components/sheet-editor.tsx
+++ b/apps/chat/components/sheet-editor.tsx
@@ -32,7 +32,8 @@ const PureSpreadsheetEditor = ({
 
   const parseData = useMemo(() => {
     if (!content) {
-      return new Array(MIN_ROWS).fill(new Array(MIN_COLS).fill(""));
+      const emptyRow = Array.from({ length: MIN_COLS }, () => "");
+      return Array.from({ length: MIN_ROWS }, () => emptyRow);
     }
     const result = parse<string[]>(content, { skipEmptyLines: true });
 
@@ -45,7 +46,7 @@ const PureSpreadsheetEditor = ({
     });
 
     while (paddedData.length < MIN_ROWS) {
-      paddedData.push(new Array(MIN_COLS).fill(""));
+      paddedData.push(Array.from({ length: MIN_COLS }, () => ""));
     }
 
     return paddedData;
@@ -53,18 +54,18 @@ const PureSpreadsheetEditor = ({
 
   const columns = useMemo(() => {
     const rowNumberColumn = {
+      cellClass: "border-t border-r bg-background text-foreground",
+      frozen: true,
+      headerCellClass: "border-t border-r bg-muted text-foreground",
       key: "rowNumber",
       name: "",
-      frozen: true,
-      width: 50,
       renderCell: ({ rowIdx }: { rowIdx: number }) => rowIdx + 1,
-      cellClass: "border-t border-r bg-background text-foreground",
-      headerCellClass: "border-t border-r bg-muted text-foreground",
+      width: 50,
     };
 
     const dataColumns = Array.from({ length: MIN_COLS }, (_, i) => ({
       key: i.toString(),
-      name: String.fromCharCode(65 + i),
+      name: String.fromCodePoint(65 + i),
       renderEditCell: isReadonly ? undefined : textEditor,
       width: 120,
       cellClass: cn("bg-background text-foreground border-t", {
@@ -86,9 +87,9 @@ const PureSpreadsheetEditor = ({
           rowNumber: rowIndex + 1,
         };
 
-        columns.slice(1).forEach((col, colIndex) => {
+        for (const [colIndex, col] of columns.slice(1).entries()) {
           rowData[col.key] = row[colIndex] || "";
-        });
+        }
 
         return rowData;
       }),

--- a/apps/chat/components/sidebar-project-item.tsx
+++ b/apps/chat/components/sidebar-project-item.tsx
@@ -43,9 +43,9 @@ export const SidebarProjectItem = ({
     await renameProject({
       id: project.id,
       updates: {
-        name: data.name,
         icon: data.icon,
         iconColor: data.color,
+        name: data.name,
       },
     });
   };

--- a/apps/chat/components/sidebar-projects.tsx
+++ b/apps/chat/components/sidebar-projects.tsx
@@ -48,9 +48,9 @@ export const SidebarProjects = () => {
 
   const handleCreateProject = (data: ProjectDetailsData) => {
     createProjectMutation.mutate({
-      name: data.name,
       icon: data.icon,
       iconColor: data.color,
+      name: data.name,
     });
   };
 

--- a/apps/chat/components/sources.tsx
+++ b/apps/chat/components/sources.tsx
@@ -122,8 +122,8 @@ const ShowSourcesButton = ({
       className="mr-1.5"
       maxVisible={3}
       sources={sources.map((s) => ({
-        url: s.url,
         title: s.title,
+        url: s.url,
       }))}
     />
     <span className="text-muted-foreground group-hover:text-foreground text-xs">

--- a/apps/chat/components/suggested-actions.tsx
+++ b/apps/chat/components/suggested-actions.tsx
@@ -44,9 +44,9 @@ const PureSuggestedActions = ({
     () =>
       [
         {
+          icon: PenLineIcon,
           id: "write",
           label: "Write",
-          icon: PenLineIcon,
           prompts: [
             "Write a concise email to reschedule a meeting",
             "Turn these bullet points into a clear memo",
@@ -56,9 +56,9 @@ const PureSuggestedActions = ({
           ],
         },
         {
+          icon: GraduationCapIcon,
           id: "learn",
           label: "Learn",
-          icon: GraduationCapIcon,
           prompts: [
             "Explain this concept like I'm smart but new to it",
             "Quiz me on this topic (start easy, ramp up)",
@@ -68,9 +68,9 @@ const PureSuggestedActions = ({
           ],
         },
         {
+          icon: Code2Icon,
           id: "code",
           label: "Code",
-          icon: Code2Icon,
           prompts: [
             "Implement this feature and explain tradeoffs",
             "Find the bug in this snippet and fix it",
@@ -80,9 +80,9 @@ const PureSuggestedActions = ({
           ],
         },
         {
+          icon: SparklesIcon,
           id: "life",
           label: "Life stuff",
-          icon: SparklesIcon,
           prompts: [
             "Plan a simple healthy meal prep for the week",
             "Help me choose between these options (pros/cons)",

--- a/apps/chat/components/text-editor.tsx
+++ b/apps/chat/components/text-editor.tsx
@@ -99,8 +99,8 @@ const ContentUpdatePlugin = ({
   const handleChange = (editorState: EditorState) => {
     if (!(isReadonly || isProgrammaticUpdate.current)) {
       handleEditorChange({
-        editorState,
         editor,
+        editorState,
         onSaveContent,
       });
     }

--- a/apps/chat/components/ui/form.tsx
+++ b/apps/chat/components/ui/form.tsx
@@ -38,6 +38,14 @@ const FormField = <
   </FormFieldContext.Provider>
 );
 
+type FormItemContextValue = {
+  id: string;
+};
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+);
+
 const useFormField = () => {
   const fieldContext = React.useContext(FormFieldContext);
   const itemContext = React.useContext(FormItemContext);
@@ -60,14 +68,6 @@ const useFormField = () => {
     ...fieldState,
   };
 };
-
-type FormItemContextValue = {
-  id: string;
-};
-
-const FormItemContext = React.createContext<FormItemContextValue>(
-  {} as FormItemContextValue
-);
 
 const FormItem = ({ className, ...props }: React.ComponentProps<"div">) => {
   const id = React.useId();

--- a/apps/chat/components/ui/scroll-area.tsx
+++ b/apps/chat/components/ui/scroll-area.tsx
@@ -5,24 +5,6 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-const ScrollArea = React.forwardRef<
-  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
->(({ className, children, ...props }, ref) => (
-  <ScrollAreaPrimitive.Root
-    className={cn("relative overflow-hidden", className)}
-    ref={ref}
-    {...props}
-  >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
-      {children}
-    </ScrollAreaPrimitive.Viewport>
-    <ScrollBar />
-    <ScrollAreaPrimitive.Corner />
-  </ScrollAreaPrimitive.Root>
-));
-ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
-
 const ScrollBar = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
   React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
@@ -44,5 +26,23 @@ const ScrollBar = React.forwardRef<
   </ScrollAreaPrimitive.ScrollAreaScrollbar>
 ));
 ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    className={cn("relative overflow-hidden", className)}
+    ref={ref}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+));
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
 
 export { ScrollArea, ScrollBar };

--- a/apps/chat/components/ui/sidebar.tsx
+++ b/apps/chat/components/ui/sidebar.tsx
@@ -128,12 +128,12 @@ const SidebarProvider = ({
 
   const contextValue = React.useMemo<SidebarContextProps>(
     () => ({
-      state,
-      open,
-      setOpen,
       isMobile,
+      open,
       openMobile,
+      setOpen,
       setOpenMobile,
+      state,
       toggleSidebar,
     }),
     [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar]

--- a/apps/chat/components/upgrade-cta/limit-display.tsx
+++ b/apps/chat/components/upgrade-cta/limit-display.tsx
@@ -27,6 +27,10 @@ const VARIANT_CONFIG: Record<
 > = {
   credits: {
     dismissible: true,
+    getClasses: ({ isAtLimit }) =>
+      isAtLimit
+        ? "bg-red-100 dark:bg-red-950/30 text-red-800 dark:text-red-200"
+        : "bg-amber-100 dark:bg-amber-950/30 text-amber-800 dark:text-amber-200",
     getMessage: ({ remaining, isAtLimit }) =>
       isAtLimit ? (
         <span>
@@ -53,13 +57,11 @@ const VARIANT_CONFIG: Record<
           </InternalLink>
         </span>
       ),
-    getClasses: ({ isAtLimit }) =>
-      isAtLimit
-        ? "bg-red-100 dark:bg-red-950/30 text-red-800 dark:text-red-200"
-        : "bg-amber-100 dark:bg-amber-950/30 text-amber-800 dark:text-amber-200",
   },
   model: {
     dismissible: false,
+    getClasses: () =>
+      "bg-amber-100 dark:bg-amber-950/30 text-amber-800 dark:text-amber-200",
     getMessage: () => (
       <span>
         This model isn&apos;t available for anonymous users.{" "}
@@ -71,14 +73,12 @@ const VARIANT_CONFIG: Record<
         </InternalLink>
       </span>
     ),
-    getClasses: () =>
-      "bg-amber-100 dark:bg-amber-950/30 text-amber-800 dark:text-amber-200",
   },
   image: {
     dismissible: false,
-    getMessage: () => <span>Image models are not supported here yet.</span>,
     getClasses: () =>
       "bg-amber-100 dark:bg-amber-950/30 text-amber-800 dark:text-amber-200",
+    getMessage: () => <span>Image models are not supported here yet.</span>,
   },
 };
 
@@ -133,7 +133,10 @@ export const LimitDisplay = ({
           )}
         >
           <div className="flex-1">
-            {config.getMessage({ remaining, isAtLimit })}
+            {config.getMessage({
+              isAtLimit,
+              remaining,
+            })}
           </div>
           {config.dismissible ? (
             <Button

--- a/apps/chat/components/upgrade-cta/login-cta-banner.tsx
+++ b/apps/chat/components/upgrade-cta/login-cta-banner.tsx
@@ -30,24 +30,24 @@ export const LoginCtaBanner = ({
   }
 
   const variantStyles = {
-    default:
-      "bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800",
     amber:
       "bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800",
+    default:
+      "bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800",
     red: "bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800",
   };
 
   const textStyles = {
-    default: "text-blue-800 dark:text-blue-200",
     amber: "text-amber-800 dark:text-amber-200",
+    default: "text-blue-800 dark:text-blue-200",
     red: "text-red-800 dark:text-red-200",
   };
 
   const linkStyles = {
-    default:
-      "text-blue-700 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-100",
     amber:
       "text-amber-700 dark:text-amber-300 hover:text-amber-900 dark:hover:text-amber-100",
+    default:
+      "text-blue-700 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-100",
     red: "text-red-700 dark:text-red-300 hover:text-red-900 dark:hover:text-red-100",
   };
 

--- a/apps/chat/components/user-message.tsx
+++ b/apps/chat/components/user-message.tsx
@@ -32,10 +32,17 @@ const PureUserMessage = ({
     isOpen: boolean;
     imageUrl: string;
     imageName?: string;
-  }>({ isOpen: false, imageUrl: "" });
+  }>({
+    imageUrl: "",
+    isOpen: false,
+  });
 
   const handleImageClick = (imageUrl: string, imageName?: string) => {
-    setImageModal({ isOpen: true, imageUrl, imageName });
+    setImageModal({
+      imageName,
+      imageUrl,
+      isOpen: true,
+    });
   };
 
   if (!message) {
@@ -140,7 +147,12 @@ const PureUserMessage = ({
         imageName={imageModal.imageName}
         imageUrl={imageModal.imageUrl}
         isOpen={imageModal.isOpen}
-        onClose={() => setImageModal({ isOpen: false, imageUrl: "" })}
+        onClose={() =>
+          setImageModal({
+            imageUrl: "",
+            isOpen: false,
+          })
+        }
       />
     </>
   );

--- a/apps/chat/components/version-footer.tsx
+++ b/apps/chat/components/version-footer.tsx
@@ -56,10 +56,10 @@ export const VersionFooter = ({
             const versionToRestore = documents[currentVersionIndex];
 
             saveDocumentMutation.mutate({
-              id: artifact.documentId,
               content: versionToRestore.content ?? "",
-              title: versionToRestore.title,
+              id: artifact.documentId,
               kind: versionToRestore.kind,
+              title: versionToRestore.title,
             });
           }}
         >


### PR DESCRIPTION
Sort reviewed component records and place component consumers after their dependencies, removing 117 net strict diagnostics across 50 source files (336 → 219). The lint baseline is intentionally unchanged; resolved exemptions will be removed in the final configuration cleanup.

- Sort 90 named prop, options, lookup, and data records. Keep arrays, feature registry order, styles, CVA configuration, and TanStack mutation callback order unchanged. Tool feature consumers read `.icon`, `.name`, and `.shortName`; only each inner record changes. Other records use named APIs/context fields or indexed lookup. Effectful expressions keep their relative order; records containing one call only move it relative to plain local/data reads.
- Move pure consumers below existing context/memo declarations. ScrollBar and ScrollArea are independent valid `forwardRef` wrappers; installed React only allocates those wrappers without executing callbacks, and each displayName assignment stays with its wrapper.
- Simplify four arrow bodies, unused catch bindings, iterable FileList copies, and a missing import separator. Use dense spreadsheet arrays while preserving the existing shared blank-row identity. The column loop is dense by construction; the code-point conversion is bounded to A–Z.

Validation: `bun lint`, `bun test:types` (all seven packages), and chat unit tests (47 files / 193 tests) pass. AST comparison verifies all 50 files retain body/parameter/property values and meaningful initialization order, with explicit normalization for the listed mechanical transforms. Two removed ordering diagnostics overlap the pending earlier helper-order PR. The existing chat-sync promise callback retains its original block form to avoid exposing a new promise-style diagnostic.

Browser validation is pending: the local Next 16.3 server announces Ready but every HTTP request, including `/_next/mcp`, hangs before any route compilation. A process sample shows its main thread blocked in macOS libuv FSEvents cleanup (`uv__fsevents_close → uv_sem_wait`). The issue persists with a clean dev cache, different worktree port, polling flags, Node 24, and Bun runtime. No successful browser result is claimed; require the integrated browser run / CI before merging.

## Summary by Sourcery

Apply safe ordering and cleanup refactors across chat components while preserving behavior and validating the resulting changes.

Enhancements:
- Standardize object and record ordering across chat components to satisfy safe ordering diagnostics without changing runtime behavior.
- Reorder dependent component declarations and simplify selected callbacks, arrow bodies, iterable conversions, and spreadsheet data construction while preserving behavior.
- Extract chat breadcrumb and composer attachment functionality into independently organized components and contexts.

Tests:
- Validate the refactor with linting, type checks, chat unit tests, and AST-based preservation checks.

Chores:
- Reduce strict diagnostics across the affected source files while keeping the lint baseline unchanged.