### PR TITLE
style(chat): clean remaining trivial records

### DIFF
--- a/apps/chat/app/layout.tsx
+++ b/apps/chat/app/layout.tsx
@@ -13,32 +13,32 @@ import { ThemeProvider } from "@/components/theme-provider";
 import { config } from "@/lib/config";
 
 export const metadata: Metadata = {
-  metadataBase: new URL(config.appUrl),
-  title: config.appTitle ?? config.appName,
   description: config.appDescription,
+  metadataBase: new URL(config.appUrl),
   openGraph: {
-    siteName: config.appName,
-    url: config.appUrl,
-    title: config.appTitle ?? config.appName,
     description: config.appDescription,
+    siteName: config.appName,
+    title: config.appTitle ?? config.appName,
+    url: config.appUrl,
   },
+  title: config.appTitle ?? config.appName,
 };
 
 export const viewport = {
+  interactiveWidget: "resizes-content" as const,
   // Disable auto-zoom on mobile Safari
   maximumScale: 1,
-  interactiveWidget: "resizes-content" as const,
 };
 
 const geist = Geist({
-  subsets: ["latin"],
   display: "swap",
+  subsets: ["latin"],
   variable: "--font-geist",
 });
 
 const geistMono = Geist_Mono({
-  subsets: ["latin"],
   display: "swap",
+  subsets: ["latin"],
   variable: "--font-geist-mono",
 });
 

--- a/apps/chat/lib/stores/with-data-stream.test.ts
+++ b/apps/chat/lib/stores/with-data-stream.test.ts
@@ -10,12 +10,12 @@ describe("withDataStream", () => {
   it("stores transient stream parts on the chat store", () => {
     const store = createCustomChatStore<ChatMessage>();
     const streamPart = {
-      type: "data-userMessagePersisted",
       data: {
         chatId: "chat-1",
         parallelGroupId: "group-1",
         userMessageId: "user-1",
       },
+      type: "data-userMessagePersisted",
     } as const;
 
     store.getState().setDataStream([streamPart]);

--- a/apps/chat/lib/stores/with-thread-state.ts
+++ b/apps/chat/lib/stores/with-thread-state.ts
@@ -51,26 +51,26 @@ export const withThreadState =
       updateThreadSnapshot: (updater) => {
         let didChangeSelectedPath = false;
         set((state) => {
-          const threadSnapshot = updater(state.threadSnapshot);
+          const nextSnapshot = updater(state.threadSnapshot);
           // Sibling switches change the rendered ids. Flush throttled
           // messages in the same update so UserMessage can still resolve
           // the ids it is currently rendering; otherwise it returns null
           // and the assistant jumps up for a frame.
           didChangeSelectedPath = haveSelectedPathIdsChanged(
             state._throttledMessages ?? state.messages,
-            threadSnapshot.messages
+            nextSnapshot.messages
           );
-          state._messageIndex.update(threadSnapshot.messages);
+          state._messageIndex.update(nextSnapshot.messages);
 
           return {
             ...state,
             _memoizedSelectors: new Map(),
-            error: threadSnapshot.error,
-            messages: threadSnapshot.messages,
-            status: threadSnapshot.status,
-            threadSnapshot,
+            error: nextSnapshot.error,
+            messages: nextSnapshot.messages,
+            status: nextSnapshot.status,
+            threadSnapshot: nextSnapshot,
             ...(didChangeSelectedPath
-              ? { _throttledMessages: threadSnapshot.messages }
+              ? { _throttledMessages: nextSnapshot.messages }
               : {}),
           };
         });

--- a/apps/chat/lib/thread-utils.test.ts
+++ b/apps/chat/lib/thread-utils.test.ts
@@ -24,9 +24,9 @@ const message = ({
   metadata: {
     activeStreamId: null,
     createdAt: new Date(parallelIndex ?? 0),
-    parentMessageId,
     parallelGroupId: parallelIndex === null ? null : "group-1",
     parallelIndex,
+    parentMessageId,
     selectedModel: gatewayModelDefaults.workflows.title,
   },
   parts: [{ text: id, type: "text" }],
@@ -42,14 +42,14 @@ describe("buildTreeSnapshotFromMessages", () => {
     });
     const first = message({
       id: "first",
-      parentMessageId: root.id,
       parallelIndex: 0,
+      parentMessageId: root.id,
       role: "assistant",
     });
     const second = message({
       id: "second",
-      parentMessageId: root.id,
       parallelIndex: 1,
+      parentMessageId: root.id,
       role: "assistant",
     });
 

--- a/apps/chat/scripts/check-redis.ts
+++ b/apps/chat/scripts/check-redis.ts
@@ -74,7 +74,7 @@ const checkRedis = async () => {
         await subscriber.unsubscribe(key);
         await publisher.del(key);
       })(),
-      new Promise<never>((_, reject) => {
+      new Promise<never>((_resolve, reject) => {
         deadline = setTimeout(
           () => reject(new Error("Redis check timed out")),
           CHECK_DEADLINE_MS


### PR DESCRIPTION
Resolve mechanically safe cleanup diagnostics across chat metadata, test fixtures, thread state naming, and Redis probe parameter naming. Record reordering affects only pure literals/references; the thread snapshot rename preserves the state property name and all iteration/effect behavior.\n\nValidation: strict targeted oxlint for sort-keys/no-shadow/no-inline-comments/promise-param-names; 3 relevant Vitest files (6 tests); bun lint; bun test:types.

## Summary by Sourcery

Enhancements:
- Clean up remaining trivial lint diagnostics across chat metadata, fixtures, thread state naming, and Redis probe parameters without changing behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up trivial lint diagnostics across chat metadata, test fixtures, thread state, and the Redis probe. No behavior changes—key reordering is pure literal/reference movement, the thread snapshot rename preserves the `threadSnapshot` state property and all effect behavior, and the Redis probe only renames an unused promise parameter.

<sup>Written for commit be0b3b746062b806592bf4adf15d0eea9bf9e5a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

