### PR TITLE
chore: normalize test imports and fixture records

### DIFF
--- a/apps/chat/components/part/tool-part.test.tsx
+++ b/apps/chat/components/part/tool-part.test.tsx
@@ -1,10 +1,12 @@
 import { expect, it, vi } from "vitest";
 
+import { ToolPart } from "./tool-part";
+
 const renderers = vi.hoisted(() => ({
   "tool-codeExecution": () => null,
-  "tool-webSearch": () => null,
   "tool-generateImage": () => null,
   "tool-generateVideo": () => null,
+  "tool-webSearch": () => null,
 }));
 vi.mock("@/lib/ai/tool-renderer-registry", () => ({
   isInstalledToolType: (type: string) => Object.hasOwn(renderers, type),
@@ -13,8 +15,6 @@ vi.mock("@/lib/ai/tool-renderer-registry", () => ({
 vi.mock("./deep-research", () => ({ DeepResearch: () => null }));
 vi.mock("./document-tool", () => ({ DocumentTool: () => null }));
 vi.mock("./read-document", () => ({ ReadDocument: () => null }));
-
-import { ToolPart } from "./tool-part";
 
 it.each([
   "tool-codeExecution",
@@ -26,10 +26,10 @@ it.each([
     isReadonly: false,
     messageId: "test-message",
     part: {
-      type,
-      toolCallId: "test-call",
-      state: "input-streaming",
       input: {},
+      state: "input-streaming",
+      toolCallId: "test-call",
+      type,
     },
   });
   expect(element?.type).toBe(renderers[type]);

--- a/apps/chat/tools/chatjs/vercel-code-execution/tool.test.ts
+++ b/apps/chat/tools/chatjs/vercel-code-execution/tool.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, expect, it, vi } from "vitest";
 
+import { codeExecution } from "./tool";
+
 const mocks = vi.hoisted(() => ({
   cleanup: vi.fn(),
   create: vi.fn(),
@@ -19,8 +21,6 @@ vi.mock("./javascript", () => ({
 vi.mock("@/lib/logger", () => ({
   createModuleLogger: () => ({ debug: vi.fn(), error: vi.fn(), info: vi.fn() }),
 }));
-
-import { codeExecution } from "./tool";
 
 const sandbox = { id: "isolated-sandbox" };
 beforeEach(() => {


### PR DESCRIPTION
Move two test imports into the import section and sort two plain fixture records. Vitest hoists `vi.hoisted` and `vi.mock` before transformed imports, preserving mock initialization and renderer lookup behavior.

Validation: `bun lint`, `bun test:types`, and both affected Vitest files (7 tests) pass. Existing lint exemptions will be pruned together after the source cleanup batches merge.

## Summary by Sourcery

Normalize test imports and fixture records across the affected chat component and tool tests.

Enhancements:
- Normalize test import placement and ordering for consistent module structure.
- Sort fixture object fields in the affected tests for consistent formatting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves test imports into the import section and sorts fixture records so Vitest hoisting preserves mock initialization and renderer lookup behavior. No functional changes.

<sup>Written for commit bf7775d90a6af79fd2cea35f36964772d007d855. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

