### PR TITLE
style(chat): clean final metadata and store records

### DIFF
--- a/apps/chat/app/(auth)/device-login/page.tsx
+++ b/apps/chat/app/(auth)/device-login/page.tsx
@@ -10,8 +10,8 @@ import { config } from "@/lib/config";
 import { toSearchParamRecord } from "@/lib/electron-auth";
 
 export const metadata: Metadata = {
-  title: "Device Login",
   description: "Sign in for the desktop app",
+  title: "Device Login",
 };
 
 const DeviceLoginFallback = () => (

--- a/apps/chat/app/(auth)/login/page.tsx
+++ b/apps/chat/app/(auth)/login/page.tsx
@@ -18,8 +18,8 @@ import {
 import { cn } from "@/lib/utils";
 
 export const metadata: Metadata = {
-  title: "Login",
   description: "Login to your account",
+  title: "Login",
 };
 
 const LoginPageContent = async ({

--- a/apps/chat/app/(auth)/register/page.tsx
+++ b/apps/chat/app/(auth)/register/page.tsx
@@ -5,8 +5,8 @@ import { AuthCardSkeleton } from "@/components/auth-card-skeleton";
 import { SignupForm } from "@/components/signup-form";
 
 export const metadata: Metadata = {
-  title: "Create an account",
   description: "Create an account to get started.",
+  title: "Create an account",
 };
 
 const RegisterPage = () => (

--- a/apps/chat/app/privacy/page.tsx
+++ b/apps/chat/app/privacy/page.tsx
@@ -1,159 +1,151 @@
 import { config } from "@/lib/config";
 
-const PrivacyPage = () => {
-  const _currencySymbolMap: Record<string, string> = {
-    USD: "$",
-    EUR: "€",
-    GBP: "£",
-  };
-
-  return (
-    <main className="prose dark:prose-invert container mx-auto max-w-3xl py-10">
-      <h1>{config.policies.privacy.title}</h1>
-      {config.policies.privacy.lastUpdated ? (
-        <p>
-          <strong>Last updated:</strong> {config.policies.privacy.lastUpdated}
-        </p>
-      ) : null}
-
+const PrivacyPage = () => (
+  <main className="prose dark:prose-invert container mx-auto max-w-3xl py-10">
+    <h1>{config.policies.privacy.title}</h1>
+    {config.policies.privacy.lastUpdated ? (
       <p>
-        At {config.organization.name}, we respect your privacy and are committed
-        to protecting your personal data. This Privacy Policy explains how we
-        collect, use, and safeguard your information when you use our service.
+        <strong>Last updated:</strong> {config.policies.privacy.lastUpdated}
       </p>
+    ) : null}
 
-      <h2>Information We Collect</h2>
-      <p>We may collect the following types of information:</p>
-      <ul>
-        <li>
-          <strong>Search Queries</strong>: The questions and searches you submit
-          to our service.
-        </li>
-        <li>
-          <strong>Usage Data</strong>: Information about how you interact with
-          our service, including features used and time spent on the platform.
-        </li>
-        <li>
-          <strong>Device Information</strong>: Information about your device,
-          browser type, IP address, and operating system.
-        </li>
-        <li>
-          <strong>Account Information</strong>: Email address and profile
-          information when you create an account.
-        </li>
-        <li>
-          <strong>Subscription Data</strong>: Information about your
-          subscription status and billing history (but not payment details).
-        </li>
-        <li>
-          <strong>Cookies and Similar Technologies</strong>: We use cookies and
-          similar tracking technologies to enhance your experience and collect
-          usage information.
-        </li>
-      </ul>
-      <p>
-        <strong>Important Note on Payment Data</strong>:{" "}
-        {config.organization.name} does not collect, store, or process any
-        payment card details, bank information, or other sensitive payment data.
-        All payment information is handled directly by our payment processors (
-        {config.services.paymentProcessors.join(", ")}) and is subject to their
-        respective privacy policies and security standards.
-      </p>
+    <p>
+      At {config.organization.name}, we respect your privacy and are committed
+      to protecting your personal data. This Privacy Policy explains how we
+      collect, use, and safeguard your information when you use our service.
+    </p>
 
-      <h2>How We Use Your Information</h2>
-      <ul>
-        <li>To provide and improve our service</li>
-        <li>To understand how users interact with our platform</li>
-        <li>To personalize and enhance your experience</li>
-        <li>To monitor and analyze usage patterns and trends</li>
-        <li>To detect, prevent, and address technical issues</li>
-      </ul>
+    <h2>Information We Collect</h2>
+    <p>We may collect the following types of information:</p>
+    <ul>
+      <li>
+        <strong>Search Queries</strong>: The questions and searches you submit
+        to our service.
+      </li>
+      <li>
+        <strong>Usage Data</strong>: Information about how you interact with our
+        service, including features used and time spent on the platform.
+      </li>
+      <li>
+        <strong>Device Information</strong>: Information about your device,
+        browser type, IP address, and operating system.
+      </li>
+      <li>
+        <strong>Account Information</strong>: Email address and profile
+        information when you create an account.
+      </li>
+      <li>
+        <strong>Subscription Data</strong>: Information about your subscription
+        status and billing history (but not payment details).
+      </li>
+      <li>
+        <strong>Cookies and Similar Technologies</strong>: We use cookies and
+        similar tracking technologies to enhance your experience and collect
+        usage information.
+      </li>
+    </ul>
+    <p>
+      <strong>Important Note on Payment Data</strong>:{" "}
+      {config.organization.name} does not collect, store, or process any payment
+      card details, bank information, or other sensitive payment data. All
+      payment information is handled directly by our payment processors (
+      {config.services.paymentProcessors.join(", ")}) and is subject to their
+      respective privacy policies and security standards.
+    </p>
 
-      <h2>Data Sharing and Disclosure</h2>
-      <p>We may share your information in the following circumstances:</p>
-      <ul>
-        <li>
-          <strong>Service Providers</strong>: With third-party service providers
-          who help us operate, improve, and analyze our service.
-        </li>
-        <li>
-          <strong>Hosting</strong>: {config.services.hosting} hosts our
-          infrastructure.
-        </li>
-        <li>
-          <strong>AI Processing Partners</strong>: We utilize services from
-          companies including {config.services.aiProviders.join(", ")} to
-          process queries and provide results.
-        </li>
-        <li>
-          <strong>Payment Processors</strong>: We use{" "}
-          {config.services.paymentProcessors.join(", ")} to process payments and
-          manage subscriptions. These providers handle all payment data directly
-          and have their own privacy policies governing payment information.
-        </li>
-        <li>
-          <strong>Compliance with Laws</strong>: When required by applicable
-          law, regulation, legal process, or governmental request.
-        </li>
-        <li>
-          <strong>Business Transfers</strong>: In connection with a merger,
-          acquisition, or sale of assets.
-        </li>
-      </ul>
-      <p>
-        <strong>Payment Data</strong>: When you make a payment, your payment
-        information is transmitted directly to our payment processors and is not
-        stored on our servers. We only receive confirmation of successful
-        payments and subscription status updates.
-      </p>
+    <h2>How We Use Your Information</h2>
+    <ul>
+      <li>To provide and improve our service</li>
+      <li>To understand how users interact with our platform</li>
+      <li>To personalize and enhance your experience</li>
+      <li>To monitor and analyze usage patterns and trends</li>
+      <li>To detect, prevent, and address technical issues</li>
+    </ul>
 
-      <h2>Data Security</h2>
-      <p>
-        We implement appropriate technical and organizational measures to
-        protect your personal information. However, no method of transmission
-        over the Internet or electronic storage is 100% secure, and we cannot
-        guarantee absolute security.
-      </p>
+    <h2>Data Sharing and Disclosure</h2>
+    <p>We may share your information in the following circumstances:</p>
+    <ul>
+      <li>
+        <strong>Service Providers</strong>: With third-party service providers
+        who help us operate, improve, and analyze our service.
+      </li>
+      <li>
+        <strong>Hosting</strong>: {config.services.hosting} hosts our
+        infrastructure.
+      </li>
+      <li>
+        <strong>AI Processing Partners</strong>: We utilize services from
+        companies including {config.services.aiProviders.join(", ")} to process
+        queries and provide results.
+      </li>
+      <li>
+        <strong>Payment Processors</strong>: We use{" "}
+        {config.services.paymentProcessors.join(", ")} to process payments and
+        manage subscriptions. These providers handle all payment data directly
+        and have their own privacy policies governing payment information.
+      </li>
+      <li>
+        <strong>Compliance with Laws</strong>: When required by applicable law,
+        regulation, legal process, or governmental request.
+      </li>
+      <li>
+        <strong>Business Transfers</strong>: In connection with a merger,
+        acquisition, or sale of assets.
+      </li>
+    </ul>
+    <p>
+      <strong>Payment Data</strong>: When you make a payment, your payment
+      information is transmitted directly to our payment processors and is not
+      stored on our servers. We only receive confirmation of successful payments
+      and subscription status updates.
+    </p>
 
-      <h2>Your Rights</h2>
-      <p>Depending on your location, you may have the right to:</p>
-      <ul>
-        <li>Access the personal information we hold about you</li>
-        <li>Request correction or deletion of your personal information</li>
-        <li>Object to or restrict certain processing activities</li>
-        <li>Data portability</li>
-        <li>Withdraw consent where applicable</li>
-      </ul>
+    <h2>Data Security</h2>
+    <p>
+      We implement appropriate technical and organizational measures to protect
+      your personal information. However, no method of transmission over the
+      Internet or electronic storage is 100% secure, and we cannot guarantee
+      absolute security.
+    </p>
 
-      <h2>Children&apos;s Privacy</h2>
-      <p>
-        Our service is not directed to children under the age of
-        {` ${config.legal.minimumAge}`}. We do not knowingly collect personal
-        information from children under
-        {` ${config.legal.minimumAge}`}. If you are a parent or guardian and
-        believe your child has provided us with personal information, please
-        contact us.
-      </p>
+    <h2>Your Rights</h2>
+    <p>Depending on your location, you may have the right to:</p>
+    <ul>
+      <li>Access the personal information we hold about you</li>
+      <li>Request correction or deletion of your personal information</li>
+      <li>Object to or restrict certain processing activities</li>
+      <li>Data portability</li>
+      <li>Withdraw consent where applicable</li>
+    </ul>
 
-      <h2>Changes to This Privacy Policy</h2>
-      <p>
-        We may update our Privacy Policy from time to time. We will notify you
-        of any changes by posting the new Privacy Policy on this page and
-        updating the &quot;Last updated&quot; date.
-      </p>
+    <h2>Children&apos;s Privacy</h2>
+    <p>
+      Our service is not directed to children under the age of
+      {` ${config.legal.minimumAge}`}. We do not knowingly collect personal
+      information from children under
+      {` ${config.legal.minimumAge}`}. If you are a parent or guardian and
+      believe your child has provided us with personal information, please
+      contact us.
+    </p>
 
-      <h2>Contact Us</h2>
-      <p>
-        If you have any questions about this Privacy Policy, please contact us
-        at: {config.organization.contact.privacyEmail}
-      </p>
+    <h2>Changes to This Privacy Policy</h2>
+    <p>
+      We may update our Privacy Policy from time to time. We will notify you of
+      any changes by posting the new Privacy Policy on this page and updating
+      the &quot;Last updated&quot; date.
+    </p>
 
-      <p>
-        By using {config.appName}, you agree to our Privacy Policy and our Terms
-        of Service.
-      </p>
-    </main>
-  );
-};
+    <h2>Contact Us</h2>
+    <p>
+      If you have any questions about this Privacy Policy, please contact us at:{" "}
+      {config.organization.contact.privacyEmail}
+    </p>
+
+    <p>
+      By using {config.appName}, you agree to our Privacy Policy and our Terms
+      of Service.
+    </p>
+  </main>
+);
 
 export default PrivacyPage;

--- a/apps/chat/app/terms/page.tsx
+++ b/apps/chat/app/terms/page.tsx
@@ -94,9 +94,9 @@ const PricingSection = ({
 
 const TermsPage = () => {
   const currencySymbolMap: Record<string, string> = {
-    USD: "$",
     EUR: "€",
     GBP: "£",
+    USD: "$",
   };
 
   const currencyCode = config.pricing?.currency;

--- a/apps/chat/lib/stores/base/hooks.ts
+++ b/apps/chat/lib/stores/base/hooks.ts
@@ -302,8 +302,8 @@ export const createChatStoreCreator = <TMessage extends UIMessage>(
           throttledEffects.forEach((cb) => {
             try {
               cb();
-            } catch (err) {
-              debug.warn("[chat-store-base] throttled effect error", err);
+            } catch (error) {
+              debug.warn("[chat-store-base] throttled effect error", error);
             }
           });
         });
@@ -630,11 +630,12 @@ export const createChatStoreCreator = <TMessage extends UIMessage>(
       setTransientDataPart: (type, data) => {
         markLastAction("chat:setTransientDataPart");
         batchUpdates(() => {
-          set((state) => {
-            const newTransientDataParts = new Map(state._transientDataParts);
-            newTransientDataParts.set(type, data);
-            return { _transientDataParts: newTransientDataParts };
-          });
+          set((state) => ({
+            _transientDataParts: new Map(state._transientDataParts).set(
+              type,
+              data
+            ),
+          }));
         });
       },
 


### PR DESCRIPTION
Sort pure metadata and currency records in the privacy, terms, login, register, and device-login routes. Rename the throttled-effect catch binding and construct the transient data Map with its entry initializer chain; state property names and behavior remain unchanged.

Validation:

- Strict targeted oxlint.
- 4 relevant Vitest files: 12 tests passed.
- `bun lint`.
- `bun test:types`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes metadata ordering, currency record sorting, and store internals in the chat app without changing behavior.

- Sorts `title` and `description` metadata in the login, register, and device-login routes.
- Sorts currency symbols in the terms route and reformats the privacy page for consistent style.
- Renames the throttled-effect catch binding and builds the transient data `Map` inline.

<sup>Written for commit 9fd5282c326b028a4581b12a9bdb8b159704b2c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Standardize route metadata and store code formatting while preserving existing behavior.

Enhancements:
- Standardize metadata and currency record ordering across authentication, privacy, and terms routes.
- Simplify the privacy page structure and transient chat-store updates without changing behavior.
- Use clearer error naming for throttled effect handling.