### PR TITLE
perf: memoize chat context values

### DIFF
--- a/apps/chat/components/ai-elements/code-block.tsx
+++ b/apps/chat/components/ai-elements/code-block.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { CheckIcon, CopyIcon } from "lucide-react";
-import { createContext, useContext, useEffect, useRef, useState } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { ComponentProps, HTMLAttributes } from "react";
 import { codeToHtml } from "shiki";
 import type { BundledLanguage, ShikiTransformer } from "shiki";
@@ -100,8 +107,10 @@ export const CodeBlock = ({
     };
   }, [code, language, showLineNumbers]);
 
+  const contextValue = useMemo(() => ({ code }), [code]);
+
   return (
-    <CodeBlockContext.Provider value={{ code }}>
+    <CodeBlockContext.Provider value={contextValue}>
       <div
         className={cn(
           "group bg-background text-foreground relative w-full overflow-hidden rounded-md border",

--- a/apps/chat/components/ai-elements/context.tsx
+++ b/apps/chat/components/ai-elements/context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext } from "react";
+import { createContext, useContext, useMemo } from "react";
 import type { ComponentProps } from "react";
 import { getUsage } from "tokenlens";
 
@@ -50,11 +50,18 @@ export const Context = ({
   usage,
   modelId,
   ...props
-}: ContextProps) => (
-  <ContextContext.Provider value={{ maxTokens, modelId, usage, usedTokens }}>
-    <HoverCard closeDelay={0} openDelay={0} {...props} />
-  </ContextContext.Provider>
-);
+}: ContextProps) => {
+  const contextValue = useMemo(
+    () => ({ maxTokens, modelId, usage, usedTokens }),
+    [maxTokens, modelId, usage, usedTokens]
+  );
+
+  return (
+    <ContextContext.Provider value={contextValue}>
+      <HoverCard closeDelay={0} openDelay={0} {...props} />
+    </ContextContext.Provider>
+  );
+};
 
 const ContextIcon = () => {
   const { usedTokens, maxTokens } = useContextValue();

--- a/apps/chat/components/ai-elements/message.tsx
+++ b/apps/chat/components/ai-elements/message.tsx
@@ -11,7 +11,15 @@ import {
   XIcon,
 } from "lucide-react";
 import type { ComponentProps, HTMLAttributes, ReactElement } from "react";
-import { createContext, memo, useContext, useEffect, useState } from "react";
+import {
+  createContext,
+  memo,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { Streamdown } from "streamdown";
 
 import { Button } from "@/components/ui/button";
@@ -150,31 +158,37 @@ export const MessageBranch = ({
   const [currentBranch, setCurrentBranch] = useState(defaultBranch);
   const [branches, setBranches] = useState<ReactElement[]>([]);
 
-  const handleBranchChange = (newBranch: number) => {
-    setCurrentBranch(newBranch);
-    onBranchChange?.(newBranch);
-  };
+  const handleBranchChange = useCallback(
+    (newBranch: number) => {
+      setCurrentBranch(newBranch);
+      onBranchChange?.(newBranch);
+    },
+    [onBranchChange]
+  );
 
-  const goToPrevious = () => {
+  const goToPrevious = useCallback(() => {
     const newBranch =
       currentBranch > 0 ? currentBranch - 1 : branches.length - 1;
     handleBranchChange(newBranch);
-  };
+  }, [branches.length, currentBranch, handleBranchChange]);
 
-  const goToNext = () => {
+  const goToNext = useCallback(() => {
     const newBranch =
       currentBranch < branches.length - 1 ? currentBranch + 1 : 0;
     handleBranchChange(newBranch);
-  };
+  }, [branches.length, currentBranch, handleBranchChange]);
 
-  const contextValue: MessageBranchContextType = {
-    branches,
-    currentBranch,
-    goToNext,
-    goToPrevious,
-    setBranches,
-    totalBranches: branches.length,
-  };
+  const contextValue = useMemo<MessageBranchContextType>(
+    () => ({
+      branches,
+      currentBranch,
+      goToNext,
+      goToPrevious,
+      setBranches,
+      totalBranches: branches.length,
+    }),
+    [branches, currentBranch, goToNext, goToPrevious]
+  );
 
   return (
     <MessageBranchContext.Provider value={contextValue}>

--- a/apps/chat/components/ai-elements/reasoning.tsx
+++ b/apps/chat/components/ai-elements/reasoning.tsx
@@ -3,7 +3,15 @@
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import { BrainIcon, ChevronDownIcon } from "lucide-react";
 import type { ComponentProps } from "react";
-import { createContext, memo, useContext, useEffect, useState } from "react";
+import {
+  createContext,
+  memo,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 
 import {
   Collapsible,
@@ -92,19 +100,19 @@ export const Reasoning = memo(
       }
     }, [isStreaming, isOpen, defaultOpen, setIsOpen, hasAutoClosed]);
 
-    const handleOpenChange = (newOpen: boolean) => {
-      setIsOpen(newOpen);
-    };
+    const handleOpenChange = useCallback(
+      (newOpen: boolean) => {
+        setIsOpen(newOpen);
+      },
+      [setIsOpen]
+    );
+    const contextValue = useMemo(
+      () => ({ duration, isOpen, isStreaming, setIsOpen }),
+      [duration, isOpen, isStreaming, setIsOpen]
+    );
 
     return (
-      <ReasoningContext.Provider
-        value={{
-          duration,
-          isOpen,
-          isStreaming,
-          setIsOpen,
-        }}
-      >
+      <ReasoningContext.Provider value={contextValue}>
         <Collapsible
           className={cn("not-prose mb-4", className)}
           onOpenChange={handleOpenChange}

--- a/apps/chat/components/chat/chat-layout.tsx
+++ b/apps/chat/components/chat/chat-layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ComponentProps } from "react";
-import { createContext, useContext } from "react";
+import { createContext, useContext, useMemo } from "react";
 
 import {
   ResizableHandle,
@@ -39,9 +39,13 @@ export const ChatLayout = ({
   ...props
 }: ChatLayoutProps) => {
   const { state: sidebarState } = useSidebar();
+  const contextValue = useMemo(
+    () => ({ isSecondaryPanelVisible }),
+    [isSecondaryPanelVisible]
+  );
 
   return (
-    <ChatLayoutContext.Provider value={{ isSecondaryPanelVisible }}>
+    <ChatLayoutContext.Provider value={contextValue}>
       <ResizablePanelGroup
         className={cn(
           "bg-background @container flex h-dvh max-h-dvh w-full max-w-screen min-w-0 flex-col md:max-w-[calc(100vw-var(--sidebar-width))]",

--- a/apps/chat/components/multimodal-input.tsx
+++ b/apps/chat/components/multimodal-input.tsx
@@ -797,6 +797,41 @@ const PureMultimodalInput = ({
     stopStreamMutation,
     thread,
   ]);
+  const composerContextValue = useMemo(
+    () => ({
+      acceptAll,
+      acceptFiles,
+      acceptImages,
+      autoFocus,
+      fileInputRef,
+      isEditMode,
+      isModelDisallowedForAnonymous,
+      onPaste: handlePaste,
+      onStop: handleStop,
+      parentMessageId,
+      removeAttachment,
+      status: responseAwareStatus,
+      submission,
+      submitForm,
+      uploadQueue,
+    }),
+    [
+      acceptAll,
+      acceptFiles,
+      acceptImages,
+      autoFocus,
+      handlePaste,
+      handleStop,
+      isEditMode,
+      isModelDisallowedForAnonymous,
+      parentMessageId,
+      removeAttachment,
+      responseAwareStatus,
+      submission,
+      submitForm,
+      uploadQueue,
+    ]
+  );
 
   return (
     <div className="relative">
@@ -842,25 +877,7 @@ const PureMultimodalInput = ({
             </div>
           )}
 
-          <ComposerContext.Provider
-            value={{
-              acceptAll,
-              acceptFiles,
-              acceptImages,
-              autoFocus,
-              fileInputRef,
-              isEditMode,
-              isModelDisallowedForAnonymous,
-              onPaste: handlePaste,
-              onStop: handleStop,
-              parentMessageId,
-              removeAttachment,
-              status: responseAwareStatus,
-              submission,
-              submitForm,
-              uploadQueue,
-            }}
-          >
+          <ComposerContext.Provider value={composerContextValue}>
             {children}
           </ComposerContext.Provider>
         </PromptInput>

--- a/apps/chat/components/ui/form.tsx
+++ b/apps/chat/components/ui/form.tsx
@@ -32,11 +32,18 @@ const FormField = <
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 >({
   ...props
-}: ControllerProps<TFieldValues, TName>) => (
-  <FormFieldContext.Provider value={{ name: props.name }}>
-    <Controller {...props} />
-  </FormFieldContext.Provider>
-);
+}: ControllerProps<TFieldValues, TName>) => {
+  const contextValue = React.useMemo(
+    () => ({ name: props.name }),
+    [props.name]
+  );
+
+  return (
+    <FormFieldContext.Provider value={contextValue}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  );
+};
 
 type FormItemContextValue = {
   id: string;
@@ -71,9 +78,10 @@ const useFormField = () => {
 
 const FormItem = ({ className, ...props }: React.ComponentProps<"div">) => {
   const id = React.useId();
+  const contextValue = React.useMemo(() => ({ id }), [id]);
 
   return (
-    <FormItemContext.Provider value={{ id }}>
+    <FormItemContext.Provider value={contextValue}>
       <div
         className={cn("grid gap-2", className)}
         data-slot="form-item"

--- a/apps/chat/oxlint-baseline.json
+++ b/apps/chat/oxlint-baseline.json
@@ -217,22 +217,6 @@
       }
     },
     {
-      "files": [
-        "components/ai-elements/code-block.tsx",
-        "components/ai-elements/context.tsx",
-        "components/ai-elements/message.tsx",
-        "components/ai-elements/reasoning.tsx",
-        "components/chat/chat-layout.tsx",
-        "components/multimodal-input.tsx",
-        "components/ui/form.tsx",
-        "providers/chat-input-provider.tsx",
-        "providers/chat-models-provider.tsx"
-      ],
-      "rules": {
-        "react/jsx-no-constructed-context-values": "off"
-      }
-    },
-    {
       "files": ["components/settings/models-table.tsx"],
       "rules": {
         "react/memo-dependencies": "off"

--- a/apps/chat/providers/chat-input-provider.tsx
+++ b/apps/chat/providers/chat-input-provider.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -235,27 +236,42 @@ export const ChatInputProvider = ({
     },
     [clearAttachments, clearInput, selectedTool, resetData]
   );
+  const contextValue = useMemo<ChatInputContextType>(
+    () => ({
+      attachments,
+      editorRef,
+      getInitialInput,
+      getInputValue,
+      handleInputChange,
+      handleSubmit,
+      handleModelChange,
+      handleModelSelectionChange,
+      isEmpty,
+      isProjectContext,
+      selectedModelId,
+      selectedModelSelection,
+      selectedTool,
+      setAttachments,
+      setSelectedTool,
+    }),
+    [
+      attachments,
+      getInitialInput,
+      getInputValue,
+      handleInputChange,
+      handleModelChange,
+      handleModelSelectionChange,
+      handleSubmit,
+      isEmpty,
+      isProjectContext,
+      selectedModelId,
+      selectedModelSelection,
+      selectedTool,
+    ]
+  );
 
   return (
-    <ChatInputContext.Provider
-      value={{
-        attachments,
-        editorRef,
-        getInitialInput,
-        getInputValue,
-        handleInputChange,
-        handleSubmit,
-        handleModelChange,
-        handleModelSelectionChange,
-        isProjectContext,
-        isEmpty,
-        selectedModelId,
-        selectedModelSelection,
-        selectedTool,
-        setAttachments,
-        setSelectedTool,
-      }}
-    >
+    <ChatInputContext.Provider value={contextValue}>
       {children}
     </ChatInputContext.Provider>
   );

--- a/apps/chat/providers/chat-models-provider.test.tsx
+++ b/apps/chat/providers/chat-models-provider.test.tsx
@@ -2,7 +2,6 @@ import { act, create } from "react-test-renderer";
 import { describe, expect, it, vi } from "vitest";
 
 import type { AppModelDefinition } from "@/lib/ai/app-models";
-import { models as generatedModels } from "@/lib/ai/models.generated";
 import { config } from "@/lib/config";
 
 import { ChatModelsProvider, useChatModels } from "./chat-models-provider";
@@ -33,17 +32,33 @@ vi.mock("@/trpc/react", () => ({
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 const models: AppModelDefinition[] = [];
-const testModel = generatedModels.find((model) => model.type === "language");
-
-if (!testModel) {
-  throw new Error("Expected a language model in the generated model snapshot");
-}
-
 const updatedModels: AppModelDefinition[] = [
   {
-    ...testModel,
     apiModelId: config.ai.workflows.chat,
+    context_window: 128_000,
+    description: "Test model",
     id: config.ai.workflows.chat,
+    input: {
+      audio: false,
+      image: false,
+      pdf: false,
+      text: true,
+      video: false,
+    },
+    max_tokens: 16_000,
+    name: "Test model",
+    object: "model",
+    output: {
+      audio: false,
+      image: false,
+      text: true,
+      video: false,
+    },
+    owned_by: "openai",
+    pricing: {},
+    reasoning: false,
+    toolCall: true,
+    type: "language",
   },
 ];
 

--- a/apps/chat/providers/chat-models-provider.test.tsx
+++ b/apps/chat/providers/chat-models-provider.test.tsx
@@ -10,7 +10,8 @@ vi.mock("@tanstack/react-query", () => ({
 }));
 
 vi.mock("@/lib/ai/app-models", () => ({
-  getDefaultEnabledModels: () => new Set(),
+  getDefaultEnabledModels: (models: { id: string }[]) =>
+    new Set(models.map((model) => model.id)),
 }));
 
 vi.mock("@/providers/session-provider", () => ({
@@ -30,15 +31,48 @@ vi.mock("@/trpc/react", () => ({
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 const models: AppModelDefinition[] = [];
+const updatedModels: AppModelDefinition[] = [
+  {
+    apiModelId: "openai/gpt-5-mini",
+    context_window: 128_000,
+    description: "Test model",
+    id: "openai/gpt-5-mini",
+    input: {
+      audio: false,
+      image: false,
+      pdf: false,
+      text: true,
+      video: false,
+    },
+    max_tokens: 16_000,
+    name: "Test model",
+    object: "model",
+    output: {
+      audio: false,
+      image: false,
+      text: true,
+      video: false,
+    },
+    owned_by: "openai",
+    pricing: {},
+    reasoning: false,
+    toolCall: true,
+    type: "language",
+  },
+];
 
-const ContextProbe = ({ onValue }: { onValue: (value: unknown) => void }) => {
+const ContextProbe = ({
+  onValue,
+}: {
+  onValue: (value: ReturnType<typeof useChatModels>) => void;
+}) => {
   onValue(useChatModels());
   return null;
 };
 
 describe("ChatModelsProvider", () => {
   it("preserves the context identity when its semantic inputs are unchanged", () => {
-    const values: unknown[] = [];
+    const values: ReturnType<typeof useChatModels>[] = [];
     let renderer: ReturnType<typeof create> | undefined;
 
     act(() => {
@@ -65,6 +99,43 @@ describe("ChatModelsProvider", () => {
 
       expect(values).toHaveLength(2);
       expect(values[1]).toBe(values[0]);
+    } finally {
+      act(() => rendered.unmount());
+    }
+  });
+
+  it("updates lookup and filtered models when the model input changes", () => {
+    const values: ReturnType<typeof useChatModels>[] = [];
+    let renderer: ReturnType<typeof create> | undefined;
+
+    act(() => {
+      renderer = create(
+        <ChatModelsProvider models={models}>
+          <ContextProbe onValue={(value) => values.push(value)} />
+        </ChatModelsProvider>
+      );
+    });
+
+    const rendered = renderer;
+    if (!rendered) {
+      throw new Error("Expected provider harness to render");
+    }
+
+    try {
+      act(() => {
+        rendered.update(
+          <ChatModelsProvider models={updatedModels}>
+            <ContextProbe onValue={(value) => values.push(value)} />
+          </ChatModelsProvider>
+        );
+      });
+
+      const updatedValue = values.at(-1);
+      expect(updatedValue).not.toBe(values[0]);
+      expect(updatedValue?.models).toEqual(updatedModels);
+      expect(updatedValue?.getModelById("openai/gpt-5-mini")).toBe(
+        updatedModels[0]
+      );
     } finally {
       act(() => rendered.unmount());
     }

--- a/apps/chat/providers/chat-models-provider.test.tsx
+++ b/apps/chat/providers/chat-models-provider.test.tsx
@@ -1,0 +1,72 @@
+import { act, create } from "react-test-renderer";
+import { describe, expect, it, vi } from "vitest";
+
+import type { AppModelDefinition } from "@/lib/ai/app-models";
+
+import { ChatModelsProvider, useChatModels } from "./chat-models-provider";
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: undefined }),
+}));
+
+vi.mock("@/lib/ai/app-models", () => ({
+  getDefaultEnabledModels: () => new Set(),
+}));
+
+vi.mock("@/providers/session-provider", () => ({
+  useSession: () => ({ data: null }),
+}));
+
+vi.mock("@/trpc/react", () => ({
+  useTRPC: () => ({
+    settings: {
+      getModelPreferences: {
+        queryOptions: () => ({}),
+      },
+    },
+  }),
+}));
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const models: AppModelDefinition[] = [];
+
+const ContextProbe = ({ onValue }: { onValue: (value: unknown) => void }) => {
+  onValue(useChatModels());
+  return null;
+};
+
+describe("ChatModelsProvider", () => {
+  it("preserves the context identity when its semantic inputs are unchanged", () => {
+    const values: unknown[] = [];
+    let renderer: ReturnType<typeof create> | undefined;
+
+    act(() => {
+      renderer = create(
+        <ChatModelsProvider models={models}>
+          <ContextProbe onValue={(value) => values.push(value)} />
+        </ChatModelsProvider>
+      );
+    });
+
+    const rendered = renderer;
+    if (!rendered) {
+      throw new Error("Expected provider harness to render");
+    }
+
+    try {
+      act(() => {
+        rendered.update(
+          <ChatModelsProvider models={models}>
+            <ContextProbe onValue={(value) => values.push(value)} />
+          </ChatModelsProvider>
+        );
+      });
+
+      expect(values).toHaveLength(2);
+      expect(values[1]).toBe(values[0]);
+    } finally {
+      act(() => rendered.unmount());
+    }
+  });
+});

--- a/apps/chat/providers/chat-models-provider.test.tsx
+++ b/apps/chat/providers/chat-models-provider.test.tsx
@@ -2,6 +2,8 @@ import { act, create } from "react-test-renderer";
 import { describe, expect, it, vi } from "vitest";
 
 import type { AppModelDefinition } from "@/lib/ai/app-models";
+import { models as generatedModels } from "@/lib/ai/models.generated";
+import { config } from "@/lib/config";
 
 import { ChatModelsProvider, useChatModels } from "./chat-models-provider";
 
@@ -31,33 +33,17 @@ vi.mock("@/trpc/react", () => ({
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 const models: AppModelDefinition[] = [];
+const testModel = generatedModels.find((model) => model.type === "language");
+
+if (!testModel) {
+  throw new Error("Expected a language model in the generated model snapshot");
+}
+
 const updatedModels: AppModelDefinition[] = [
   {
-    apiModelId: "openai/gpt-5-mini",
-    context_window: 128_000,
-    description: "Test model",
-    id: "openai/gpt-5-mini",
-    input: {
-      audio: false,
-      image: false,
-      pdf: false,
-      text: true,
-      video: false,
-    },
-    max_tokens: 16_000,
-    name: "Test model",
-    object: "model",
-    output: {
-      audio: false,
-      image: false,
-      text: true,
-      video: false,
-    },
-    owned_by: "openai",
-    pricing: {},
-    reasoning: false,
-    toolCall: true,
-    type: "language",
+    ...testModel,
+    apiModelId: config.ai.workflows.chat,
+    id: config.ai.workflows.chat,
   },
 ];
 
@@ -133,7 +119,7 @@ describe("ChatModelsProvider", () => {
       const updatedValue = values.at(-1);
       expect(updatedValue).not.toBe(values[0]);
       expect(updatedValue?.models).toEqual(updatedModels);
-      expect(updatedValue?.getModelById("openai/gpt-5-mini")).toBe(
+      expect(updatedValue?.getModelById(config.ai.workflows.chat)).toBe(
         updatedModels[0]
       );
     } finally {

--- a/apps/chat/providers/chat-models-provider.tsx
+++ b/apps/chat/providers/chat-models-provider.tsx
@@ -65,11 +65,13 @@ export const ChatModelsProvider = ({
     (modelId: string) => allModelsMap.get(modelId),
     [allModelsMap]
   );
+  const contextValue = useMemo(
+    () => ({ allModels: models, getModelById, models: filteredModels }),
+    [filteredModels, getModelById, models]
+  );
 
   return (
-    <ChatModelsContext.Provider
-      value={{ allModels: models, getModelById, models: filteredModels }}
-    >
+    <ChatModelsContext.Provider value={contextValue}>
       {children}
     </ChatModelsContext.Provider>
   );


### PR DESCRIPTION
Memoizes all ten constructed React context values with exact state and callback dependencies, preventing context consumers from rerendering when provider inputs are unchanged. Removes the corresponding baseline entries and adds a `ChatModelsProvider` identity regression test.

Validation:
- `bun lint`
- `bun test:types`
- `bun run test:unit -- providers/chat-models-provider.test.tsx`

## Summary by Sourcery

Prevent unnecessary context consumer rerenders by stabilizing provider values while preserving updates when their inputs change.

Enhancements:
- Memoize React context values and dependent callbacks across chat, input, model, message, reasoning, layout, and UI components to preserve context identity when inputs are unchanged.

Tests:
- Add ChatModelsProvider regression coverage for stable context identity and updated model lookups and filtering.

Chores:
- Remove obsolete oxlint baseline entries for the updated files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoizes the React context values across chat, input, model, message, reasoning, layout, and UI components so consumers no longer rerender when provider inputs are unchanged. Dependent callbacks inside those values are memoized too, and the obsolete oxlint baseline entries for the updated files are removed.

Adds a `ChatModelsProvider` regression test covering stable context identity across unchanged renders and updated model lookups and filtering when the model input changes.

<sup>Written for commit 50d2fb161015239362912d0bc9ce5844d92d0c72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

