### PR TITLE
refactor: replace promise chains with await

### DIFF
--- a/apps/chat/app/(chat)/api/chat/route.ts
+++ b/apps/chat/app/(chat)/api/chat/route.ts
@@ -537,19 +537,22 @@ const createChatStream = async ({
       // Otherwise the client will try to resume a stream that no longer exists and we end up with a
       // stuck partial placeholder on reload.
       if (!isAnonymous) {
-        after(() =>
-          Promise.resolve(
-            updateMessageActiveStreamId({
-              activeStreamId: null,
-              id: messageId,
-            })
-          ).catch((dbError) => {
-            log.error(
-              { error: dbError },
-              "Failed to clear activeStreamId on stream error"
-            );
-          })
-        );
+        after(() => {
+          const update = updateMessageActiveStreamId({
+            activeStreamId: null,
+            id: messageId,
+          });
+          return (async () => {
+            try {
+              await update;
+            } catch (dbError) {
+              log.error(
+                { error: dbError },
+                "Failed to clear activeStreamId on stream error"
+              );
+            }
+          })();
+        });
       }
 
       log.error({ error }, "onError");

--- a/apps/chat/components/ai-elements/code-block.tsx
+++ b/apps/chat/components/ai-elements/code-block.tsx
@@ -80,13 +80,20 @@ export const CodeBlock = ({
   const mounted = useRef(false);
 
   useEffect(() => {
-    highlightCode(code, language, showLineNumbers).then(([light, dark]) => {
+    const updateHighlightedCode = async () => {
+      const [light, dark] = await highlightCode(
+        code,
+        language,
+        showLineNumbers
+      );
       if (!mounted.current) {
         setHtml(light);
         setDarkHtml(dark);
         mounted.current = true;
       }
-    });
+    };
+
+    void updateHighlightedCode();
 
     return () => {
       mounted.current = false;

--- a/apps/chat/components/ai-elements/prompt-input.tsx
+++ b/apps/chat/components/ai-elements/prompt-input.tsx
@@ -728,17 +728,19 @@ export const PromptInput = ({
     }
 
     // Convert blob URLs to data URLs asynchronously
-    Promise.all(
-      files.map(async ({ id: _id, ...item }) => {
-        if (item.url && item.url.startsWith("blob:")) {
-          return {
-            ...item,
-            url: await convertBlobUrlToDataUrl(item.url),
-          };
-        }
-        return item;
-      })
-    ).then((convertedFiles: FileUIPart[]) => {
+    const submitConvertedFiles = async () => {
+      const convertedFiles: FileUIPart[] = await Promise.all(
+        files.map(async ({ id: _id, ...item }) => {
+          if (item.url && item.url.startsWith("blob:")) {
+            return {
+              ...item,
+              url: await convertBlobUrlToDataUrl(item.url),
+            };
+          }
+          return item;
+        })
+      );
+
       try {
         const result = onSubmit(
           {
@@ -750,27 +752,20 @@ export const PromptInput = ({
 
         // Handle both sync and async onSubmit
         if (result instanceof Promise) {
-          result
-            .then(() => {
-              clear();
-              if (usingProvider) {
-                controller.textInput.clear();
-              }
-            })
-            .catch(() => {
-              // Don't clear on error - user may want to retry
-            });
-        } else {
-          // Sync function completed without throwing, clear attachments
-          clear();
-          if (usingProvider) {
-            controller.textInput.clear();
-          }
+          await result;
+        }
+
+        // Sync function completed, or the submitted promise resolved.
+        clear();
+        if (usingProvider) {
+          controller.textInput.clear();
         }
       } catch {
         // Don't clear on error - user may want to retry
       }
-    });
+    };
+
+    void submitConvertedFiles();
   };
 
   // Render with or without local provider

--- a/apps/chat/components/chat-runtime-controller.tsx
+++ b/apps/chat/components/chat-runtime-controller.tsx
@@ -55,9 +55,14 @@ const ChatConfirmationEffects = ({ chatId }: { chatId: string }) => {
       ]);
     };
 
-    invalidatePersistedChatQueries().catch(() => {
-      toast.error("Failed to refresh chat history");
-    });
+    const invalidation = invalidatePersistedChatQueries();
+    void (async () => {
+      try {
+        await invalidation;
+      } catch {
+        toast.error("Failed to refresh chat history");
+      }
+    })();
   }, [chatId, isChatPersisted, queryClient, trpc]);
 
   return null;

--- a/apps/chat/components/device-login-page.tsx
+++ b/apps/chat/components/device-login-page.tsx
@@ -144,14 +144,19 @@ export const DeviceLoginPage = () => {
       });
     };
 
-    checkSession().catch(() => {
-      if (cancelled) {
-        return;
-      }
+    const sessionCheck = checkSession();
+    void (async () => {
+      try {
+        await sessionCheck;
+      } catch {
+        if (cancelled) {
+          return;
+        }
 
-      transferStartedRef.current = false;
-      setState("waiting-for-app");
-    });
+        transferStartedRef.current = false;
+        setState("waiting-for-app");
+      }
+    })();
 
     return () => {
       cancelled = true;
@@ -163,28 +168,31 @@ export const DeviceLoginPage = () => {
       onRetry={() => {
         transferStartedRef.current = false;
         setState("transferring");
-        authClient.electron
-          .transferUser({
-            fetchOptions: {
-              onError: () => {
-                transferStartedRef.current = false;
-                setState("waiting-for-app");
-              },
-              onSuccess: () => {
-                window.history.replaceState(
-                  {},
-                  "",
-                  `${pathname}?${DEVICE_LOGIN_COMPLETED_PARAM}=1`
-                );
-                setState("waiting-for-app");
-              },
-              query,
+        const transfer = authClient.electron.transferUser({
+          fetchOptions: {
+            onError: () => {
+              transferStartedRef.current = false;
+              setState("waiting-for-app");
             },
-          })
-          .catch(() => {
+            onSuccess: () => {
+              window.history.replaceState(
+                {},
+                "",
+                `${pathname}?${DEVICE_LOGIN_COMPLETED_PARAM}=1`
+              );
+              setState("waiting-for-app");
+            },
+            query,
+          },
+        });
+        void (async () => {
+          try {
+            await transfer;
+          } catch {
             transferStartedRef.current = false;
             setState("waiting-for-app");
-          });
+          }
+        })();
       }}
       state={state}
     />

--- a/apps/chat/components/electron-auth-handler.tsx
+++ b/apps/chat/components/electron-auth-handler.tsx
@@ -56,10 +56,12 @@ const ElectronAuthOverlay = ({
             {canCancel ? (
               <Button
                 className="mt-2"
-                onClick={() => {
-                  window.electronAPI?.cancelAuthFlow?.().catch((error) => {
+                onClick={async () => {
+                  try {
+                    await window.electronAPI?.cancelAuthFlow?.();
+                  } catch (error) {
                     console.error("Failed to cancel Electron auth flow", error);
-                  });
+                  }
                 }}
                 size="sm"
                 type="button"
@@ -129,16 +131,18 @@ export const ElectronAuthHandler = () => {
       return;
     }
 
-    const authStatePromise = window.electronAPI?.getAuthState?.();
-    authStatePromise
-      ?.then((state) => {
+    const loadAuthState = async () => {
+      try {
+        const state = await window.electronAPI?.getAuthState?.();
         if (state) {
           setAuthState(state);
         }
-      })
-      ?.catch((error) => {
+      } catch (error) {
         console.error("Failed to read Electron auth state", error);
-      });
+      }
+    };
+
+    void loadAuthState();
 
     const syncAndRefresh = async () => {
       await window.electronAPI?.syncAuthSession?.();
@@ -146,17 +150,27 @@ export const ElectronAuthHandler = () => {
     };
 
     const unsubscribeAuthenticated = window.onAuthenticated(() => {
-      syncAndRefresh().catch((error) => {
-        console.error(
-          "Failed to sync auth session after authentication",
-          error
-        );
-      });
+      const syncAuthenticatedSession = async () => {
+        try {
+          await syncAndRefresh();
+        } catch (error) {
+          console.error(
+            "Failed to sync auth session after authentication",
+            error
+          );
+        }
+      };
+      void syncAuthenticatedSession();
     });
     const unsubscribeUserUpdated = window.onUserUpdated(() => {
-      syncAndRefresh().catch((error) => {
-        console.error("Failed to sync auth session after user update", error);
-      });
+      const syncUpdatedUser = async () => {
+        try {
+          await syncAndRefresh();
+        } catch (error) {
+          console.error("Failed to sync auth session after user update", error);
+        }
+      };
+      void syncUpdatedUser();
     });
     const unsubscribeAuthError = window.onAuthError(
       (ctx: ElectronAuthErrorContext) => {

--- a/apps/chat/components/electron-auth-ui.tsx
+++ b/apps/chat/components/electron-auth-ui.tsx
@@ -30,11 +30,15 @@ export const ElectronBrowserSignIn = ({
           if (typeof requestAuth !== "function") {
             return;
           }
-          Promise.resolve()
-            .then(() => requestAuth())
-            .catch((error) => {
+          const launchBrowserSignIn = async () => {
+            try {
+              await Promise.resolve();
+              await requestAuth();
+            } catch (error) {
               console.error("Failed to launch browser sign-in", error);
-            });
+            }
+          };
+          void launchBrowserSignIn();
           window.setTimeout(() => setOpened(true), 300);
         }}
         type="button"

--- a/apps/chat/components/header-breadcrumb.tsx
+++ b/apps/chat/components/header-breadcrumb.tsx
@@ -282,9 +282,14 @@ export const HeaderBreadcrumb = ({
 
   const handleChatInputKeyDown = createInputKeyDownHandler({
     onEnter: () => {
-      handleChatRename().catch(() => {
-        // No-op: already handled via rename hook
-      });
+      const rename = handleChatRename();
+      void (async () => {
+        try {
+          await rename;
+        } catch {
+          // No-op: already handled via rename hook
+        }
+      })();
     },
     onEscape: () => {
       setIsChatEditing(false);

--- a/apps/chat/components/interactive-charts.tsx
+++ b/apps/chat/components/interactive-charts.tsx
@@ -13,7 +13,11 @@ const ChartSkeleton = () => (
 );
 
 export default dynamic(
-  () => import("./interactive-chart-impl").then((m) => m.default),
+  async () => {
+    const { default: InteractiveChart } =
+      await import("./interactive-chart-impl");
+    return InteractiveChart;
+  },
   {
     loading: () => <ChartSkeleton />,
     ssr: false,

--- a/apps/chat/components/multimodal-input.tsx
+++ b/apps/chat/components/multimodal-input.tsx
@@ -515,7 +515,7 @@ const PureMultimodalInput = ({
     if (primaryRequest) {
       handleModelChange(primaryRequest.modelId);
 
-      runParallelThreadRequestSpecs({
+      const runRequests = runParallelThreadRequestSpecs({
         chatId,
         isAuthenticated: !!session?.user,
         message,
@@ -523,17 +523,20 @@ const PureMultimodalInput = ({
         projectId: currentRoute.projectId,
         requestSpecs,
         startRun,
-      })
-        .then(async (failedRequestSpecs) => {
+      });
+      const completeRequests = async () => {
+        try {
+          const failedRequestSpecs = await runRequests;
           if (failedRequestSpecs.length > 0) {
             toast.error("Failed to complete all parallel responses");
           }
 
           await invalidatePersistedMessages();
-        })
-        .catch(() => {
+        } catch {
           toast.error("Failed to complete all parallel responses");
-        });
+        }
+      };
+      void completeRequests();
     } else {
       toast.error("No model selected");
     }

--- a/apps/chat/components/part/document-preview.tsx
+++ b/apps/chat/components/part/document-preview.tsx
@@ -17,23 +17,36 @@ import { InlineDocumentSkeleton } from "../document-skeleton";
 import { DocumentToolCall, DocumentToolResult } from "./document-common";
 
 const CodeEditor = dynamic(
-  () => import("../code-editor").then((m) => ({ default: m.CodeEditor })),
+  async () => {
+    const { CodeEditor: CodeEditorComponent } = await import("../code-editor");
+    return { default: CodeEditorComponent };
+  },
   { loading: () => <InlineDocumentSkeleton />, ssr: false }
 );
 
 const Editor = dynamic(
-  () => import("../text-editor").then((m) => ({ default: m.Editor })),
+  async () => {
+    const { Editor: EditorComponent } = await import("../text-editor");
+    return { default: EditorComponent };
+  },
   { loading: () => <InlineDocumentSkeleton />, ssr: false }
 );
 
 const ImageEditor = dynamic(
-  () => import("../image-editor").then((m) => ({ default: m.ImageEditor })),
+  async () => {
+    const { ImageEditor: ImageEditorComponent } =
+      await import("../image-editor");
+    return { default: ImageEditorComponent };
+  },
   { loading: () => <InlineDocumentSkeleton />, ssr: false }
 );
 
 const SpreadsheetEditor = dynamic(
-  () =>
-    import("../sheet-editor").then((m) => ({ default: m.SpreadsheetEditor })),
+  async () => {
+    const { SpreadsheetEditor: SpreadsheetEditorComponent } =
+      await import("../sheet-editor");
+    return { default: SpreadsheetEditorComponent };
+  },
   { loading: () => <InlineDocumentSkeleton />, ssr: false }
 );
 

--- a/apps/chat/components/retry-button.tsx
+++ b/apps/chat/components/retry-button.tsx
@@ -42,7 +42,7 @@ export const RetryButton = ({
       return;
     }
 
-    regenerate({
+    const retry = regenerate({
       body: {
         isPrimaryParallel: retryInput.isPrimaryParallel,
         parallelGroupId: retryInput.parallelGroupId,
@@ -50,9 +50,14 @@ export const RetryButton = ({
         selectedModelId: retryInput.selectedModelId,
       },
       messageId,
-    }).catch(() => {
-      toast.error("Could not retry this message");
     });
+    void (async () => {
+      try {
+        await retry;
+      } catch {
+        toast.error("Could not retry this message");
+      }
+    })();
   }, [messageId, chatStore]);
 
   if (status === "streaming" || status === "submitted") {

--- a/apps/chat/components/suggested-actions.tsx
+++ b/apps/chat/components/suggested-actions.tsx
@@ -144,7 +144,7 @@ const PureSuggestedActions = ({
 
     const [primaryRequest] = submission.requestSpecs;
     if (primaryRequest) {
-      runParallelThreadRequestSpecs({
+      const runRequests = runParallelThreadRequestSpecs({
         chatId,
         isAuthenticated: !!session?.user,
         message: submission.message,
@@ -152,9 +152,14 @@ const PureSuggestedActions = ({
         projectId: currentRoute.projectId,
         requestSpecs: submission.requestSpecs,
         startRun,
-      }).catch(() => {
-        // The chat-level error callback owns user-facing request errors.
       });
+      void (async () => {
+        try {
+          await runRequests;
+        } catch {
+          // The chat-level error callback owns user-facing request errors.
+        }
+      })();
     }
   };
 

--- a/apps/chat/lib/anonymous-session-client.ts
+++ b/apps/chat/lib/anonymous-session-client.ts
@@ -27,17 +27,20 @@ const setCookie = (name: string, value: string, maxAge: number): void => {
   const secure = window.location.protocol === "https:" ? "; Secure" : "";
   const encodedValue = encodeURIComponent(value);
   if ("cookieStore" in window) {
-    window.cookieStore
-      .set({
-        expires: Date.now() + maxAge * 1000,
-        name,
-        path: "/",
-        sameSite: "lax",
-        value: encodedValue,
-      })
-      .catch(() => {
+    const cookieSet = window.cookieStore.set({
+      expires: Date.now() + maxAge * 1000,
+      name,
+      path: "/",
+      sameSite: "lax",
+      value: encodedValue,
+    });
+    void (async () => {
+      try {
+        await cookieSet;
+      } catch {
         // Fail silently if Cookie Store API fails
-      });
+      }
+    })();
   } else {
     document.cookie = `${name}=${encodedValue}; Path=/; Max-Age=${maxAge}; SameSite=Lax${secure}`;
   }
@@ -48,9 +51,14 @@ const deleteCookie = (name: string): void => {
     return;
   }
   if ("cookieStore" in window) {
-    window.cookieStore.delete(name).catch(() => {
-      // Fail silently if Cookie Store API fails
-    });
+    const cookieDeletion = window.cookieStore.delete(name);
+    void (async () => {
+      try {
+        await cookieDeletion;
+      } catch {
+        // Fail silently if Cookie Store API fails
+      }
+    })();
   } else {
     document.cookie = `${name}=; Path=/; Max-Age=0`;
   }

--- a/apps/chat/lib/artifacts/text/client.tsx
+++ b/apps/chat/lib/artifacts/text/client.tsx
@@ -7,7 +7,11 @@ import { DocumentSkeleton } from "@/components/document-skeleton";
 import { config } from "@/lib/config";
 
 const DiffView = dynamic(
-  () => import("@/components/diffview").then((m) => ({ default: m.DiffView })),
+  async () => {
+    const { DiffView: DiffViewComponent } =
+      await import("@/components/diffview");
+    return { default: DiffViewComponent };
+  },
   {
     loading: () => <DocumentSkeleton artifactKind="text" />,
     ssr: false,
@@ -15,7 +19,11 @@ const DiffView = dynamic(
 );
 
 const Editor = dynamic(
-  () => import("@/components/text-editor").then((m) => ({ default: m.Editor })),
+  async () => {
+    const { Editor: EditorComponent } =
+      await import("@/components/text-editor");
+    return { default: EditorComponent };
+  },
   {
     loading: () => <DocumentSkeleton artifactKind="text" />,
     ssr: false,

--- a/apps/chat/lib/cancellation-aware-chat-transport.ts
+++ b/apps/chat/lib/cancellation-aware-chat-transport.ts
@@ -103,9 +103,14 @@ const observeCancellation = ({
   }
 
   const cancel = () => {
-    onCancel(target).catch(() => {
-      // Cancellation is best effort; transport termination still proceeds.
-    });
+    const cancellation = onCancel(target);
+    void (async () => {
+      try {
+        await cancellation;
+      } catch {
+        // Cancellation is best effort; transport termination still proceeds.
+      }
+    })();
   };
   signal.addEventListener("abort", cancel, { once: true });
 

--- a/apps/chat/lib/gated-chat-transport.test.ts
+++ b/apps/chat/lib/gated-chat-transport.test.ts
@@ -45,7 +45,7 @@ describe("createGatedChatTransport", () => {
     await Promise.resolve();
     assert.equal(sendMessages.mock.calls.length, 0);
 
-    release();
+    release(undefined);
     assert.equal(await request, stream);
     assert.equal(sendMessages.mock.calls.length, 1);
     assert.equal(forwardedMetadata, originalMetadata);

--- a/apps/chat/lib/gated-chat-transport.test.ts
+++ b/apps/chat/lib/gated-chat-transport.test.ts
@@ -45,7 +45,8 @@ describe("createGatedChatTransport", () => {
     await Promise.resolve();
     assert.equal(sendMessages.mock.calls.length, 0);
 
-    release(undefined);
+    const resolved = undefined;
+    release(resolved);
     assert.equal(await request, stream);
     assert.equal(sendMessages.mock.calls.length, 1);
     assert.equal(forwardedMetadata, originalMetadata);

--- a/apps/chat/lib/gated-chat-transport.test.ts
+++ b/apps/chat/lib/gated-chat-transport.test.ts
@@ -82,13 +82,26 @@ describe("createGatedChatTransport", () => {
       reconnectToStream: async () => null,
       sendMessages,
     });
+    const abortController = new AbortController();
+    const removeEventListener = vi.spyOn(
+      abortController.signal,
+      "removeEventListener"
+    );
 
     const request = transport.sendMessages(
-      requestOptions(gateChatRequest(Promise.reject(gateError)).metadata)
+      requestOptions(
+        gateChatRequest(Promise.reject(gateError)).metadata,
+        abortController.signal
+      )
     );
 
     await assert.rejects(request, gateError);
     assert.equal(sendMessages.mock.calls.length, 0);
+    assert.equal(
+      removeEventListener.mock.calls.filter(([type]) => type === "abort")
+        .length,
+      1
+    );
   });
 
   it("does not forward a request that was already stopped", async () => {
@@ -110,6 +123,58 @@ describe("createGatedChatTransport", () => {
     );
 
     await assert.rejects(request, { name: "AbortError" });
+    assert.equal(sendMessages.mock.calls.length, 0);
+  });
+
+  it("observes a gate rejection after a request is stopped while waiting", async () => {
+    let rejectGate: (error: Error) => void = () => {};
+    const ready = new Promise<void>((_resolve, reject) => {
+      rejectGate = reject;
+    });
+    const sendMessages = vi.fn(() =>
+      Promise.resolve(new ReadableStream<UIMessageChunk>())
+    );
+    const transport = createGatedChatTransport<UIMessage>({
+      reconnectToStream: async () => null,
+      sendMessages,
+    });
+    const abortController = new AbortController();
+    const request = transport.sendMessages(
+      requestOptions(gateChatRequest(ready).metadata, abortController.signal)
+    );
+
+    abortController.abort();
+    await assert.rejects(request, { name: "AbortError" });
+
+    rejectGate(new Error("persist failed after cancellation"));
+    await Promise.resolve();
+
+    assert.equal(sendMessages.mock.calls.length, 0);
+  });
+
+  it("observes a rejected gate for a request that was already stopped", async () => {
+    let rejectGate: (error: Error) => void = () => {};
+    const ready = new Promise<void>((_resolve, reject) => {
+      rejectGate = reject;
+    });
+    const sendMessages = vi.fn(() =>
+      Promise.resolve(new ReadableStream<UIMessageChunk>())
+    );
+    const transport = createGatedChatTransport<UIMessage>({
+      reconnectToStream: async () => null,
+      sendMessages,
+    });
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const request = transport.sendMessages(
+      requestOptions(gateChatRequest(ready).metadata, abortController.signal)
+    );
+    await assert.rejects(request, { name: "AbortError" });
+
+    rejectGate(new Error("persist failed before request started"));
+    await Promise.resolve();
+
     assert.equal(sendMessages.mock.calls.length, 0);
   });
 });

--- a/apps/chat/lib/gated-chat-transport.test.ts
+++ b/apps/chat/lib/gated-chat-transport.test.ts
@@ -22,10 +22,8 @@ const requestOptions = (
 
 describe("createGatedChatTransport", () => {
   it("waits before forwarding a request and restores its metadata", async () => {
-    let release: () => void = () => {};
-    const ready = new Promise<void>((resolve) => {
-      release = resolve;
-    });
+    const { promise: ready, resolve: release } =
+      Promise.withResolvers<undefined>();
     const stream = new ReadableStream<UIMessageChunk>();
     let forwardedMetadata: unknown;
     const sendMessages = vi.fn(
@@ -127,15 +125,13 @@ describe("createGatedChatTransport", () => {
   });
 
   it("observes a gate rejection after a request is stopped while waiting", async () => {
-    let rejectGate: (error: Error) => void = () => {};
-    const ready = new Promise<void>((_resolve, reject) => {
-      rejectGate = reject;
-    });
+    const { promise: ready, reject: rejectGate } =
+      Promise.withResolvers<undefined>();
     const sendMessages = vi.fn(() =>
       Promise.resolve(new ReadableStream<UIMessageChunk>())
     );
     const transport = createGatedChatTransport<UIMessage>({
-      reconnectToStream: async () => null,
+      reconnectToStream: () => Promise.resolve(null),
       sendMessages,
     });
     const abortController = new AbortController();
@@ -153,15 +149,13 @@ describe("createGatedChatTransport", () => {
   });
 
   it("observes a rejected gate for a request that was already stopped", async () => {
-    let rejectGate: (error: Error) => void = () => {};
-    const ready = new Promise<void>((_resolve, reject) => {
-      rejectGate = reject;
-    });
+    const { promise: ready, reject: rejectGate } =
+      Promise.withResolvers<undefined>();
     const sendMessages = vi.fn(() =>
       Promise.resolve(new ReadableStream<UIMessageChunk>())
     );
     const transport = createGatedChatTransport<UIMessage>({
-      reconnectToStream: async () => null,
+      reconnectToStream: () => Promise.resolve(null),
       sendMessages,
     });
     const abortController = new AbortController();

--- a/apps/chat/lib/gated-chat-transport.ts
+++ b/apps/chat/lib/gated-chat-transport.ts
@@ -14,9 +14,13 @@ const waitForGate = (ready: Promise<void>, signal?: AbortSignal) => {
     return ready;
   }
   if (signal.aborted) {
-    ready.catch(() => {
-      // Observe a rejected gate after cancellation without changing the abort error.
-    });
+    void (async () => {
+      try {
+        await ready;
+      } catch {
+        // Observe a rejected gate after cancellation without changing the abort error.
+      }
+    })();
     return Promise.reject(createAbortError());
   }
 
@@ -24,16 +28,17 @@ const waitForGate = (ready: Promise<void>, signal?: AbortSignal) => {
     const abort = () => reject(createAbortError());
     const cleanup = () => signal.removeEventListener("abort", abort);
     signal.addEventListener("abort", abort, { once: true });
-    ready.then(
-      () => {
+    const resolveWhenReady = async () => {
+      try {
+        await ready;
         cleanup();
         resolve();
-      },
-      (error: unknown) => {
+      } catch (error) {
         cleanup();
         reject(error);
       }
-    );
+    };
+    void resolveWhenReady();
   });
 };
 

--- a/apps/chat/lib/start-provisional-chat.ts
+++ b/apps/chat/lib/start-provisional-chat.ts
@@ -86,7 +86,7 @@ export const useStartProvisionalChat = (chatId: string) => {
         changeModel(primaryRequest.modelId);
       }
 
-      runParallelThreadRequestSpecs({
+      const runRequests = runParallelThreadRequestSpecs({
         chatId,
         isAuthenticated: true,
         message,
@@ -94,18 +94,33 @@ export const useStartProvisionalChat = (chatId: string) => {
         projectId: currentRoute.projectId,
         requestSpecs,
         startRun,
-      })
-        .finally(() => {
+      });
+      const completeRequests = async () => {
+        let shouldDiscardConfirmation = true;
+        try {
+          const failedRequestSpecs = await runRequests;
+          shouldDiscardConfirmation = false;
           discardUnacknowledgedProvisionalChatConfirmation(chatId, message.id);
-        })
-        .then((failedRequestSpecs) => {
+
           if (failedRequestSpecs.length > 0) {
             toast.error("Failed to complete all parallel responses");
           }
-        })
-        .catch(() => {
+        } catch {
+          if (shouldDiscardConfirmation) {
+            try {
+              discardUnacknowledgedProvisionalChatConfirmation(
+                chatId,
+                message.id
+              );
+            } catch {
+              toast.error("Failed to complete all parallel responses");
+              return;
+            }
+          }
           toast.error("Failed to complete all parallel responses");
-        });
+        }
+      };
+      void completeRequests();
 
       window.history.pushState(null, "", href);
       onStarted?.();

--- a/apps/chat/oxlint-baseline.json
+++ b/apps/chat/oxlint-baseline.json
@@ -184,32 +184,6 @@
       }
     },
     {
-      "files": [
-        "app/(chat)/api/chat/route.ts",
-        "components/ai-elements/code-block.tsx",
-        "components/ai-elements/prompt-input.tsx",
-        "components/chat-runtime-controller.tsx",
-        "components/device-login-page.tsx",
-        "components/electron-auth-handler.tsx",
-        "components/electron-auth-ui.tsx",
-        "components/header-breadcrumb.tsx",
-        "components/interactive-charts.tsx",
-        "components/multimodal-input.tsx",
-        "components/part/document-preview.tsx",
-        "components/retry-button.tsx",
-        "components/suggested-actions.tsx",
-        "lib/anonymous-session-client.ts",
-        "lib/artifacts/text/client.tsx",
-        "lib/cancellation-aware-chat-transport.ts",
-        "lib/gated-chat-transport.ts",
-        "lib/start-provisional-chat.ts",
-        "tools/platform/deep-research/supervisor-agent.ts"
-      ],
-      "rules": {
-        "promise/prefer-await-to-then": "off"
-      }
-    },
-    {
       "files": ["lib/gated-chat-transport.ts"],
       "rules": {
         "promise/prefer-catch": "off"

--- a/apps/chat/oxlint-baseline.json
+++ b/apps/chat/oxlint-baseline.json
@@ -160,33 +160,9 @@
       }
     },
     {
-      "files": ["components/ai-elements/prompt-input.tsx"],
-      "rules": {
-        "promise/no-nesting": "off"
-      }
-    },
-    {
-      "files": ["app/(chat)/api/chat/route.ts"],
-      "rules": {
-        "promise/no-promise-in-callback": "off"
-      }
-    },
-    {
-      "files": [
-        "components/chat-sync.tsx",
-        "components/electron-auth-handler.tsx",
-        "components/electron-auth-ui.tsx",
-        "lib/gated-chat-transport.ts",
-        "lib/stores/base/hooks.ts"
-      ],
+      "files": ["components/chat-sync.tsx", "lib/stores/base/hooks.ts"],
       "rules": {
         "promise/prefer-await-to-callbacks": "off"
-      }
-    },
-    {
-      "files": ["lib/gated-chat-transport.ts"],
-      "rules": {
-        "promise/prefer-catch": "off"
       }
     },
     {
@@ -471,12 +447,6 @@
       "files": ["components/ai-elements/prompt-input.tsx"],
       "rules": {
         "typescript/prefer-function-type": "off"
-      }
-    },
-    {
-      "files": ["lib/gated-chat-transport.test.ts"],
-      "rules": {
-        "unicorn/consistent-function-scoping": "off"
       }
     },
     {

--- a/apps/chat/tools/platform/deep-research/supervisor-agent.ts
+++ b/apps/chat/tools/platform/deep-research/supervisor-agent.ts
@@ -23,9 +23,11 @@ export const runSupervisor = async (
   const conductResearchTool = tool({
     description: "Call this tool to conduct research on a specific topic.",
     execute: ({ research_topic }) => {
-      researchQueue = researchQueue.then(() =>
-        runResearcher(research_topic, options)
-      );
+      const previousResearch = researchQueue;
+      researchQueue = (async () => {
+        await previousResearch;
+        return runResearcher(research_topic, options);
+      })();
       return researchQueue as Promise<string>;
     },
     inputSchema: z.object({

--- a/oxlint-baseline.json
+++ b/oxlint-baseline.json
@@ -72,12 +72,6 @@
       }
     },
     {
-      "files": ["packages/thread/src/abstract-thread.ts"],
-      "rules": {
-        "promise/prefer-await-to-then": "off"
-      }
-    },
-    {
       "files": ["packages/thread/test/use-thread-types.ts"],
       "rules": {
         "react/invariant": "off"

--- a/packages/thread/src/abstract-thread.ts
+++ b/packages/thread/src/abstract-thread.ts
@@ -800,11 +800,15 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
     };
     this.#runs.add(record);
     this.publish();
-    const finished = start(chat).finally(() => this.publish());
+    const finished = this.publishWhenFinished(start(chat));
     // startRun may be detached; observing the rejection keeps finished awaitable.
-    void finished.catch(() => {
-      // The original finished promise retains the rejection for callers.
-    });
+    void (async () => {
+      try {
+        await finished;
+      } catch {
+        // The original finished promise retains the rejection for callers.
+      }
+    })();
     record.finished = finished;
     return this.createRunHandle(record);
   }
@@ -843,7 +847,7 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
       this.#runs.select(run.spec.id);
       this.updateTree((tree) => tree.setCursor(messageId));
     }
-    const finished = run.chat.start(options).finally(() => this.publish());
+    const finished = this.publishWhenFinished(run.chat.start(options));
     run.finished = finished;
     this.publish();
     return this.createRunHandle(run);
@@ -890,15 +894,21 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
     };
   }
 
+  private async publishWhenFinished<T>(promise: Promise<T>) {
+    try {
+      return await promise;
+    } finally {
+      this.publish();
+    }
+  }
+
   private async resumeRunRequest(
     run: RunRecord<TMessage>,
     options: ChatRequestOptions
   ) {
     this.#runs.assertHasCapacity(run.spec.parentMessageId);
     run.chat.refreshPath();
-    const finished = run.chat
-      .resumeStream(options)
-      .finally(() => this.publish());
+    const finished = this.publishWhenFinished(run.chat.resumeStream(options));
     run.finished = finished;
     this.publish();
     await finished;

--- a/packages/thread/test/thread.test.ts
+++ b/packages/thread/test/thread.test.ts
@@ -683,17 +683,23 @@ describe("Thread", () => {
 
   test("unexpected application errors reject the run promise", async () => {
     const transport = new ControlledTransport();
-    const chat = new Thread({
-      sendAutomaticallyWhen: () => {
-        throw new Error("application callback failed");
-      },
-      transport,
+    const state = new RecordingThreadState([]);
+    const chat = new StateBackedThread(state, transport);
+    chat.sendAutomaticallyWhen = () => {
+      throw new Error("application callback failed");
+    };
+    let publishes = 0;
+    const unsubscribe = state.subscribe(() => {
+      publishes += 1;
     });
     const run = await chat.startRun({ message: user("user-1") });
     await waitFor(() => transport.requests.length === 1);
+    const publishesBeforeCompletion = publishes;
     transport.emitText(0, "assistant-1", "complete");
 
     await expect(run.finished).rejects.toThrow("application callback failed");
+    expect(publishes).toBeGreaterThan(publishesBeforeCompletion);
+    unsubscribe();
   });
 
   test("regenerates an assistant as a sibling response", async () => {


### PR DESCRIPTION
Removes all `promise/prefer-await-to-then` baseline exemptions across Chat and Thread by preserving the existing completion, cleanup, cancellation, and detached-error behavior with `async`/`await`.

Validation:
- `bun lint`
- `bun test:types`
- `bun test packages/thread/test/thread.test.ts`
- `bun --filter=@chatjs/chat run test:unit -- lib/gated-chat-transport.test.ts lib/cancellation-aware-chat-transport.test.ts`
- strict audit: zero `promise/prefer-await-to-then` diagnostics

## Summary by Sourcery

Replace promise chains with async/await across Chat and Thread while preserving existing completion, cleanup, cancellation, and error behavior.

Bug Fixes:
- Preserve cancellation cleanup, detached error handling, and thread publishing behavior while converting promise chains to async/await.

Enhancements:
- Replace promise chaining across Chat and Thread with async/await patterns.
- Remove resolved promise lint baseline exemptions.

Tests:
- Add regression coverage for rejected gates after cancellation and thread publishing when runs fail unexpectedly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces promise chains with `async`/`await` in `apps/chat` and `packages/thread`; completion, cleanup, cancellation, and detached-error behavior are unchanged. Removes the now-resolved promise lint baseline exemptions and adds regression coverage for cancellation cleanup, rejected gates after cancellation, and `packages/thread` publishing completion state when runs reject unexpectedly.

<sup>Written for commit 807a106612434936cc133c1c17ee6ec48f3d8d6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

