### PR TITLE
refactor: tighten chat store types and remove unused selector cache

### DIFF
--- a/apps/chat/components/ai-elements/prompt-input.tsx
+++ b/apps/chat/components/ai-elements/prompt-input.tsx
@@ -1065,13 +1065,13 @@ interface SpeechRecognition extends EventTarget {
   lang: string;
   start(): void;
   stop(): void;
-  onstart: ((this: SpeechRecognition, ev: Event) => any) | null;
-  onend: ((this: SpeechRecognition, ev: Event) => any) | null;
+  onstart: ((this: SpeechRecognition, ev: Event) => void) | null;
+  onend: ((this: SpeechRecognition, ev: Event) => void) | null;
   onresult:
-    | ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => any)
+    | ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void)
     | null;
   onerror:
-    | ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => any)
+    | ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => void)
     | null;
 }
 

--- a/apps/chat/lib/stores/base/hooks.test.tsx
+++ b/apps/chat/lib/stores/base/hooks.test.tsx
@@ -1,0 +1,114 @@
+import type { UIMessage } from "ai";
+import { act, create } from "react-test-renderer";
+import { describe, expect, it } from "vitest";
+
+import {
+  createChatStore,
+  Provider,
+  useChatStatus,
+  useChatStore,
+} from "./hooks";
+import type { StoreState } from "./hooks";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+type LabeledMessage = UIMessage<{ label: string }>;
+
+const MessageLabel = () => {
+  const label = useChatStore(
+    (state: StoreState<LabeledMessage>) => state.messages[0]?.metadata?.label
+  );
+  return <output>{label}</output>;
+};
+
+const FullState = () => {
+  const state = useChatStore<LabeledMessage>();
+  return (
+    <output>{`${state.status}:${state.messages[0]?.metadata?.label}`}</output>
+  );
+};
+
+const Status = () => <output>{useChatStatus()}</output>;
+
+const message: LabeledMessage = {
+  id: "message-1",
+  metadata: { label: "initial" },
+  parts: [],
+  role: "assistant",
+};
+
+describe("chat store hooks", () => {
+  it("subscribes to selected typed message data and the full store", () => {
+    const store = createChatStore<LabeledMessage>([message]);
+    let renderer: ReturnType<typeof create> | undefined;
+    act(() => {
+      renderer = create(
+        <Provider store={store}>
+          <MessageLabel />
+          <FullState />
+          <Status />
+        </Provider>
+      );
+    });
+    if (!renderer) {
+      throw new Error("Expected hook harness to render");
+    }
+    const rendered = renderer;
+    try {
+      expect(
+        rendered.root.findAllByType("output").map((node) => node.children)
+      ).toEqual([["initial"], ["ready:initial"], ["ready"]]);
+      act(() => {
+        store.getState().setStatus("streaming");
+        store
+          .getState()
+          .setMessages([{ ...message, metadata: { label: "updated" } }]);
+      });
+      expect(
+        rendered.root.findAllByType("output").map((node) => node.children)
+      ).toEqual([["updated"], ["streaming:updated"], ["streaming"]]);
+      act(() => store.getState().reset());
+      expect(
+        rendered.root.findAllByType("output").map((node) => node.children)
+      ).toEqual([[], ["ready:undefined"], ["ready"]]);
+    } finally {
+      act(() => rendered.unmount());
+    }
+  });
+
+  it("keeps separate providers subscribed to their own stores", () => {
+    const first = createChatStore<LabeledMessage>([message]);
+    const second = createChatStore<LabeledMessage>([
+      { ...message, metadata: { label: "second" } },
+    ]);
+    let renderer: ReturnType<typeof create> | undefined;
+    act(() => {
+      renderer = create(
+        <>
+          <Provider store={first}>
+            <MessageLabel />
+          </Provider>
+          <Provider store={second}>
+            <MessageLabel />
+          </Provider>
+        </>
+      );
+    });
+    if (!renderer) {
+      throw new Error("Expected hook harness to render");
+    }
+    const rendered = renderer;
+    try {
+      act(() =>
+        first
+          .getState()
+          .setMessages([{ ...message, metadata: { label: "changed" } }])
+      );
+      expect(
+        rendered.root.findAllByType("output").map((node) => node.children)
+      ).toEqual([["changed"], ["second"]]);
+    } finally {
+      act(() => rendered.unmount());
+    }
+  });
+});

