### PR TITLE
refactor: finish bounded component syntax cleanup

### DIFF
--- a/apps/chat/components/ai-elements/prompt-input.tsx
+++ b/apps/chat/components/ai-elements/prompt-input.tsx
@@ -461,6 +461,17 @@ export type PromptInputProps = Omit<
   inputGroupClassName?: string;
 };
 
+const convertBlobUrlToDataUrl = async (url: string): Promise<string> => {
+  const response = await fetch(url);
+  const blob = await response.blob();
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+};
+
 export const PromptInput = ({
   className,
   inputGroupClassName,
@@ -683,17 +694,6 @@ export const PromptInput = ({
     if (event.currentTarget.files) {
       add(event.currentTarget.files);
     }
-  };
-
-  const convertBlobUrlToDataUrl = async (url: string): Promise<string> => {
-    const response = await fetch(url);
-    const blob = await response.blob();
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onloadend = () => resolve(reader.result as string);
-      reader.onerror = reject;
-      reader.readAsDataURL(blob);
-    });
   };
 
   const ctx = useMemo<AttachmentsContext>(
@@ -1295,6 +1295,7 @@ export const PromptInputTab = ({
 export type PromptInputTabLabelProps = HTMLAttributes<HTMLHeadingElement>;
 
 export const PromptInputTabLabel = ({
+  children,
   className,
   ...props
 }: PromptInputTabLabelProps) => (
@@ -1304,7 +1305,9 @@ export const PromptInputTabLabel = ({
       className
     )}
     {...props}
-  />
+  >
+    {children}
+  </h3>
 );
 
 export type PromptInputTabBodyProps = HTMLAttributes<HTMLDivElement>;

--- a/apps/chat/components/ai-elements/prompt-input.tsx
+++ b/apps/chat/components/ai-elements/prompt-input.tsx
@@ -1303,7 +1303,6 @@ export const PromptInputTab = ({
 export type PromptInputTabLabelProps = HTMLAttributes<HTMLHeadingElement>;
 
 export const PromptInputTabLabel = ({
-  children,
   className,
   ...props
 }: PromptInputTabLabelProps) => (
@@ -1313,9 +1312,7 @@ export const PromptInputTabLabel = ({
       className
     )}
     {...props}
-  >
-    {children}
-  </h3>
+  />
 );
 
 export type PromptInputTabBodyProps = HTMLAttributes<HTMLDivElement>;

--- a/apps/chat/components/parallel-response-cards.tsx
+++ b/apps/chat/components/parallel-response-cards.tsx
@@ -90,7 +90,7 @@ const PureParallelResponseCards = ({ messageId }: { messageId: string }) => {
   }, [message, parallelGroupInfo]);
 
   const sortedCardSlots = useMemo(() => {
-    return [...cardSlots].sort((left, right) => {
+    return cardSlots.toSorted((left, right) => {
       const leftOrder = getModelOrderIndex(
         getEffectiveModelId(left.message, left.modelId),
         models

--- a/apps/chat/components/search-chats-dialog.tsx
+++ b/apps/chat/components/search-chats-dialog.tsx
@@ -55,11 +55,11 @@ const groupChatsByDate = (chats: UIChat[]): GroupedChats => {
       return groups;
     },
     {
+      lastMonth: [],
+      lastWeek: [],
+      older: [],
       today: [],
       yesterday: [],
-      lastWeek: [],
-      lastMonth: [],
-      older: [],
     } as GroupedChats
   );
 };

--- a/apps/chat/components/settings/models-table.tsx
+++ b/apps/chat/components/settings/models-table.tsx
@@ -38,7 +38,7 @@ export const ModelsTable = ({
             return old;
           }
           const idx = old.findIndex((p) => p.modelId === newData.modelId);
-          if (idx >= 0) {
+          if (idx !== -1) {
             return old.with(idx, { ...old[idx], enabled: newData.enabled });
           }
           return [

--- a/apps/chat/components/sheet-editor.tsx
+++ b/apps/chat/components/sheet-editor.tsx
@@ -21,6 +21,8 @@ interface SheetEditorProps {
 const MIN_ROWS = 50;
 const MIN_COLS = 26;
 
+const generateCsv = (data: (string | number)[][]) => unparse(data);
+
 const PureSpreadsheetEditor = ({
   content,
   saveContent,
@@ -100,8 +102,6 @@ const PureSpreadsheetEditor = ({
   useEffect(() => {
     setLocalRows(initialRows);
   }, [initialRows]);
-
-  const generateCsv = (data: (string | number)[][]) => unparse(data);
 
   const handleRowsChange = (newRows: Record<string, string | number>[]) => {
     if (isReadonly) {

--- a/apps/chat/components/sidebar-chats-list.tsx
+++ b/apps/chat/components/sidebar-chats-list.tsx
@@ -73,17 +73,17 @@ export const SidebarChatsList = () => {
         return acc;
       },
       {
+        lastMonth: [],
+        lastWeek: [],
+        older: [],
         pinned: [],
         today: [],
         yesterday: [],
-        lastWeek: [],
-        lastMonth: [],
-        older: [],
       } as GroupedChats
     );
 
     // Add pinned chats (sorted by most recently updated first)
-    groups.pinned = pinnedChats.sort(
+    groups.pinned = pinnedChats.toSorted(
       (a, b) =>
         new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
     );

--- a/apps/chat/components/ui/alert.tsx
+++ b/apps/chat/components/ui/alert.tsx
@@ -36,12 +36,14 @@ Alert.displayName = "Alert";
 const AlertTitle = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLHeadingElement>
->(({ className, ...props }, ref) => (
+>(({ children, className, ...props }, ref) => (
   <h5
     className={cn("mb-1 leading-none font-medium tracking-tight", className)}
     ref={ref}
     {...props}
-  />
+  >
+    {children}
+  </h5>
 ));
 AlertTitle.displayName = "AlertTitle";
 

--- a/apps/chat/components/ui/alert.tsx
+++ b/apps/chat/components/ui/alert.tsx
@@ -36,14 +36,12 @@ Alert.displayName = "Alert";
 const AlertTitle = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLHeadingElement>
->(({ children, className, ...props }, ref) => (
+>(({ className, ...props }, ref) => (
   <h5
     className={cn("mb-1 leading-none font-medium tracking-tight", className)}
     ref={ref}
     {...props}
-  >
-    {children}
-  </h5>
+  />
 ));
 AlertTitle.displayName = "AlertTitle";
 

--- a/apps/chat/components/ui/button.tsx
+++ b/apps/chat/components/ui/button.tsx
@@ -51,7 +51,7 @@ const Button = ({
 
   return (
     <Comp
-      className={cn(buttonVariants({ variant, size, className }))}
+      className={cn(buttonVariants({ className, size, variant }))}
       data-slot="button"
       {...props}
     />

--- a/apps/chat/components/ui/sidebar.tsx
+++ b/apps/chat/components/ui/sidebar.tsx
@@ -72,15 +72,15 @@ const SidebarProvider = ({
 
   // This is the internal state of the sidebar.
   // We use openProp and setOpenProp for control from outside the component.
-  const [_open, _setOpen] = React.useState(defaultOpen);
-  const open = openProp ?? _open;
+  const [internalOpen, setInternalOpen] = React.useState(defaultOpen);
+  const open = openProp ?? internalOpen;
   const setOpen = React.useCallback(
     (value: boolean | ((value: boolean) => boolean)) => {
       const openState = typeof value === "function" ? value(open) : value;
       if (setOpenProp) {
         setOpenProp(openState);
       } else {
-        _setOpen(openState);
+        setInternalOpen(openState);
       }
 
       // This sets the cookie to keep the sidebar state.
@@ -527,7 +527,7 @@ const SidebarMenuButton = ({
 
   const button = (
     <Comp
-      className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+      className={cn(sidebarMenuButtonVariants({ size, variant }), className)}
       data-active={isActive}
       data-sidebar="menu-button"
       data-size={size}

--- a/apps/chat/components/ui/slider.tsx
+++ b/apps/chat/components/ui/slider.tsx
@@ -13,15 +13,15 @@ const Slider = ({
   max = 100,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) => {
-  const _values = React.useMemo(
-    () =>
-      Array.isArray(value)
-        ? value
-        : Array.isArray(defaultValue)
-          ? defaultValue
-          : [min, max],
-    [value, defaultValue, min, max]
-  );
+  const _values = React.useMemo(() => {
+    if (Array.isArray(value)) {
+      return value;
+    }
+    if (Array.isArray(defaultValue)) {
+      return defaultValue;
+    }
+    return [min, max];
+  }, [value, defaultValue, min, max]);
 
   return (
     <SliderPrimitive.Root

--- a/apps/chat/components/ui/toggle.tsx
+++ b/apps/chat/components/ui/toggle.tsx
@@ -37,7 +37,7 @@ const Toggle = ({
 }: React.ComponentProps<typeof TogglePrimitive.Root> &
   VariantProps<typeof toggleVariants>) => (
   <TogglePrimitive.Root
-    className={cn(toggleVariants({ variant, size, className }))}
+    className={cn(toggleVariants({ className, size, variant }))}
     data-slot="toggle"
     {...props}
   />


### PR DESCRIPTION
Finish the final bounded component syntax list: remove 12 strict diagnostics across 10 source files, without new warnings or baseline edits.

- Move two helpers with no captured locals to module scope, retaining their exact bodies and async execution. Replace one findIndex condition, rename internal sidebar state, and express the slider selection through equivalent early returns inside the same memo.
- Use `toSorted` for dense local arrays. Card slots originate from a push-built model ID array followed by `map`; pinned chats originate from `filter` and have no later aliases. Keep comparator order, element identities, and source contents. The app already uses `toSorted`, targets ESNext, and runs CI on Node 22.
- Sort three CVA argument records and two date-group records. CVA continues to enumerate its unchanged variant dimensions; grouped chat consumers read named fields in explicit rendering order.


Validation: `bun lint`, `bun test:types` (seven packages), and 193 chat unit tests pass. Ten-file AST comparison preserves bodies, values, and module initialization order with explicit normalization for these mechanical changes. Additional checks cover 243 exact CVA class strings, and stable sorting/element identity without input mutation. Latest main is merged. The two intrinsic heading wrappers retain their original spread-children implementations and known false-positive exemptions; no heading rendering changes remain, so no new fixture is needed for those reverted edits.

The combined integration browser/visual run remains required before merge. Local macOS file watching was stalled in prior worktrees, so this pass starts no additional dev server; no local visual pass is claimed. This PR is the finite followup to #427, not a new broad formatting sweep.

## Summary by Sourcery

Finish the bounded component syntax cleanup without changing application behavior or introducing new warnings.

Enhancements:
- Complete the bounded component syntax cleanup across the chat application while preserving behavior and rendering output.
- Improve local code clarity by moving non-capturing helpers to module scope, clarifying sidebar state names, and simplifying equivalent selection logic.
- Adopt non-mutating sorting for card slots and pinned chats and standardize record ordering in grouped data and variant calls.
- Preserve stable ordering, element identity, class strings, and component behavior throughout the refactor.

Tests:
- Validate the cleanup with linting, type checks, chat unit tests, AST comparisons, class-string checks, and sorting/immutability coverage.