### PR TITLE
refactor: clear mechanical component and CVA dictionary warnings

### DIFF
--- a/apps/chat/components/ai-elements/prompt-input.tsx
+++ b/apps/chat/components/ai-elements/prompt-input.tsx
@@ -157,7 +157,9 @@ export const PromptInputProvider = ({
     (FileUIPart & { id: string })[]
   >([]);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const openRef = useRef<() => void>(() => {});
+  const openRef = useRef<() => void>(() => {
+    // The provider registers the file dialog callback after mounting.
+  });
 
   const add = useCallback((files: File[] | FileList) => {
     const incoming = Array.from(files);
@@ -165,17 +167,16 @@ export const PromptInputProvider = ({
       return;
     }
 
-    setAttachements((prev) =>
-      prev.concat(
-        incoming.map((file) => ({
-          id: nanoid(),
-          type: "file" as const,
-          url: URL.createObjectURL(file),
-          mediaType: file.type,
-          filename: file.name,
-        }))
-      )
-    );
+    setAttachements((prev) => [
+      ...prev,
+      ...incoming.map((file) => ({
+        id: nanoid(),
+        type: "file" as const,
+        url: URL.createObjectURL(file),
+        mediaType: file.type,
+        filename: file.name,
+      })),
+    ]);
   }, []);
 
   const remove = useCallback((id: string) => {
@@ -542,14 +543,15 @@ export const PromptInput = ({
             filename: file.name,
           });
         }
-        return prev.concat(next);
+        return [...prev, ...next];
       });
     },
     [matchesAccept, maxFiles, maxFileSize, onError]
   );
 
   const add = usingProvider
-    ? (files: File[] | FileList) => controller.attachments.add(files)
+    ? (incomingFiles: File[] | FileList) =>
+        controller.attachments.add(incomingFiles)
     : addLocal;
 
   const remove = usingProvider
