### PR TITLE
style: clean electron menu and gateway log records

### DIFF
--- a/apps/chat/lib/ai/gateways/fallback-models.ts
+++ b/apps/chat/lib/ai/gateways/fallback-models.ts
@@ -20,7 +20,7 @@ export const getFallbackModels = (
 ): readonly AiGatewayModel[] => {
   if (generatedForGateway !== gateway) {
     log.warn(
-      { expected: gateway, actual: generatedForGateway },
+      { actual: generatedForGateway, expected: gateway },
       "Fallback snapshot was generated for a different gateway, skipping. Run `bun fetch:models` to regenerate."
     );
     return [];

--- a/apps/electron/src/main.ts
+++ b/apps/electron/src/main.ts
@@ -578,8 +578,9 @@ const setupApplicationMenu = (): void => {
     {
       role: "editMenu",
     },
-    ...(!app.isPackaged
-      ? ([
+    ...(app.isPackaged
+      ? []
+      : ([
           {
             role: "viewMenu",
             submenu: [
@@ -589,8 +590,7 @@ const setupApplicationMenu = (): void => {
               { role: "toggleDevTools" },
             ],
           },
-        ] satisfies MenuItemConstructorOptions[])
-      : []),
+        ] satisfies MenuItemConstructorOptions[])),
     {
       role: "windowMenu",
     },


### PR DESCRIPTION
Normalize the Electron development menu conditional to the positive packaged case while preserving the exact menu entries and order. Sort the fallback gateway logger context fields without changing values.

Validation:

- Strict target oxlint.
- Electron icon tests: 2 passed.
- `bun lint`.
- `bun test:types`.
