### PR TITLE
chore: normalize client state and plain records

### DIFF
--- a/apps/chat/hooks/use-artifact.tsx
+++ b/apps/chat/hooks/use-artifact.tsx
@@ -13,14 +13,14 @@ import type { UIArtifact } from "@/components/artifact-panel";
 import type { ArtifactMetadata } from "@/components/create-artifact";
 
 const initialArtifactData: UIArtifact = {
-  documentId: "init",
   content: "",
+  date: undefined,
+  documentId: "init",
+  isVisible: false,
   kind: "text",
-  title: "",
   messageId: "",
   status: "idle",
-  isVisible: false,
-  date: undefined,
+  title: "",
 };
 
 type Selector<T> = (state: UIArtifact) => T;
@@ -46,7 +46,7 @@ const ArtifactContext = createContext<ArtifactContextType | undefined>(
 );
 
 export const ArtifactProvider = ({ children }: { children: ReactNode }) => {
-  const [artifact, setArtifactState] =
+  const [artifactState, setArtifactState] =
     useState<UIArtifact>(initialArtifactData);
   const [metadataStore, setMetadataStore] = useState<MetadataStore>({});
 
@@ -77,12 +77,12 @@ export const ArtifactProvider = ({ children }: { children: ReactNode }) => {
 
   const contextValue = useMemo(
     () => ({
-      artifact,
-      setArtifact,
+      artifact: artifactState,
       metadata: metadataStore,
+      setArtifact,
       setMetadata,
     }),
-    [artifact, setArtifact, metadataStore, setMetadata]
+    [artifactState, setArtifact, metadataStore, setMetadata]
   );
 
   return (
@@ -151,10 +151,10 @@ export const useArtifact = () => {
   return useMemo(
     () => ({
       artifact,
-      setArtifact,
-      resetArtifact,
       closeArtifact,
       metadata,
+      resetArtifact,
+      setArtifact,
       setMetadata,
     }),
     [artifact, setArtifact, metadata, setMetadata, resetArtifact, closeArtifact]

--- a/apps/chat/lib/anonymous-session-client.ts
+++ b/apps/chat/lib/anonymous-session-client.ts
@@ -29,11 +29,11 @@ const setCookie = (name: string, value: string, maxAge: number): void => {
   if ("cookieStore" in window) {
     window.cookieStore
       .set({
-        name,
-        value: encodedValue,
-        path: "/",
         expires: Date.now() + maxAge * 1000,
+        name,
+        path: "/",
         sameSite: "lax",
+        value: encodedValue,
       })
       .catch(() => {
         // Fail silently if Cookie Store API fails


### PR DESCRIPTION
Align the artifact state value with its existing setter name, sort three plain artifact/context records, and sort named Cookie Store options. Public context keys, callback bodies, memo dependencies, state identities, cookie values, expiry timing, and fallback behavior remain unchanged.

Validation: `bun lint`, `bun test:types`, and 193 chat unit tests pass. A normalized runtime AST comparison verifies the artifact changes; 24 cookie API/fallback scenarios preserve arguments and call order. Five strict diagnostics are removed. Existing artifact/browser fixtures also run in CI and on the private combined checkout before merge. Stale lint exemptions are reserved for the final baseline cleanup PR.

## Summary by Sourcery

Normalize client artifact state and plain record definitions while preserving existing public behavior.

Enhancements:
- Normalize artifact state naming and ordering of public artifact/context records without changing runtime behavior.
- Normalize the ordering of Cookie Store options while preserving cookie semantics and fallback behavior.