### PR TITLE
style(chat): iterate throttled effects directly

### DIFF
--- a/apps/chat/lib/stores/base/hooks.ts
+++ b/apps/chat/lib/stores/base/hooks.ts
@@ -299,13 +299,13 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
             _throttledMessages: newThrottledMessages,
           });
 
-          throttledEffects.forEach((cb) => {
+          for (const cb of throttledEffects) {
             try {
               cb();
             } catch (err) {
               debug.warn("[chat-store-base] throttled effect error", err);
             }
-          });
+          }
         });
       }, MESSAGES_THROTTLE_MS);
     }


### PR DESCRIPTION
Replace Set.forEach with a for-of loop when invoking throttled effects. Set iteration order and live membership semantics are preserved, while the callback remains inside the existing try/catch. This resolves the array-forEach and callback-return diagnostics without changing scheduling or error handling.\n\nValidation: targeted oxlint; 11 store tests; bun lint; bun test:types.

## Summary by Sourcery

Enhancements:
- Iterate throttled chat-store effects directly while preserving iteration behavior and existing error handling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches throttled chat-store effects from `Set.forEach` to a `for...of` loop, clearing array-forEach and callback-return diagnostics without changing iteration order, live membership, scheduling, or error handling.

<sup>Written for commit ef4d8c6766a740bf8c47fa68064e68f4f246fc2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

