### PR TITLE
refactor: await serialized chat completions

### DIFF
--- a/apps/chat/lib/ai/completion-queue.test.ts
+++ b/apps/chat/lib/ai/completion-queue.test.ts
@@ -47,4 +47,69 @@ describe("createCompletionQueue", () => {
     expect(onError).toHaveBeenCalledExactlyOnceWith(error);
     expect(laterCompletion).toHaveBeenCalledOnce();
   });
+
+  it("reports synchronous throws without interrupting enqueue", async () => {
+    const error = new Error("completion threw");
+    const onError = vi.fn();
+    const queue = createCompletionQueue(onError);
+    const laterCompletion = vi.fn(() => Promise.resolve());
+
+    queue.enqueue(() => {
+      throw error;
+    });
+    queue.enqueue(laterCompletion);
+
+    await queue.waitForIdle();
+    expect(onError).toHaveBeenCalledExactlyOnceWith(error);
+    expect(laterCompletion).toHaveBeenCalledOnce();
+  });
+
+  it("keeps an idle snapshot scoped to the completions already queued", async () => {
+    const first = deferred();
+    const second = deferred();
+    const events: string[] = [];
+    const queue = createCompletionQueue(vi.fn());
+
+    queue.enqueue(async () => {
+      await first.promise;
+      events.push("first");
+    });
+    const firstIdle = queue.waitForIdle();
+    queue.enqueue(async () => {
+      await second.promise;
+      events.push("second");
+    });
+
+    first.resolve();
+    await firstIdle;
+    expect(events).toEqual(["first"]);
+
+    second.resolve();
+    await queue.waitForIdle();
+    expect(events).toEqual(["first", "second"]);
+  });
+
+  it("propagates an error-handler failure and skips the next completion", async () => {
+    const completionError = new Error("completion failed");
+    const handlerError = new Error("error handler failed");
+    const onError = vi.fn().mockImplementationOnce(() => {
+      throw handlerError;
+    });
+    const queue = createCompletionQueue(onError);
+    const skippedCompletion = vi.fn(() => Promise.resolve());
+
+    queue.enqueue(() => Promise.reject(completionError));
+    const failedIdle = queue.waitForIdle();
+    queue.enqueue(skippedCompletion);
+
+    await expect(failedIdle).rejects.toBe(handlerError);
+    await queue.waitForIdle();
+    expect(onError.mock.calls).toEqual([[completionError], [handlerError]]);
+    expect(skippedCompletion).not.toHaveBeenCalled();
+
+    const laterCompletion = vi.fn(() => Promise.resolve());
+    queue.enqueue(laterCompletion);
+    await queue.waitForIdle();
+    expect(laterCompletion).toHaveBeenCalledOnce();
+  });
 });

--- a/apps/chat/lib/ai/completion-queue.ts
+++ b/apps/chat/lib/ai/completion-queue.ts
@@ -3,6 +3,19 @@ export type CompletionQueue = {
   waitForIdle: () => Promise<void>;
 };
 
+const runCompletion = async (
+  previous: Promise<void>,
+  completion: () => Promise<void>,
+  onError: (error: unknown) => void
+) => {
+  try {
+    await previous;
+    return await completion();
+  } catch (error) {
+    return onError(error);
+  }
+};
+
 export const createCompletionQueue = (
   onError: (error: unknown) => void
 ): CompletionQueue => {
@@ -10,7 +23,7 @@ export const createCompletionQueue = (
 
   return {
     enqueue(completion) {
-      pending = pending.then(completion).catch(onError);
+      pending = runCompletion(pending, completion, onError);
     },
     waitForIdle() {
       return pending;

--- a/apps/chat/oxlint-baseline.json
+++ b/apps/chat/oxlint-baseline.json
@@ -198,7 +198,6 @@
         "components/part/document-preview.tsx",
         "components/retry-button.tsx",
         "components/suggested-actions.tsx",
-        "lib/ai/completion-queue.ts",
         "lib/anonymous-session-client.ts",
         "lib/artifacts/text/client.tsx",
         "lib/cancellation-aware-chat-transport.ts",


### PR DESCRIPTION
The chat completion queue still used a promise chain covered by a lint exemption. Replace it with an async helper that waits for the previous completion, runs the next one, and preserves error recovery. Remove the resolved exemption (two strict diagnostics).

Add regression coverage for synchronous throws, idle snapshots, and an error handler that throws and causes the next completion to be skipped before recovery. These tests pass against both implementations. Existing tests cover ordering and rejected completions.

Validation: `bun lint`, `bun test:types` (seven packages), and all 196 chat unit tests pass. Independent review checked pending-promise capture, reentrant enqueue, and error propagation. The strict audit drops from 443 to 441 diagnostics with no new findings.

Runtime validation: a real browser chat returned “OK”, and the response persisted after a full reload. Next.js/Turbopack reported no compilation or runtime errors.
