### PR TITLE
refactor: enforce contravariant gateway provider contracts

### DIFF
--- a/apps/chat/components/ai-elements/prompt-input.tsx
+++ b/apps/chat/components/ai-elements/prompt-input.tsx
@@ -1058,8 +1058,8 @@ interface SpeechRecognition extends EventTarget {
   continuous: boolean;
   interimResults: boolean;
   lang: string;
-  start(): void;
-  stop(): void;
+  start: () => void;
+  stop: () => void;
   onstart: ((this: SpeechRecognition, ev: Event) => void) | null;
   onend: ((this: SpeechRecognition, ev: Event) => void) | null;
   onresult:
@@ -1077,13 +1077,13 @@ interface SpeechRecognitionEvent extends Event {
 
 type SpeechRecognitionResultList = {
   readonly length: number;
-  item(index: number): SpeechRecognitionResult;
+  item: (index: number) => SpeechRecognitionResult;
   [index: number]: SpeechRecognitionResult;
 };
 
 type SpeechRecognitionResult = {
   readonly length: number;
-  item(index: number): SpeechRecognitionAlternative;
+  item: (index: number) => SpeechRecognitionAlternative;
   [index: number]: SpeechRecognitionAlternative;
   isFinal: boolean;
 };

--- a/apps/chat/lib/ai/gateways/registry.ts
+++ b/apps/chat/lib/ai/gateways/registry.ts
@@ -6,7 +6,12 @@ import type { generatedForGateway, models } from "../models.generated";
 
 export type InstalledGateway = InstanceType<typeof Gateway>;
 export type GatewayType = typeof gatewayType;
-export type GatewayProvider = GatewayProviderBase<GatewayType>;
+export type GatewayProvider = GatewayProviderBase<
+  GatewayType,
+  Parameters<InstalledGateway["createLanguageModel"]>[0],
+  Parameters<InstalledGateway["createImageModel"]>[0],
+  Parameters<InstalledGateway["createVideoModel"]>[0]
+>;
 
 export type GatewayModelIdMap = Record<
   GatewayType,

--- a/apps/chat/lib/ai/providers.ts
+++ b/apps/chat/lib/ai/providers.ts
@@ -6,16 +6,17 @@ import type { LanguageModelMiddleware } from "ai";
 import { getActiveGateway } from "./active-gateway";
 import type { AppModelId } from "./app-models";
 import { getAppModelDefinition } from "./app-models";
-import type {
-  GatewayImageModelIdMap,
-  GatewayModelIdMap,
-  GatewayType,
-  GatewayVideoModelIdMap,
-} from "./gateways/registry";
+import type { InstalledGateway } from "./gateways/registry";
 
-type ActiveGatewayModelId = GatewayModelIdMap[GatewayType];
-type ActiveGatewayImageModelId = GatewayImageModelIdMap[GatewayType];
-type ActiveGatewayVideoModelId = GatewayVideoModelIdMap[GatewayType];
+type ActiveGatewayModelId = Parameters<
+  InstalledGateway["createLanguageModel"]
+>[0];
+type ActiveGatewayImageModelId = Parameters<
+  InstalledGateway["createImageModel"]
+>[0];
+type ActiveGatewayVideoModelId = Parameters<
+  InstalledGateway["createVideoModel"]
+>[0];
 
 export const getLanguageModel = async (modelId: AppModelId) => {
   const model = await getAppModelDefinition(modelId);

--- a/apps/chat/lib/ai/providers.ts
+++ b/apps/chat/lib/ai/providers.ts
@@ -6,6 +6,16 @@ import type { LanguageModelMiddleware } from "ai";
 import { getActiveGateway } from "./active-gateway";
 import type { AppModelId } from "./app-models";
 import { getAppModelDefinition } from "./app-models";
+import type {
+  GatewayImageModelIdMap,
+  GatewayModelIdMap,
+  GatewayType,
+  GatewayVideoModelIdMap,
+} from "./gateways/registry";
+
+type ActiveGatewayModelId = GatewayModelIdMap[GatewayType];
+type ActiveGatewayImageModelId = GatewayImageModelIdMap[GatewayType];
+type ActiveGatewayVideoModelId = GatewayVideoModelIdMap[GatewayType];
 
 export const getLanguageModel = async (modelId: AppModelId) => {
   const model = await getAppModelDefinition(modelId);
@@ -35,7 +45,7 @@ export const getLanguageModel = async (modelId: AppModelId) => {
   });
 };
 
-export const getImageModel = (modelId: string) => {
+export const getImageModel = (modelId: ActiveGatewayImageModelId) => {
   const imageModel = getActiveGateway().createImageModel(modelId);
   if (!imageModel) {
     throw new Error(
@@ -45,7 +55,7 @@ export const getImageModel = (modelId: string) => {
   return imageModel;
 };
 
-export const getVideoModel = (modelId: string) => {
+export const getVideoModel = (modelId: ActiveGatewayVideoModelId) => {
   const videoModel = getActiveGateway().createVideoModel(modelId);
   if (!videoModel) {
     throw new Error(
@@ -56,7 +66,7 @@ export const getVideoModel = (modelId: string) => {
 };
 
 // Get a multimodal language model that can generate images via generateText
-export const getMultimodalImageModel = (modelId: string) =>
+export const getMultimodalImageModel = (modelId: ActiveGatewayModelId) =>
   getActiveGateway().createLanguageModel(modelId);
 
 // Model aliases removed - use getLanguageModel directly with specific model IDs

--- a/apps/chat/oxlint-baseline.json
+++ b/apps/chat/oxlint-baseline.json
@@ -413,10 +413,7 @@
       }
     },
     {
-      "files": [
-        "components/ai-elements/prompt-input.tsx",
-        "lib/stores/base/hooks.ts"
-      ],
+      "files": ["lib/stores/base/hooks.ts"],
       "rules": {
         "typescript/method-signature-style": "off"
       }

--- a/apps/chat/tools/chatjs/generate-image/tool.ts
+++ b/apps/chat/tools/chatjs/generate-image/tool.ts
@@ -4,6 +4,11 @@ import { z } from "zod";
 
 import { getAppModelDefinition } from "@/lib/ai/app-models";
 import type { AppModelId } from "@/lib/ai/app-models";
+import type {
+  GatewayImageModelIdMap,
+  GatewayModelIdMap,
+  GatewayType,
+} from "@/lib/ai/gateways/registry";
 import { getImageModel, getMultimodalImageModel } from "@/lib/ai/providers";
 import type { ChatToolContext } from "@/lib/ai/tool-context";
 import { config } from "@/lib/config";
@@ -16,6 +21,8 @@ import { getBaseUrl } from "@/lib/url";
 const log = createModuleLogger("ai.tools.generate-image");
 
 type ImageMode = "edit" | "generate";
+type ActiveGatewayModelId = GatewayModelIdMap[GatewayType];
+type ActiveGatewayImageModelId = GatewayImageModelIdMap[GatewayType];
 
 /**
  * Resolve which model to use for image generation and whether it's a
@@ -26,8 +33,16 @@ type ImageMode = "edit" | "generate";
 const resolveImageModel = async (
   selectedModel?: string
 ): Promise<
-  | { modelId: string; multimodal: true; usageModelId: AppModelId }
-  | { modelId: string; multimodal: false; usageModelId?: never }
+  | {
+      modelId: ActiveGatewayModelId;
+      multimodal: true;
+      usageModelId: AppModelId;
+    }
+  | {
+      modelId: ActiveGatewayImageModelId;
+      multimodal: false;
+      usageModelId?: never;
+    }
 > => {
   // If the user's selected chat model can generate images, prefer it
   if (selectedModel) {
@@ -257,7 +272,7 @@ const runGenerateImageMultimodal = async ({
   startMs,
   costAccumulator,
 }: {
-  modelId: string;
+  modelId: ActiveGatewayModelId;
   usageModelId: AppModelId;
   mode: ImageMode;
   prompt: string;

--- a/apps/chat/tools/chatjs/generate-image/tool.ts
+++ b/apps/chat/tools/chatjs/generate-image/tool.ts
@@ -4,11 +4,7 @@ import { z } from "zod";
 
 import { getAppModelDefinition } from "@/lib/ai/app-models";
 import type { AppModelId } from "@/lib/ai/app-models";
-import type {
-  GatewayImageModelIdMap,
-  GatewayModelIdMap,
-  GatewayType,
-} from "@/lib/ai/gateways/registry";
+import type { InstalledGateway } from "@/lib/ai/gateways/registry";
 import { getImageModel, getMultimodalImageModel } from "@/lib/ai/providers";
 import type { ChatToolContext } from "@/lib/ai/tool-context";
 import { config } from "@/lib/config";
@@ -21,8 +17,12 @@ import { getBaseUrl } from "@/lib/url";
 const log = createModuleLogger("ai.tools.generate-image");
 
 type ImageMode = "edit" | "generate";
-type ActiveGatewayModelId = GatewayModelIdMap[GatewayType];
-type ActiveGatewayImageModelId = GatewayImageModelIdMap[GatewayType];
+type ActiveGatewayModelId = Parameters<
+  InstalledGateway["createLanguageModel"]
+>[0];
+type ActiveGatewayImageModelId = Parameters<
+  InstalledGateway["createImageModel"]
+>[0];
 
 /**
  * Resolve which model to use for image generation and whether it's a

--- a/oxlint-baseline.json
+++ b/oxlint-baseline.json
@@ -89,12 +89,6 @@
       }
     },
     {
-      "files": ["packages/gateways/src/gateway-provider.ts"],
-      "rules": {
-        "typescript/method-signature-style": "off"
-      }
-    },
-    {
       "files": ["apps/site/components/thread-showcase.tsx"],
       "rules": {
         "unicorn/consistent-function-scoping": "off"

--- a/packages/gateways/src/contract.test.ts
+++ b/packages/gateways/src/contract.test.ts
@@ -1,3 +1,8 @@
+import type {
+  Experimental_VideoModelV4,
+  LanguageModelV4,
+} from "@ai-sdk/provider";
+import type { ImageModel } from "ai";
 import { describe, expect, it } from "vitest";
 
 import { LiteLLMGateway } from "../../registry/src/gateways/litellm/gateway";
@@ -11,51 +16,96 @@ import gatewayPackage from "../package.json";
 import type { GatewayProvider } from "./gateway-provider";
 import type { GatewayOptions } from "./runtime";
 
+const callUnsupportedModel = <T>(
+  method: (modelId: never) => T,
+  receiver: object
+): T => Reflect.apply(method, receiver, ["unsupported-model"]);
+
 const adapters: {
   name: GatewayType;
-  create: (options: GatewayOptions) => GatewayProvider;
+  create: (
+    options: GatewayOptions
+  ) => GatewayProvider<string, never, never, never>;
   env: Record<string, string>;
-  model: string;
+  createImageModel: (options: GatewayOptions) => ImageModel | null;
+  createLanguageModel: (options: GatewayOptions) => LanguageModelV4;
+  createVideoModel: (
+    options: GatewayOptions
+  ) => Experimental_VideoModelV4 | null;
   image: boolean;
   video: boolean;
 }[] = [
   {
     create: (o) => new VercelGateway(o),
+    createImageModel: (o) =>
+      new VercelGateway(o).createImageModel("openai/gpt-image-1"),
+    createLanguageModel: (o) =>
+      new VercelGateway(o).createLanguageModel("openai/gpt-5-mini"),
+    createVideoModel: (o) =>
+      new VercelGateway(o).createVideoModel("google/veo-3"),
     env: { AI_GATEWAY_API_KEY: "test" },
     image: true,
-    model: "openai/gpt-5-mini",
     name: "vercel",
     video: true,
   },
   {
     create: (o) => new OpenAIGateway(o),
+    createImageModel: (o) => new OpenAIGateway(o).createImageModel("dall-e-3"),
+    createLanguageModel: (o) =>
+      new OpenAIGateway(o).createLanguageModel("gpt-5-mini"),
+    createVideoModel: (o) => {
+      const gateway = new OpenAIGateway(o);
+      return callUnsupportedModel(gateway.createVideoModel, gateway);
+    },
     env: { OPENAI_API_KEY: "test" },
     image: true,
-    model: "gpt-5-mini",
     name: "openai",
     video: false,
   },
   {
     create: (o) => new OpenRouterGateway(o),
+    createImageModel: (o) => {
+      const gateway = new OpenRouterGateway(o);
+      return callUnsupportedModel(gateway.createImageModel, gateway);
+    },
+    createLanguageModel: (o) =>
+      new OpenRouterGateway(o).createLanguageModel("openai/gpt-5-mini"),
+    createVideoModel: (o) => {
+      const gateway = new OpenRouterGateway(o);
+      return callUnsupportedModel(gateway.createVideoModel, gateway);
+    },
     env: { OPENROUTER_API_KEY: "test" },
     image: false,
-    model: "openai/gpt-5-mini",
     name: "openrouter",
     video: false,
   },
   {
     create: (o) => new OpenAICompatibleGateway(o),
+    createImageModel: (o) =>
+      new OpenAICompatibleGateway(o).createImageModel("custom-image-model"),
+    createLanguageModel: (o) =>
+      new OpenAICompatibleGateway(o).createLanguageModel("custom-model"),
+    createVideoModel: (o) => {
+      const gateway = new OpenAICompatibleGateway(o);
+      return callUnsupportedModel(gateway.createVideoModel, gateway);
+    },
     env: { OPENAI_COMPATIBLE_BASE_URL: "https://example.test/v1" },
     image: true,
-    model: "custom-model",
     name: "openai-compatible",
     video: false,
   },
   {
     create: (o) => new LiteLLMGateway(o),
+    createImageModel: (o) =>
+      new LiteLLMGateway(o).createImageModel("custom-image-model"),
+    createLanguageModel: (o) =>
+      new LiteLLMGateway(o).createLanguageModel("custom-model"),
+    createVideoModel: (o) => {
+      const gateway = new LiteLLMGateway(o);
+      return callUnsupportedModel(gateway.createVideoModel, gateway);
+    },
     env: { LITELLM_BASE_URL: "https://example.test" },
     image: true,
-    model: "custom-model",
     name: "litellm",
     video: false,
   },
@@ -69,10 +119,14 @@ describe.each(adapters)("$name gateway contract", (adapter) => {
     const { dependency, version } = gatewayMetadata[adapter.name];
     expect(gatewayPackage.devDependencies[dependency]).toBe(version);
     expect(
-      gateway.createLanguageModel(adapter.model).specificationVersion
+      adapter.createLanguageModel({ env: adapter.env }).specificationVersion
     ).toBe("v4");
-    expect(gateway.createImageModel("test-image") !== null).toBe(adapter.image);
-    expect(gateway.createVideoModel("test-video") !== null).toBe(adapter.video);
+    expect(adapter.createImageModel({ env: adapter.env }) !== null).toBe(
+      adapter.image
+    );
+    expect(adapter.createVideoModel({ env: adapter.env }) !== null).toBe(
+      adapter.video
+    );
   });
 
   it("uses only the host's fallback snapshot after a discovery failure", async () => {

--- a/packages/gateways/src/defaults.ts
+++ b/packages/gateways/src/defaults.ts
@@ -1,6 +1,8 @@
 import type { GatewayProvider } from "./gateway-provider.ts";
 
-type VideoDefault<G extends GatewayProvider> = [
+type AnyGatewayProvider = GatewayProvider<string, never, never, never>;
+
+type VideoDefault<G extends AnyGatewayProvider> = [
   Parameters<G["createVideoModel"]>[0],
 ] extends [never]
   ? { enabled: false }
@@ -8,7 +10,7 @@ type VideoDefault<G extends GatewayProvider> = [
       | { enabled: true; default: Parameters<G["createVideoModel"]>[0] }
       | { enabled: false; default?: Parameters<G["createVideoModel"]>[0] };
 
-type ImageDefault<G extends GatewayProvider> = [
+type ImageDefault<G extends AnyGatewayProvider> = [
   Parameters<G["createImageModel"]>[0],
 ] extends [never]
   ? { enabled: false }
@@ -16,7 +18,7 @@ type ImageDefault<G extends GatewayProvider> = [
       | { enabled: true; default: Parameters<G["createImageModel"]>[0] }
       | { enabled: false; default?: Parameters<G["createImageModel"]>[0] };
 
-export interface GatewayModelDefaults<G extends GatewayProvider> {
+export interface GatewayModelDefaults<G extends AnyGatewayProvider> {
   anonymousModels: Parameters<G["createLanguageModel"]>[0][];
   curatedDefaults: Parameters<G["createLanguageModel"]>[0][];
   disabledModels: Parameters<G["createLanguageModel"]>[0][];

--- a/packages/gateways/src/gateway-provider.ts
+++ b/packages/gateways/src/gateway-provider.ts
@@ -13,15 +13,17 @@ export interface GatewayProvider<
   TVideoModelId extends string = string,
 > {
   /** Create a dedicated image model instance, or null if unsupported */
-  createImageModel(modelId: TImageModelId): ImageModel | null;
+  createImageModel: (modelId: TImageModelId) => ImageModel | null;
 
   /** Create a language model instance from a model ID like "openai/gpt-5-nano" */
-  createLanguageModel(modelId: TModelId): LanguageModelV4;
+  createLanguageModel: (modelId: TModelId) => LanguageModelV4;
 
   /** Create a video model instance, or null if unsupported */
-  createVideoModel(modelId: TVideoModelId): Experimental_VideoModelV4 | null;
+  createVideoModel: (
+    modelId: TVideoModelId
+  ) => Experimental_VideoModelV4 | null;
 
   /** Fetch the list of available models from the gateway's API */
-  fetchModels(): Promise<AiGatewayModel[]>;
+  fetchModels: () => Promise<AiGatewayModel[]>;
   readonly type: TGateway;
 }

--- a/packages/registry/src/tools/generate-image/tool.ts
+++ b/packages/registry/src/tools/generate-image/tool.ts
@@ -4,6 +4,11 @@ import { z } from "zod";
 
 import { getAppModelDefinition } from "@/lib/ai/app-models";
 import type { AppModelId } from "@/lib/ai/app-models";
+import type {
+  GatewayImageModelIdMap,
+  GatewayModelIdMap,
+  GatewayType,
+} from "@/lib/ai/gateways/registry";
 import { getImageModel, getMultimodalImageModel } from "@/lib/ai/providers";
 import type { ChatToolContext } from "@/lib/ai/tool-context";
 import { config } from "@/lib/config";
@@ -16,6 +21,8 @@ import { getBaseUrl } from "@/lib/url";
 const log = createModuleLogger("ai.tools.generate-image");
 
 type ImageMode = "edit" | "generate";
+type ActiveGatewayModelId = GatewayModelIdMap[GatewayType];
+type ActiveGatewayImageModelId = GatewayImageModelIdMap[GatewayType];
 
 /**
  * Resolve which model to use for image generation and whether it's a
@@ -26,8 +33,16 @@ type ImageMode = "edit" | "generate";
 const resolveImageModel = async (
   selectedModel?: string
 ): Promise<
-  | { modelId: string; multimodal: true; usageModelId: AppModelId }
-  | { modelId: string; multimodal: false; usageModelId?: never }
+  | {
+      modelId: ActiveGatewayModelId;
+      multimodal: true;
+      usageModelId: AppModelId;
+    }
+  | {
+      modelId: ActiveGatewayImageModelId;
+      multimodal: false;
+      usageModelId?: never;
+    }
 > => {
   // If the user's selected chat model can generate images, prefer it
   if (selectedModel) {
@@ -257,7 +272,7 @@ const runGenerateImageMultimodal = async ({
   startMs,
   costAccumulator,
 }: {
-  modelId: string;
+  modelId: ActiveGatewayModelId;
   usageModelId: AppModelId;
   mode: ImageMode;
   prompt: string;

--- a/packages/registry/src/tools/generate-image/tool.ts
+++ b/packages/registry/src/tools/generate-image/tool.ts
@@ -4,11 +4,7 @@ import { z } from "zod";
 
 import { getAppModelDefinition } from "@/lib/ai/app-models";
 import type { AppModelId } from "@/lib/ai/app-models";
-import type {
-  GatewayImageModelIdMap,
-  GatewayModelIdMap,
-  GatewayType,
-} from "@/lib/ai/gateways/registry";
+import type { InstalledGateway } from "@/lib/ai/gateways/registry";
 import { getImageModel, getMultimodalImageModel } from "@/lib/ai/providers";
 import type { ChatToolContext } from "@/lib/ai/tool-context";
 import { config } from "@/lib/config";
@@ -21,8 +17,12 @@ import { getBaseUrl } from "@/lib/url";
 const log = createModuleLogger("ai.tools.generate-image");
 
 type ImageMode = "edit" | "generate";
-type ActiveGatewayModelId = GatewayModelIdMap[GatewayType];
-type ActiveGatewayImageModelId = GatewayImageModelIdMap[GatewayType];
+type ActiveGatewayModelId = Parameters<
+  InstalledGateway["createLanguageModel"]
+>[0];
+type ActiveGatewayImageModelId = Parameters<
+  InstalledGateway["createImageModel"]
+>[0];
 
 /**
  * Resolve which model to use for image generation and whether it's a


### PR DESCRIPTION
Replaces gateway and speech-recognition method signatures with function-property signatures so parameter variance is checked correctly. Updates gateway contract coverage to call supported typed IDs and exercise intentionally unsupported `never` parameters through controlled reflective calls.

Validation: `bun lint`, `bun test:types`, `bun --filter=@chat-js/gateways test:unit` (14 tests).

The prompt-input edit changes only TypeScript declaration syntax; it does not alter rendered UI behavior.

## Summary by Sourcery

Enforce gateway model-ID contracts across providers and application integrations while improving contract coverage.

Enhancements:
- Enforce contravariant gateway and speech-recognition provider contracts through function-property types.
- Propagate installed gateway model ID constraints through application providers and image-generation tools so unsupported IDs are rejected at compile time.
- Scope gateway model defaults to providers with explicit model-ID contracts.

Tests:
- Expand gateway contract coverage for supported typed model IDs and intentionally unsupported capabilities.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converts gateway and speech-recognition method signatures to function-property syntax and propagates the installed gateway's model ID constraints through the app, so unsupported model IDs fail at compile time instead of runtime. No runtime behavior changes.

**Changes**
- `GatewayProvider` now exposes `createImageModel`, `createLanguageModel`, `createVideoModel`, and `fetchModels` as callable properties.
- The `SpeechRecognition` and result-list interfaces in `apps/chat/components/ai-elements/prompt-input.tsx` follow the same style, allowing the `method-signature-style` lint exemptions to be removed from both oxlint baselines.
- `@chat-js/gateways` contract tests use typed model IDs for supported calls and `Reflect.apply` for intentionally unsupported model IDs.
- `GatewayModelDefaults` is scoped to `GatewayProvider<string, never, never, never>`.
- The app's provider functions and both generate-image tools now accept only model IDs supported by the installed gateway, with language, image, and video model IDs typed separately.

<sup>Written for commit 26e1fbc8c743c5ed45191a27197cd6f1539c8740. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