@@ -1123,7 +1125,7 @@ export const PromptInputSpeechButton = ({
       speechRecognition.onresult = (event) => {
         let finalTranscript = "";
 
-        for (let i = event.resultIndex; i < event.results.length; i++) {
+        for (let i = event.resultIndex; i < event.results.length; i += 1) {
           const result = event.results[i];
           if (result.isFinal) {
             finalTranscript += result[0]?.transcript ?? "";

--- a/apps/chat/components/anonymous-session-init.tsx
+++ b/apps/chat/components/anonymous-session-init.tsx
@@ -53,7 +53,6 @@ export const AnonymousSessionInit = () => {
         queryClient.invalidateQueries({
           queryKey: trpc.credits.getAvailableCredits.queryKey(),
         });
-        return;
       }
     } else {
       setAnonymousSession(createAnonymousSession());

--- a/apps/chat/components/chat-rename-dialog.tsx
+++ b/apps/chat/components/chat-rename-dialog.tsx
@@ -38,10 +38,8 @@ export const ChatRenameDialog = ({
     const trimmedValue = chatTitle.trim();
     if (trimmedValue && trimmedValue !== currentTitle) {
       await onSubmit(trimmedValue);
-      onOpenChange(false);
-    } else {
-      onOpenChange(false);
     }
+    onOpenChange(false);
   };
 
   const handleOpenChange = (newOpen: boolean) => {

--- a/apps/chat/components/chat-sync.tsx
+++ b/apps/chat/components/chat-sync.tsx
@@ -78,12 +78,14 @@ export const ChatSync = ({
             prepareReconnectToStreamRequest({ id: chatId }) {
               const current = thread.getSnapshot().messages.at(-1);
               const activeStreamId = current?.metadata?.activeStreamId ?? null;
-              const partialMessageId = isResumableActiveStreamId(activeStreamId)
+              const resumableMessageId = isResumableActiveStreamId(
+                activeStreamId
+              )
                 ? (current?.id ?? null)
                 : null;
 
               return {
-                api: `/api/chat/${chatId}/stream${partialMessageId ? `?messageId=${encodeURIComponent(partialMessageId)}` : ""}`,
+                api: `/api/chat/${chatId}/stream${resumableMessageId ? `?messageId=${encodeURIComponent(resumableMessageId)}` : ""}`,
               };
             },
           }),

--- a/apps/chat/components/create-artifact.tsx
+++ b/apps/chat/components/create-artifact.tsx
@@ -109,7 +109,7 @@ export class Artifact<
   }: {
     documentId: string;
     setMetadata: Dispatch<SetStateAction<M>>;
-    trpc: ReturnType<typeof import("@/trpc/react").useTRPC>;
+    trpc: ReturnType<typeof useTRPC>;
     queryClient: QueryClient;
     isAuthenticated: boolean;
   }) => void;

--- a/apps/chat/components/data-stream-handler.tsx
+++ b/apps/chat/components/data-stream-handler.tsx
@@ -132,7 +132,7 @@ export const DataStreamHandler = () => {
     const newDeltas = dataStream.slice(lastProcessedIndex.current + 1);
     lastProcessedIndex.current = dataStream.length - 1;
     lastProcessedPart.current = dataStream.at(-1);
-    const messages = chatStore.getState().messages;
+    const { messages } = chatStore.getState();
 
     for (const delta of newDeltas) {
       if (!isDataPartOnMessagePath(delta, messages)) {

--- a/apps/chat/components/diffview.tsx
+++ b/apps/chat/components/diffview.tsx
@@ -102,7 +102,8 @@ class DiffTextNode extends TextNode {
 
     if (prevDiffType !== currentDiffType) {
       // Update classes if diff type changed
-      return false; // Force recreation
+      // Force recreation
+      return false;
     }
 
     return super.updateDOM(prevNode as this, dom, config);

--- a/apps/chat/components/image-modal.tsx
+++ b/apps/chat/components/image-modal.tsx
@@ -57,9 +57,9 @@ const handleDownload = async (
     const a = document.createElement("a");
     a.href = url;
     a.download = `image-${Date.now()}.png`;
-    document.body.appendChild(a);
+    document.body.append(a);
     a.click();
-    document.body.removeChild(a);
+    a.remove();
     URL.revokeObjectURL(url);
   } catch (_error) {
     toast.error("Failed to download image");

--- a/apps/chat/components/keyboard-shortcuts.tsx
+++ b/apps/chat/components/keyboard-shortcuts.tsx
@@ -32,6 +32,6 @@ export const getNewChatShortcutText = () => {
     return "Ctrl+Shift+O";
   }
 
-  const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+  const isMac = navigator.platform.toUpperCase().includes("MAC");
   return isMac ? "Cmd+Shift+O" : "Ctrl+Shift+O";
 };

--- a/apps/chat/components/message.tsx
+++ b/apps/chat/components/message.tsx
@@ -18,23 +18,19 @@ const PurePreviewMessage = ({
     return null;
   }
 
-  return (
-    <>
-      {role === "user" ? (
-        <UserMessage
-          isLoading={isLoading}
-          isReadonly={isReadonly}
-          messageId={messageId}
-          parentMessageId={parentMessageId}
-        />
-      ) : (
-        <AssistantMessage
-          isLoading={isLoading}
-          isReadonly={isReadonly}
-          messageId={messageId}
-        />
-      )}
-    </>
+  return role === "user" ? (
+    <UserMessage
+      isLoading={isLoading}
+      isReadonly={isReadonly}
+      messageId={messageId}
+      parentMessageId={parentMessageId}
+    />
+  ) : (
+    <AssistantMessage
+      isLoading={isLoading}
+      isReadonly={isReadonly}
+      messageId={messageId}
+    />
   );
 };
 

--- a/apps/chat/components/parallel-response-cards.tsx
+++ b/apps/chat/components/parallel-response-cards.tsx
@@ -136,7 +136,7 @@ const PureParallelResponseCards = ({ messageId }: { messageId: string }) => {
     }
 
     const slot = cardSlots.find(
-      (slot) => slot.parallelIndex === pendingParallelIndex
+      (candidate) => candidate.parallelIndex === pendingParallelIndex
     );
     if (!slot) {
       return;

--- a/apps/chat/components/part/document-tool.tsx
+++ b/apps/chat/components/part/document-tool.tsx
@@ -10,7 +10,7 @@ import type { DocumentToolType } from "@/tools/platform/documents/types";
 
 import { DocumentPreview } from "./document-preview";
 
-type DocumentTool = Extract<
+type DocumentToolPart = Extract<
   ChatMessage["parts"][number],
   { type: DocumentToolType }
 >;
@@ -18,7 +18,7 @@ type DocumentTool = Extract<
 interface DocumentToolComponentProps {
   isReadonly: boolean;
   messageId: string;
-  tool: DocumentTool;
+  tool: DocumentToolPart;
 }
 
 const PureDocumentTool = ({

--- a/apps/chat/components/search-chats.tsx
+++ b/apps/chat/components/search-chats.tsx
@@ -14,7 +14,7 @@ const getSearchShortcutText = () => {
     return "Ctrl+K";
   }
 
-  const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+  const isMac = navigator.platform.toUpperCase().includes("MAC");
   return isMac ? "Cmd+K" : "Ctrl+K";
 };
 

--- a/apps/chat/components/settings/mcp-details-page.tsx
+++ b/apps/chat/components/settings/mcp-details-page.tsx
@@ -26,7 +26,7 @@ import { ConnectorHeader } from "./connector-header";
 import { McpConnectDialog } from "./mcp-connect-dialog";
 import { SettingsPageContent } from "./settings-page";
 
-const HTTP_STATUS_REGEX = /HTTP (\d{3})/;
+const HTTP_STATUS_REGEX = /HTTP (?<status>\d{3})/u;
 
 const formatMcpError = (message: string): string => {
   const httpMatch = message.match(HTTP_STATUS_REGEX);

--- a/apps/chat/components/ui/alert.tsx
+++ b/apps/chat/components/ui/alert.tsx
@@ -7,15 +7,15 @@ import { cn } from "@/lib/utils";
 const alertVariants = cva(
   "[&>svg]:text-foreground relative w-full rounded-lg border p-4 [&>svg]:absolute [&>svg]:top-4 [&>svg]:left-4 [&>svg+div]:translate-y-[-3px] [&>svg~*]:pl-7",
   {
+    defaultVariants: {
+      variant: "default",
+    },
     variants: {
       variant: {
         default: "bg-background text-foreground",
         destructive:
           "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
       },
-    },
-    defaultVariants: {
-      variant: "default",
     },
   }
 );

--- a/apps/chat/components/ui/badge.tsx
+++ b/apps/chat/components/ui/badge.tsx
@@ -7,19 +7,19 @@ import { cn } from "@/lib/utils";
 const badgeVariants = cva(
   "focus:ring-ring inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none",
   {
+    defaultVariants: {
+      variant: "default",
+    },
     variants: {
       variant: {
         default:
           "bg-primary text-primary-foreground hover:bg-primary/80 border-transparent",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80 border-transparent",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/80 border-transparent",
         outline: "text-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 border-transparent",
       },
-    },
-    defaultVariants: {
-      variant: "default",
     },
   }
 );

--- a/apps/chat/components/ui/button-group.tsx
+++ b/apps/chat/components/ui/button-group.tsx
@@ -8,6 +8,9 @@ import { cn } from "@/lib/utils";
 const buttonGroupVariants = cva(
   "flex w-fit items-stretch has-[>[data-slot=button-group]]:gap-2 [&>*]:focus-visible:relative [&>*]:focus-visible:z-10 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
   {
+    defaultVariants: {
+      orientation: "horizontal",
+    },
     variants: {
       orientation: {
         horizontal:
@@ -15,9 +18,6 @@ const buttonGroupVariants = cva(
         vertical:
           "flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none",
       },
-    },
-    defaultVariants: {
-      orientation: "horizontal",
     },
   }
 );

--- a/apps/chat/components/ui/button.tsx
+++ b/apps/chat/components/ui/button.tsx
@@ -8,31 +8,28 @@ import { cn } from "@/lib/utils";
 const buttonVariants = cva(
   "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
+    defaultVariants: { size: "default", variant: "default" },
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
           "bg-destructive hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 text-white",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
         outline:
           "bg-background hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 border shadow-xs",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
-        "icon-sm": "size-8",
         "icon-lg": "size-10",
+        "icon-sm": "size-8",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
       },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
     },
   }
 );

--- a/apps/chat/components/ui/input-group.tsx
+++ b/apps/chat/components/ui/input-group.tsx
@@ -38,20 +38,20 @@ const InputGroup = ({ className, ...props }: React.ComponentProps<"div">) => (
 const inputGroupAddonVariants = cva(
   "text-muted-foreground flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium select-none group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
   {
-    variants: {
-      align: {
-        "inline-start":
-          "order-first pl-3 has-[>button]:ml-[-0.45rem] has-[>kbd]:ml-[-0.35rem]",
-        "inline-end":
-          "order-last pr-3 has-[>button]:mr-[-0.45rem] has-[>kbd]:mr-[-0.35rem]",
-        "block-start":
-          "order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-2.5 [.border-b]:pb-3",
-        "block-end":
-          "order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-2.5 [.border-t]:pt-3",
-      },
-    },
     defaultVariants: {
       align: "inline-start",
+    },
+    variants: {
+      align: {
+        "block-end":
+          "order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-2.5 [.border-t]:pt-3",
+        "block-start":
+          "order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-2.5 [.border-b]:pb-3",
+        "inline-end":
+          "order-last pr-3 has-[>button]:mr-[-0.45rem] has-[>kbd]:mr-[-0.35rem]",
+        "inline-start":
+          "order-first pl-3 has-[>button]:ml-[-0.45rem] has-[>kbd]:ml-[-0.35rem]",
+      },
     },
   }
 );
@@ -80,17 +80,17 @@ const InputGroupAddon = ({
 const inputGroupButtonVariants = cva(
   "flex items-center gap-2 text-sm shadow-none",
   {
-    variants: {
-      size: {
-        xs: "h-6 gap-1 rounded-[calc(var(--radius)-5px)] px-2 has-[>svg]:px-2 [&>svg:not([class*='size-'])]:size-3.5",
-        sm: "h-8 gap-1.5 rounded-md px-2.5 has-[>svg]:px-2.5",
-        "icon-xs":
-          "size-6 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0",
-        "icon-sm": "size-8 p-0 has-[>svg]:p-0",
-      },
-    },
     defaultVariants: {
       size: "xs",
+    },
+    variants: {
+      size: {
+        "icon-sm": "size-8 p-0 has-[>svg]:p-0",
+        "icon-xs":
+          "size-6 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0",
+        sm: "h-8 gap-1.5 rounded-md px-2.5 has-[>svg]:px-2.5",
+        xs: "h-6 gap-1 rounded-[calc(var(--radius)-5px)] px-2 has-[>svg]:px-2 [&>svg:not([class*='size-'])]:size-3.5",
+      },
     },
   }
 );

--- a/apps/chat/components/ui/sidebar.tsx
+++ b/apps/chat/components/ui/sidebar.tsx
@@ -539,11 +539,8 @@ const SidebarMenuButton = ({
     return button;
   }
 
-  if (typeof tooltip === "string") {
-    tooltip = {
-      children: tooltip,
-    };
-  }
+  const normalizedTooltip =
+    typeof tooltip === "string" ? { children: tooltip } : tooltip;
 
   return (
     <Tooltip>
@@ -552,7 +549,7 @@ const SidebarMenuButton = ({
         align="center"
         hidden={state !== "collapsed" || isMobile}
         side="right"
-        {...tooltip}
+        {...normalizedTooltip}
       />
     </Tooltip>
   );

--- a/apps/chat/components/ui/sidebar.tsx
+++ b/apps/chat/components/ui/sidebar.tsx
@@ -102,7 +102,9 @@ const SidebarProvider = ({
   // Helper to toggle the sidebar.
   const toggleSidebar = React.useCallback(
     () =>
-      isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open),
+      isMobile
+        ? setOpenMobile((wasOpen) => !wasOpen)
+        : setOpen((wasOpen) => !wasOpen),
     [isMobile, setOpen, setOpenMobile]
   );
 
@@ -490,6 +492,7 @@ const SidebarMenuItem = ({
 const sidebarMenuButtonVariants = cva(
   "peer/menu-button ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:font-medium [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
+    defaultVariants: { size: "default", variant: "default" },
     variants: {
       variant: {
         default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
@@ -498,13 +501,9 @@ const sidebarMenuButtonVariants = cva(
       },
       size: {
         default: "h-8 text-sm",
-        sm: "h-7 text-xs",
         lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
+        sm: "h-7 text-xs",
       },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
     },
   }
 );

--- a/apps/chat/components/ui/toggle.tsx
+++ b/apps/chat/components/ui/toggle.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/lib/utils";
 const toggleVariants = cva(
   "hover:bg-muted hover:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground dark:aria-invalid:ring-destructive/40 inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
+    defaultVariants: { size: "default", variant: "default" },
     variants: {
       variant: {
         default: "bg-transparent",
@@ -18,13 +19,9 @@ const toggleVariants = cva(
       },
       size: {
         default: "h-9 min-w-9 px-2",
-        sm: "h-8 min-w-8 px-1.5",
         lg: "h-10 min-w-10 px-2.5",
+        sm: "h-8 min-w-8 px-1.5",
       },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
     },
   }
 );


### PR DESCRIPTION
Remove 41 strict component diagnostics across 21 files (133 → 92), with no new strict warnings. This is source-only: the lint baseline stays unchanged for the final dedicated exemption cleanup.

- Sort 18 safe CVA configuration/default/value records. Installed CVA enumerates only the outer variant dimensions and indexes each inner value dictionary. Preserve that dimension order and compound-variant arrays. Exhaustive combinations, missing/null/unknown values, and extra classes produce identical class strings in 344 comparisons across seven component files.
- Rename five shadowing locals, use the existing type-only import, remove a type/component naming collision, simplify terminal return/shared branch/fragment syntax, preserve the inline rationale, document the intentional placeholder callback, and use equivalent includes, DOM, increment, and state-destructuring forms.
- Replace two attachment concatenations with spreads. Both arrays are internally produced dense arrays (`Array.from` → `map`, then filtering/appending); retain file order and object identities.
- Normalize tooltip props without assigning to the parameter. Add a named Unicode status capture while retaining the numeric capture used by the consumer; 3,000 numeric matches plus invalid inputs retain matched text, status, and index.

Validation: `bun lint`, `bun test:types` (seven packages), and 193 chat unit tests pass. Full AST comparison covers all 21 files with explicit normalization for these mechanical changes; property values, function bodies, parameters, and module initialization order remain equivalent. CVA class strings and regex behavior have additional targeted checks. Latest main is merged cleanly.

Local browser verification remains blocked by the same macOS file-watcher hang documented in #422: Next 16.3 prints Ready but even `/_next/mcp` times out before route compilation. The local server is stopped. Require the combined integration browser run / CI before merging; no local visual pass is claimed.

## Summary by Sourcery

Clear strict component and CVA dictionary diagnostics through behavior-preserving source cleanup across the chat application.

Enhancements:
- Resolve 41 strict component diagnostics across 21 chat component files without changing runtime behavior.
- Normalize CVA configuration ordering and defaults while preserving generated class names.
- Apply behavior-preserving code cleanup for naming collisions, imports, callbacks, DOM operations, state handling, and tooltip props.
- Preserve regex matching behavior while adding a named HTTP status capture.

Tests:
- Validate equivalence with AST comparisons and targeted CVA and regex checks, alongside lint, type checks, and chat unit tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes 41 strict component diagnostics across 21 files (133 → 92) with no new warnings. This source-only refactor keeps the lint baseline unchanged and preserves all runtime behavior.

**Changes**
- Sorts CVA configuration records in 7 component files; exhaustive combinations produce identical class strings across 344 comparisons.
- Replaces two attachment concatenations with spreads; both arrays are dense so file order and object identities are preserved.
- Adds a named Unicode status capture while keeping the existing numeric capture; inputs retain matched text, status, and index.
- Renames shadowing locals, removes type/component naming collisions, and simplifies terminal returns, fragments, DOM calls, and state destructuring.
- Normalizes tooltip props without mutating the parameter.

**Validation**
- `bun lint`, `bun test:types` (seven packages), and 193 chat unit tests pass.
- Full AST comparison of all 21 files confirms property values, function bodies, parameters, and module init order are equivalent.
- Local browser verification is blocked by the macOS file-watcher hang in #422; requires CI or the combined integration browser run before merging.

<sup>Written for commit 62b13b3b7a3456fd607995e4993e70a6455851b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