--- a/apps/chat/lib/stores/base/hooks.ts
+++ b/apps/chat/lib/stores/base/hooks.ts
@@ -9,7 +9,7 @@ import { useStore } from "zustand";
 import { devtools, subscribeWithSelector } from "zustand/middleware";
 import { useShallow } from "zustand/shallow";
 import { createStore } from "zustand/vanilla";
-import type { StateCreator } from "zustand/vanilla";
+import type { StateCreator, StoreApi } from "zustand/vanilla";
 
 import { debug } from "./debug";
 
@@ -213,7 +213,6 @@ type SyncedChatState<TMessage extends UIMessage> = Partial<
 >;
 
 export interface StoreState<TMessage extends UIMessage = UIMessage> {
-  _memoizedSelectors: Map<string, { result: any; deps: any[] }>;
   _messageIndex: MessageIndex<TMessage>;
 
   // Performance optimizations
@@ -234,8 +233,6 @@ export interface StoreState<TMessage extends UIMessage = UIMessage> {
   // Optimized getters
   getLastMessageId: () => string | null;
 
-  // Memoized complex selectors
-  getMemoizedSelector: <T>(key: string, selector: () => T, deps: any[]) => T;
   getMessageById: (id: string) => TMessage | undefined;
   getMessageCount: () => number;
   getMessageIds: () => string[];
@@ -317,7 +314,6 @@ export const createChatStoreCreator = <TMessage extends UIMessage>(
       error: undefined,
       _throttledMessages: [...initialMessages],
       _messageIndex: messageIndex,
-      _memoizedSelectors: new Map(),
       _transientDataParts: new Map(),
       _scheduleThrottledMessagesUpdate: () => {
         throttledMessagesUpdater?.();
@@ -350,7 +346,6 @@ export const createChatStoreCreator = <TMessage extends UIMessage>(
           set({
             messages,
             // Clear memoized selectors
-            _memoizedSelectors: new Map(),
           });
 
           // During streaming, update immediately for smooth text rendering
@@ -386,7 +381,6 @@ export const createChatStoreCreator = <TMessage extends UIMessage>(
         batchUpdates(() => {
           get()._messageIndex.update(messages);
           set({
-            _memoizedSelectors: new Map(),
             error: undefined,
             id,
             messages,
@@ -404,7 +398,6 @@ export const createChatStoreCreator = <TMessage extends UIMessage>(
             const messages = [...state.messages, message];
             state._messageIndex.update(messages);
             return {
-              _memoizedSelectors: new Map(),
               messages,
             };
           });
@@ -434,7 +427,6 @@ export const createChatStoreCreator = <TMessage extends UIMessage>(
             const messages = state.messages.slice(0, -1);
             state._messageIndex.update(messages);
             return {
-              _memoizedSelectors: new Map(),
               messages,
             };
           });
@@ -451,7 +443,6 @@ export const createChatStoreCreator = <TMessage extends UIMessage>(
             newMessages[index] = structuredClone(message);
             state._messageIndex.update(newMessages);
             return {
-              _memoizedSelectors: new Map(),
               messages: newMessages,
             };
           });
@@ -488,7 +479,6 @@ export const createChatStoreCreator = <TMessage extends UIMessage>(
             newMessages[index] = structuredClone(message);
             state._messageIndex.update(newMessages);
             return {
-              _memoizedSelectors: new Map(),
               messages: newMessages,
             };
           });
@@ -518,7 +508,6 @@ export const createChatStoreCreator = <TMessage extends UIMessage>(
             {
               ...newState,
               // Clear memoized selectors on sync
-              _memoizedSelectors: new Map(),
             },
             false
             // 'syncFromUseChat',
@@ -539,7 +528,6 @@ export const createChatStoreCreator = <TMessage extends UIMessage>(
           }
 
           set({
-            _memoizedSelectors: new Map(),
             _messageIndex: newMessageIndex,
             _throttledMessages: [],
             _transientDataParts: new Map(),
@@ -594,28 +582,6 @@ export const createChatStoreCreator = <TMessage extends UIMessage>(
         const state = get();
         const messages = state._throttledMessages || state.messages;
         return messages.length;
-      },
-
-      getMemoizedSelector: <T>(
-        key: string,
-        selector: () => T,
-        deps: any[]
-      ): T => {
-        const state = get();
-        const cached = state._memoizedSelectors.get(key);
-
-        // Reference-equality dep check, matching React dependency semantics.
-        if (
-          cached &&
-          cached.deps.length === deps.length &&
-          cached.deps.every((dep, index) => Object.is(dep, deps[index]))
-        ) {
-          return cached.result;
-        }
-
-        const result = selector();
-        state._memoizedSelectors.set(key, { deps: [...deps], result });
-        return result;
       },
 
       // Effects
@@ -677,7 +643,13 @@ type ChatStoreApi<TMessage extends UIMessage = UIMessage> = ReturnType<
   typeof createChatStore<TMessage>
 >;
 
-export const ChatStoreContext = createContext<ChatStoreApi<any> | undefined>(
+// The provider can carry any message specialization; typed hooks select it at the boundary.
+type ChatStoreHandle = Pick<
+  StoreApi<unknown>,
+  "getInitialState" | "getState" | "subscribe"
+>;
+
+export const ChatStoreContext = createContext<ChatStoreHandle | undefined>(
   undefined
 );
 
@@ -730,6 +702,14 @@ export const Provider = <TMessage extends UIMessage = UIMessage>({
   );
 };
 
+export const useChatStoreApi = <TMessage extends UIMessage = UIMessage>() => {
+  const store = useContext(ChatStoreContext);
+  if (!store) {
+    throw new Error("useChatStoreApi must be used within Provider");
+  }
+  return store as ChatStoreApi<TMessage>;
+};
+
 // Standard Zustand v5 store hook
 export function useChatStore<T, TMessage extends UIMessage = UIMessage>(
   selector: (store: StoreState<TMessage>) => T
@@ -741,25 +721,15 @@ export function useChatStore<
   T = StoreState<UIMessage>,
   TMessage extends UIMessage = UIMessage,
 >(selector?: (store: StoreState<TMessage>) => T) {
-  const store = useContext(ChatStoreContext);
-  if (!store) {
-    throw new Error("useChatStore must be used within Provider");
-  }
-
+  const store = useChatStoreApi<TMessage>();
   const selectorOrIdentity =
-    selector || ((s: StoreState<TMessage>) => s as unknown as T);
+    selector ?? ((state: StoreState<TMessage>) => state);
 
-  // Use Zustand's built-in useStore
-  return useStore(store, selectorOrIdentity as (state: any) => T);
+  return useStore<ChatStoreApi<TMessage>, T | StoreState<TMessage>>(
+    store,
+    selectorOrIdentity
+  );
 }
-
-export const useChatStoreApi = <TMessage extends UIMessage = UIMessage>() => {
-  const store = useContext(ChatStoreContext);
-  if (!store) {
-    throw new Error("useChatStoreApi must be used within Provider");
-  }
-  return store as ChatStoreApi<TMessage>;
-};
 
 // Optimized selector hooks with memoization
 export const useChatMessages = <TMessage extends UIMessage = UIMessage>() =>
@@ -768,11 +738,10 @@ export const useChatMessages = <TMessage extends UIMessage = UIMessage>() =>
   );
 
 // Stable selector functions to avoid recreation
-const statusSelector = (state: StoreState<any>) => state.status;
-const errorSelector = (state: StoreState<any>) => state.error;
-const idSelector = (state: StoreState<any>) => state.id;
-const messageCountSelector = (state: StoreState<any>) =>
-  state.getMessageCount();
+const statusSelector = (state: StoreState) => state.status;
+const errorSelector = (state: StoreState) => state.error;
+const idSelector = (state: StoreState) => state.id;
+const messageCountSelector = (state: StoreState) => state.getMessageCount();
 
 export const useChatStatus = () => useChatStore(statusSelector);
 export const useChatError = () => useChatStore(errorSelector);
@@ -869,22 +838,4 @@ export const useChatActions = <
       startRun: state.startRun || fallbackStartRun,
       stop: state.stop || fallbackStop,
     }))
-  );
-
-// Memoized complex selector hook
-export const useSelector = <TMessage extends UIMessage = UIMessage, T = any>(
-  key: string,
-  selector: (messages: TMessage[]) => T,
-  deps: any[] = []
-) =>
-  useChatStore(
-    useCallback(
-      (state: StoreState<TMessage>) =>
-        state.getMemoizedSelector(
-          key,
-          () => selector(state.getThrottledMessages()),
-          [state.getMessageCount(), ...deps]
-        ),
-      [key, selector, ...deps]
-    )
   );

--- a/apps/chat/lib/stores/base/index.ts
+++ b/apps/chat/lib/stores/base/index.ts
@@ -20,7 +20,6 @@ export {
   useMessageById,
   useMessageCount,
   useMessageIds,
-  useSelector,
   useVirtualMessages,
 } from "./hooks";
 // Enhanced useChat hook

--- a/apps/chat/lib/stores/with-thread-state.ts
+++ b/apps/chat/lib/stores/with-thread-state.ts
@@ -64,7 +64,6 @@ export const withThreadState =
 
           return {
             ...state,
-            _memoizedSelectors: new Map(),
             error: nextSnapshot.error,
             messages: nextSnapshot.messages,
             status: nextSnapshot.status,

--- a/apps/chat/oxlint-baseline.json
+++ b/apps/chat/oxlint-baseline.json
@@ -233,8 +233,7 @@
     {
       "files": [
         "components/ai-elements/message.tsx",
-        "components/ai-elements/prompt-input.tsx",
-        "lib/stores/base/hooks.ts"
+        "components/ai-elements/prompt-input.tsx"
       ],
       "rules": {
         "react/exhaustive-deps": "off"
@@ -384,12 +383,6 @@
       }
     },
     {
-      "files": ["lib/stores/base/hooks.ts"],
-      "rules": {
-        "react/use-memo": "off"
-      }
-    },
-    {
       "files": [
         "app/layout.tsx",
         "components/create-artifact.tsx",
@@ -485,10 +478,7 @@
       }
     },
     {
-      "files": [
-        "components/ai-elements/prompt-input.tsx",
-        "lib/stores/base/hooks.ts"
-      ],
+      "files": ["lib/stores/base/hooks.ts"],
       "rules": {
         "typescript/no-explicit-any": "off"
       }


### PR DESCRIPTION
Chat store helpers and browser speech callbacks still exposed explicit `any` types. Use a structurally checked, read-only store handle at the shared React context boundary, preserve typed selector/full-state overloads, and give speech callbacks void returns. Remove the unused memoized selector API/cache and its repeated message-update invalidations; repository-wide search confirms it has no consumers.

This resolves 16 of 19 explicit-any diagnostics and four related diagnostics in deleted code (strict audit 441 → 421). The three transient-data `any` declarations remain for a dedicated typed data-part contract. Remove three resolved file/rule exemptions without adding suppressions.

Validation: `bun lint`, `bun test:types` (7 packages), all 198 chat unit tests, and independent review pass. New hook regressions exercise typed selectors, full-store subscriptions, status/message updates, reset, and isolation between providers. Speech edits are type-only; no component states or visual output change.

Combined runtime verification: two consecutive real chat messages completed and persisted after a full reload. Next.js/Turbopack reported no compilation or runtime errors; UI Verify rendered 20 screenshots with no visual changes.
